### PR TITLE
feat: add scroll bottom to top button on landing page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 import {
   MapPin, Wifi, Zap, Volume2, Clock, Sparkles, Download,
   ArrowRight, Coffee, Camera, Radio, Star, Users, Building2,
-  ChevronRight, Globe, FileText, BarChart3
+  ChevronRight, Globe, FileText, BarChart3, ArrowUp
 } from "lucide-react";
 import { SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
 import { useEffect, useState } from "react";
@@ -308,6 +308,17 @@ export default function Home() {
           </div>
         </div>
       </footer>
+
+      {/* Scroll to Top Button */}
+      {scrollY > 300 && (
+        <button
+          onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+          className="fixed bottom-6 left-6 z-50 p-3 rounded-xl bg-gradient-to-br from-blue-600 to-purple-600 text-white shadow-lg shadow-blue-500/20 hover:shadow-blue-500/40 hover:scale-110 active:scale-95 transition-all duration-300 border border-white/10 cursor-pointer group"
+          aria-label="Scroll to top"
+        >
+          <ArrowUp className="w-5 h-5 group-hover:-translate-y-0.5 transition-transform" />
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
This PR adds a floating "Scroll to Top" button on the bottom-left of the landing page. It appears only when the user scrolls down beyond 300px and smoothly scrolls the window back to the top when clicked.

## Changes
- **page.tsx** (`src/app/page.tsx`):
  - Imported `ArrowUp` icon from `lucide-react`.
  - Rendered a floating button at `fixed bottom-6 left-6 z-50` conditioned on `scrollY > 300`.
  - Used matching brand gradient styles (`from-blue-600 to-purple-600`), hover-scaling, shadow glow, and micro-animated arrow hover effects for a premium UI experience.

## Screenshot
<img width="1902" height="866" alt="image" src="https://github.com/user-attachments/assets/6cbeb512-e3de-4d00-84ac-7f90a5df7825" />


Closes #4
