### PR TITLE
bug(sse): implement exponential backoff on sse connection failure

### DIFF
--- a/src/hooks/useRealTime.tsx
+++ b/src/hooks/useRealTime.tsx
@@ -37,13 +37,16 @@ export function useRealTimeUpdates(options: UseRealTimeUpdatesOptions = {}) {
   const venueIdsKey = venueIds.slice().sort().join(",");
 
   useEffect(() => {
-    if (!enabled || venueIds.length === 0) return;
+    const ids = venueIdsKey ? venueIdsKey.split(",") : [];
+    if (!enabled || ids.length === 0) return;
 
     let eventSource: EventSource | null = null;
     let reconnectTimeout: ReturnType<typeof setTimeout>;
-    let currentBackoff = 2000; // Start with 2s
+    let currentBackoff = 1000; // Start with 1s
 
     const connect = () => {
+      clearTimeout(reconnectTimeout);
+
       // Don't even try if we know we're offline
       if (typeof window !== "undefined" && !window.navigator.onLine) {
         setIsConnected(false);
@@ -52,14 +55,14 @@ export function useRealTimeUpdates(options: UseRealTimeUpdatesOptions = {}) {
       }
 
       const params = new URLSearchParams();
-      venueIds.forEach((id) => params.append("venueId", id));
+      ids.forEach((id) => params.append("venueId", id));
 
       eventSource = new EventSource(`/api/venues/updates?${params.toString()}`);
 
       eventSource.onopen = () => {
         setIsConnected(true);
         setError(null);
-        currentBackoff = 2000; // Reset backoff on success
+        currentBackoff = 1000; // Reset backoff on success
         console.log("[RealTime] Connected to updates stream");
       };
 
@@ -81,17 +84,18 @@ export function useRealTimeUpdates(options: UseRealTimeUpdatesOptions = {}) {
         setError(isOffline ? "Browser is offline" : "Connection failed. Retrying...");
         eventSource?.close();
 
-        // Exponential backoff: double the delay up to 60 seconds
+        // Exponential backoff: double the delay up to 30 seconds
         console.warn(`[RealTime] Connection failed. Retrying in ${currentBackoff / 1000}s...`);
+        clearTimeout(reconnectTimeout);
         reconnectTimeout = setTimeout(connect, currentBackoff);
-        currentBackoff = Math.min(60000, currentBackoff * 2);
+        currentBackoff = Math.min(30000, currentBackoff * 2);
       };
     };
 
     // Handle online/offline events automatically
     const handleOnline = () => {
       console.log("[RealTime] Browser online, reconnecting...");
-      currentBackoff = 2000;
+      currentBackoff = 1000;
       connect();
     };
 
@@ -114,7 +118,7 @@ export function useRealTimeUpdates(options: UseRealTimeUpdatesOptions = {}) {
       window.removeEventListener("online", handleOnline);
       window.removeEventListener("offline", handleOffline);
     };
-  }, [venueIdsKey, enabled, venueIds]);
+  }, [venueIdsKey, enabled]);
 
   return { updates, isConnected, error, clearUpdates };
 }


### PR DESCRIPTION
Closes #48

## Description
This PR resolves the Server-Sent Events (SSE) reconnect loop bug. Previously, when the network fluctuated or the server was offline, the client page triggered an immediate, near-instantaneous reconnection loop of hundreds of requests per second. 

This loop happened because:
1. The hook depended directly on the `venueIds` array reference. Any state change caused a parent re-render, creating a new array reference that constantly restarted the connection effect and bypassed the backoff timeout.
2. Multiple parallel reconnection timers were scheduled during `onerror` events without being cleared.

## Scope of Changes
- **`src/hooks/useRealTime.tsx`**:
  - Removed the unstable `venueIds` array reference from the dependency array. 
  - Restructured the inner logic to dynamically map the IDs inside the effect using the stable string key `venueIdsKey` via `venueIdsKey.split(",")` to prevent hook cycles.
  - Implemented timeout clear safeguards (`clearTimeout(reconnectTimeout)`) at connect entry and error loops to prevent duplicate overlapping timers.
  - Configured exponential backoff intervals to start at **1s (1000ms)** and cap at **30s (30000ms)**.

## Verification Check
- Verified console log sequences when the Next.js server is stopped:
  - First retry after 1s
  - Second retry after 2s
  - Third retry after 4s
  - Fourth retry after 8s... up to 30s max backoff delay.
- Confirmed that the client successfully reconnects automatically once the Next.js dev server is restarted.

## Screenshot 
<img width="1917" height="1078" alt="image" src="https://github.com/user-attachments/assets/713ba159-5a45-4ea1-803f-0883573bae48" />

