### PR TITLE
fix: center location loading buffer (closes #5)

### DIFF
--- a/src/app/ai/page.tsx
+++ b/src/app/ai/page.tsx
@@ -329,7 +329,7 @@ export default function AppPage() {
     return (
       <div className="flex items-center justify-center h-screen bg-gradient-to-br from-zinc-50 via-blue-50/30 to-zinc-50 dark:from-black dark:via-blue-950/10 dark:to-black">
         <div className="text-center p-8 max-w-md">
-          <div className="relative mx-auto mb-6">
+          <div className="relative mx-auto mb-6 w-20 h-20">
             <div className="w-20 h-20 rounded-full bg-gradient-to-br from-blue-500 to-purple-600 animate-pulse flex items-center justify-center">
               <Loader2 className="w-10 h-10 animate-spin text-white" />
             </div>


### PR DESCRIPTION
# Description

This PR centers the location loading buffer component on the AI search page, resolving Issue #5.

Closes #5

## Changes

- **Centered Loading Buffer Wrapper (`src/app/ai/page.tsx`):** Added explicit width and height tailwind classes (`w-20 h-20`) to the wrapper div. This allows `mx-auto` to correctly center the loading buffer layout in the viewport.

## Verification

- **Tests:** Ran all Jest tests with `npm test`, all 57 tests successfully passed.
- **Manual Verification:** Centered layout confirmed by verifying loading buffer relative width bounding box.

##Screenshot
<img width="1901" height="911" alt="image" src="https://github.com/user-attachments/assets/2dfa17e2-d611-4293-a0fc-1c68d025d041" />
