### PR TITLE
fix: resolve global hubs dropdown selection and sync issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# clerk configuration (can include secrets)
+/.clerk/

--- a/src/app/ai/page.tsx
+++ b/src/app/ai/page.tsx
@@ -250,6 +250,10 @@ export default function AppPage() {
             zoom: update.data.zoom,
             animate: update.data.animate !== false,
           });
+          setLocation({
+            latitude: update.data.center.lat,
+            longitude: update.data.center.lng,
+          });
         }
         break;
 

--- a/src/components/EnhancedChatbot.tsx
+++ b/src/components/EnhancedChatbot.tsx
@@ -138,7 +138,12 @@ export function EnhancedChatbot({ onMapUpdate, onOpenDetails, onBook, userLocati
 
   useEffect(() => {
     if (userLocation) {
-      setLocation(userLocation);
+      setLocation((prev) => {
+        if (prev && prev.lat === userLocation.lat && prev.lng === userLocation.lng) {
+          return prev;
+        }
+        return userLocation;
+      });
     }
   }, [userLocation]);
 
@@ -471,7 +476,7 @@ export function EnhancedChatbot({ onMapUpdate, onOpenDetails, onBook, userLocati
     <div className="flex h-full flex-col bg-white dark:bg-zinc-950">
       <ChatHeader
         onOpenVenueSubmission={() => setShowVenueSubmission(true)}
-        userLocation={userLocation}
+        userLocation={location}
         onLocationChange={handleLocationChange}
         filters={filters}
         showFilters={showFilters}

--- a/src/components/EnhancedChatbot.tsx
+++ b/src/components/EnhancedChatbot.tsx
@@ -136,6 +136,12 @@ export function EnhancedChatbot({ onMapUpdate, onOpenDetails, onBook, userLocati
     }
   }, [location, getPreciseLocation]);
 
+  useEffect(() => {
+    if (userLocation) {
+      setLocation(userLocation);
+    }
+  }, [userLocation]);
+
   const handleLocationChange = (lat: number, lng: number) => {
     if (lat === 0 && lng === 0) {
       getPreciseLocation();

--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -60,6 +60,7 @@ const GLOBAL_HUBS = [
 
 export function ChatHeader({
     onOpenVenueSubmission,
+    userLocation,
     onLocationChange,
     filters,
     showFilters,
@@ -74,6 +75,17 @@ export function ChatHeader({
     onShowBookings
 }: ChatHeaderProps) {
     const [isHubOpen, setIsHubOpen] = useState(false);
+
+    const getActiveHubName = () => {
+        if (!userLocation) return "Global Hubs";
+        const matchingHub = GLOBAL_HUBS.find(
+            (hub) =>
+                hub.lat !== 0 &&
+                Math.abs(hub.lat - userLocation.lat) < 0.001 &&
+                Math.abs(hub.lng - userLocation.lng) < 0.001
+        );
+        return matchingHub ? matchingHub.name : "Current Location";
+    };
 
     return (
         <div className="bg-white dark:bg-zinc-950 sticky top-0 z-50 p-4 border-b border-zinc-200 dark:border-zinc-800 shadow-sm transition-all">
@@ -118,7 +130,7 @@ export function ChatHeader({
                             className="flex items-center gap-2 px-3 py-2 bg-zinc-100 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl text-[10px] font-black uppercase tracking-widest text-zinc-700 dark:text-zinc-300 hover:bg-zinc-200 dark:hover:bg-zinc-800 transition-all active:scale-95"
                         >
                             <Globe className="w-3.5 h-3.5 text-blue-500" />
-                            <span className="hidden md:inline">Global Hubs</span>
+                            <span className="hidden md:inline">{getActiveHubName()}</span>
                             <ChevronDown className={`w-3 h-3 transition-transform ${isHubOpen ? 'rotate-180' : ''}`} />
                         </button>
 


### PR DESCRIPTION
## Summary
This PR fixes the issue where selecting a Global Hub (e.g., London, Tokyo, New York, San Francisco) from the dropdown in the header does not correctly center the map or update the chatbot's search context.

## Changes
- **page.tsx**: Updated the parent's coordinate state using `setLocation` in the `"SET_MAP_VIEW"` case inside `handleMapUpdate` to keep the parent's location in sync with Leaflet map view updates.
- **EnhancedChatbot.tsx**: Added a `useEffect` hook to synchronize the chatbot's local `location` state with the parent-provided `userLocation` prop using value comparison. Passed the local `location` state down to the `ChatHeader` component.
- **ChatHeader.tsx**: Destructured `userLocation` from the props and implemented `getActiveHubName` to compare coordinates. The dropdown button label now dynamically updates to show the selected hub's name rather than static text.

##Screenshots-
<img width="1917" height="917" alt="Screenshot 2026-07-08 023626" src="https://github.com/user-attachments/assets/8aaccdfe-2ef6-4a08-8c73-26e0e87bf4b1" />
<img width="1912" height="903" alt="Screenshot 2026-07-08 023650" src="https://github.com/user-attachments/assets/3ea2add3-1d7e-4cd0-9ff1-563783eb2323" />


Closes #2
