### PR TITLE
feat: add social coworking and RSVP features

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,9 @@ model User {
   bookings      Booking[]
   memories      UserMemory[]
   crdtState     Bytes?
+  workStatus       WorkBuddyStatus?
+  hostedSessions   CoworkingSession[] @relation("SessionHost")
+  sessionRsvps     SessionRsvp[]
 }
 
 model Venue {
@@ -47,6 +50,8 @@ model Venue {
   ratings        VenueRating[]
   favorites      Favorite[]
   bookings       Booking[]
+  workStatuses WorkBuddyStatus[]
+  sessions     CoworkingSession[]
 
   @@index([latitude, longitude])
   @@index([category])
@@ -151,4 +156,61 @@ model SemanticCache {
   createdAt DateTime @default(now())
 
   @@index([query])
+}
+
+model WorkBuddyStatus {
+  id        String   @id @default(cuid())
+  userId    String   @unique
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  venueId   String
+  venue     Venue    @relation(fields: [venueId], references: [id], onDelete: Cascade)
+  note      String?
+  until     DateTime
+  isPublic  Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([venueId])
+  @@index([until])
+}
+
+model CoworkingSession {
+  id          String        @id @default(cuid())
+  slug        String        @unique
+  hostId      String
+  host        User          @relation("SessionHost", fields: [hostId], references: [id], onDelete: Cascade)
+  venueId     String
+  venue       Venue         @relation(fields: [venueId], references: [id], onDelete: Cascade)
+  title       String
+  description String?
+  startsAt    DateTime
+  endsAt      DateTime
+  maxGuests   Int?
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+  rsvps       SessionRsvp[]
+
+  @@index([hostId])
+  @@index([venueId])
+  @@index([startsAt])
+}
+
+model SessionRsvp {
+  id        String           @id @default(cuid())
+  sessionId String
+  session   CoworkingSession @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  userId    String
+  user      User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  status    RsvpStatus       @default(GOING)
+  createdAt DateTime         @default(now())
+  updatedAt DateTime         @updatedAt
+
+  @@unique([sessionId, userId])
+  @@index([userId])
+}
+
+enum RsvpStatus {
+  GOING
+  MAYBE
+  DECLINED
 }

--- a/src/app/api/social/sessions/[slug]/route.ts
+++ b/src/app/api/social/sessions/[slug]/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+
+  const session = await prisma.coworkingSession.findUnique({
+    where: { slug },
+    include: {
+      venue: true,
+      host: {
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+        },
+      },
+      rsvps: {
+        include: {
+          user: {
+            select: {
+              id: true,
+              firstName: true,
+              lastName: true,
+            },
+          },
+        },
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+
+  if (!session) {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(session);
+}

--- a/src/app/api/social/sessions/[slug]/rsvp/route.ts
+++ b/src/app/api/social/sessions/[slug]/rsvp/route.ts
@@ -1,0 +1,77 @@
+import { auth } from "@clerk/nextjs/server";
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+const allowed = new Set(["GOING", "MAYBE", "DECLINED"]);
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { userId } = await auth();
+
+  if (!userId) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+  }
+
+  const { slug } = await params;
+  const body = await request.json();
+  const status = typeof body.status === "string" ? body.status.toUpperCase() : "";
+
+  if (!allowed.has(status)) {
+    return NextResponse.json({ error: "Invalid RSVP status" }, { status: 400 });
+  }
+
+  const session = await prisma.coworkingSession.findUnique({
+    where: { slug },
+    include: {
+      _count: {
+        select: {
+          rsvps: {
+            where: { status: "GOING" },
+          },
+        },
+      },
+    },
+  });
+
+  if (!session) {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+
+  if (
+    status === "GOING" &&
+    session.maxGuests &&
+    session._count.rsvps >= session.maxGuests
+  ) {
+    const existing = await prisma.sessionRsvp.findUnique({
+      where: {
+        sessionId_userId: {
+          sessionId: session.id,
+          userId,
+        },
+      },
+    });
+
+    if (!existing || existing.status !== "GOING") {
+      return NextResponse.json({ error: "Session is full" }, { status: 409 });
+    }
+  }
+
+  const rsvp = await prisma.sessionRsvp.upsert({
+    where: {
+      sessionId_userId: {
+        sessionId: session.id,
+        userId,
+      },
+    },
+    update: { status: status as "GOING" | "MAYBE" | "DECLINED" },
+    create: {
+      sessionId: session.id,
+      userId,
+      status: status as "GOING" | "MAYBE" | "DECLINED",
+    },
+  });
+
+  return NextResponse.json(rsvp);
+}

--- a/src/app/api/social/sessions/route.ts
+++ b/src/app/api/social/sessions/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+
+  const session = await prisma.coworkingSession.findUnique({
+    where: { slug },
+    include: {
+      venue: true,
+      host: {
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+        },
+      },
+      rsvps: {
+        include: {
+          user: {
+            select: {
+              id: true,
+              firstName: true,
+              lastName: true,
+            },
+          },
+        },
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+
+  if (!session) {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(session);
+}

--- a/src/app/api/social/status/route.ts
+++ b/src/app/api/social/status/route.ts
@@ -1,0 +1,101 @@
+import { auth } from "@clerk/nextjs/server";
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function GET() {
+  const statuses = await prisma.workBuddyStatus.findMany({
+    where: {
+      isPublic: true,
+      until: { gt: new Date() },
+    },
+    orderBy: { updatedAt: "desc" },
+    include: {
+      user: {
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+        },
+      },
+      venue: {
+        select: {
+          id: true,
+          name: true,
+          address: true,
+          latitude: true,
+          longitude: true,
+          category: true,
+        },
+      },
+    },
+    take: 50,
+  });
+
+  return NextResponse.json(statuses);
+}
+
+export async function POST(request: NextRequest) {
+  const { userId } = await auth();
+
+  if (!userId) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const venueId = typeof body.venueId === "string" ? body.venueId : "";
+  const note = typeof body.note === "string" ? body.note.trim().slice(0, 160) : null;
+  const until = new Date(body.until);
+
+  if (!venueId || Number.isNaN(until.getTime()) || until <= new Date()) {
+    return NextResponse.json(
+      { error: "A valid venue and future end time are required" },
+      { status: 400 },
+    );
+  }
+
+  const venue = await prisma.venue.findUnique({
+    where: { id: venueId },
+    select: { id: true },
+  });
+
+  if (!venue) {
+    return NextResponse.json({ error: "Venue not found" }, { status: 404 });
+  }
+
+  const status = await prisma.workBuddyStatus.upsert({
+    where: { userId },
+    update: {
+      venueId,
+      note,
+      until,
+      isPublic: body.isPublic !== false,
+    },
+    create: {
+      userId,
+      venueId,
+      note,
+      until,
+      isPublic: body.isPublic !== false,
+    },
+    include: {
+      venue: true,
+      user: {
+        select: { firstName: true, lastName: true },
+      },
+    },
+  });
+
+  return NextResponse.json(status);
+}
+
+export async function DELETE() {
+  const { userId } = await auth();
+
+  if (!userId) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+  }
+
+  await prisma.workBuddyStatus.deleteMany({ where: { userId } });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/venues/share/route.tsx
+++ b/src/app/api/venues/share/route.tsx
@@ -1,0 +1,122 @@
+import { ImageResponse } from "next/og";
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest) {
+  const venueId = request.nextUrl.searchParams.get("venueId");
+
+  if (!venueId) {
+    return new Response("venueId is required", { status: 400 });
+  }
+
+  const venue = await prisma.venue.findUnique({
+    where: { id: venueId },
+  });
+
+  if (!venue) {
+    return new Response("Venue not found", { status: 404 });
+  }
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "1200px",
+          height: "630px",
+          display: "flex",
+          position: "relative",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "64px",
+          color: "white",
+          background:
+            "radial-gradient(circle at top right, #6d28d9 0%, #111827 38%, #030712 100%)",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: "18px" }}>
+          <div
+            style={{
+              width: "52px",
+              height: "52px",
+              borderRadius: "16px",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              background: "#8b5cf6",
+              fontSize: "28px",
+            }}
+          >
+            W
+          </div>
+          <div style={{ fontSize: "28px", color: "#c4b5fd" }}>WorkSphere</div>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: "22px" }}>
+          <div
+            style={{
+              fontSize: "70px",
+              fontWeight: 800,
+              maxWidth: "940px",
+              letterSpacing: "-2px",
+              lineHeight: 1.05,
+            }}
+          >
+            {venue.name}
+          </div>
+
+          <div style={{ fontSize: "30px", color: "#d1d5db" }}>
+            {venue.address || "A workspace worth sharing"}
+          </div>
+
+          <div style={{ display: "flex", gap: "18px", fontSize: "24px" }}>
+            <span
+              style={{
+                padding: "12px 20px",
+                borderRadius: "999px",
+                background: "rgba(139, 92, 246, 0.22)",
+                border: "1px solid rgba(196, 181, 253, 0.35)",
+              }}
+            >
+              {venue.category}
+            </span>
+
+            {venue.rating ? (
+              <span
+                style={{
+                  padding: "12px 20px",
+                  borderRadius: "999px",
+                  background: "rgba(250, 204, 21, 0.16)",
+                }}
+              >
+                ★ {venue.rating.toFixed(1)}
+              </span>
+            ) : null}
+
+            {venue.wifiQuality ? (
+              <span
+                style={{
+                  padding: "12px 20px",
+                  borderRadius: "999px",
+                  background: "rgba(34, 211, 238, 0.14)",
+                }}
+              >
+                WiFi {venue.wifiQuality}/5
+              </span>
+            ) : null}
+          </div>
+        </div>
+
+        <div style={{ fontSize: "24px", color: "#9ca3af" }}>
+          Discover better places to work together.
+        </div>
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 630,
+    },
+  );
+}

--- a/src/app/sessions/[slug]/page.tsx
+++ b/src/app/sessions/[slug]/page.tsx
@@ -1,0 +1,73 @@
+import { notFound } from "next/navigation";
+import { prisma } from "@/lib/prisma";
+import SessionDetailClient from "./session-detail-client";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const session = await prisma.coworkingSession.findUnique({
+    where: { slug },
+    include: { venue: true },
+  });
+
+  if (!session) {
+    return { title: "Session not found | WorkSphere" };
+  }
+
+  return {
+    title: `${session.title} | WorkSphere`,
+    description:
+      session.description ||
+      `Join a coworking session at ${session.venue.name}.`,
+    openGraph: {
+      title: session.title,
+      description:
+        session.description ||
+        `Join a coworking session at ${session.venue.name}.`,
+    },
+  };
+}
+
+export default async function SessionPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+
+  const session = await prisma.coworkingSession.findUnique({
+    where: { slug },
+    include: {
+      venue: true,
+      host: {
+        select: {
+          firstName: true,
+          lastName: true,
+        },
+      },
+      rsvps: {
+        include: {
+          user: {
+            select: {
+              id: true,
+              firstName: true,
+              lastName: true,
+            },
+          },
+        },
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+
+  if (!session) notFound();
+
+  return (
+    <SessionDetailClient
+      session={JSON.parse(JSON.stringify(session))}
+    />
+  );
+}

--- a/src/app/sessions/[slug]/session-detail-client.tsx
+++ b/src/app/sessions/[slug]/session-detail-client.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  CalendarDays,
+  Check,
+  Clock3,
+  Copy,
+  MapPin,
+  Navigation,
+  Share2,
+  UsersRound,
+} from "lucide-react";
+
+type Props = {
+  session: {
+    slug: string;
+    title: string;
+    description: string | null;
+    startsAt: string;
+    endsAt: string;
+    maxGuests: number | null;
+    host: {
+      firstName: string | null;
+      lastName: string | null;
+    };
+    venue: {
+      name: string;
+      address: string | null;
+      latitude: number;
+      longitude: number;
+      category: string;
+    };
+    rsvps: Array<{
+      status: "GOING" | "MAYBE" | "DECLINED";
+      user: {
+        id: string;
+        firstName: string | null;
+        lastName: string | null;
+      };
+    }>;
+  };
+};
+
+export default function SessionDetailClient({ session }: Props) {
+  const [rsvps, setRsvps] = useState(session.rsvps);
+  const [message, setMessage] = useState("");
+  const going = useMemo(
+    () => rsvps.filter((item) => item.status === "GOING"),
+    [rsvps],
+  );
+
+  const hostName =
+    [session.host.firstName, session.host.lastName].filter(Boolean).join(" ") ||
+    "WorkSphere member";
+
+  async function respond(status: "GOING" | "MAYBE" | "DECLINED") {
+    setMessage("");
+
+    const response = await fetch(`/api/social/sessions/${session.slug}/rsvp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status }),
+    });
+
+    const payload = await response.json();
+
+    if (!response.ok) {
+      setMessage(payload.error ?? "Unable to update RSVP");
+      return;
+    }
+
+    setMessage(`RSVP updated: ${status.toLowerCase()}.`);
+
+    const refreshed = await fetch(`/api/social/sessions/${session.slug}`, {
+      cache: "no-store",
+    });
+
+    if (refreshed.ok) {
+      const data = await refreshed.json();
+      setRsvps(data.rsvps);
+    }
+  }
+
+  async function share() {
+    const url = window.location.href;
+    if (navigator.share) {
+      await navigator.share({
+        title: session.title,
+        text: `Join me at ${session.venue.name}`,
+        url,
+      });
+    } else {
+      await navigator.clipboard.writeText(url);
+      setMessage("Session link copied.");
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-[#07070a] px-5 py-10 text-white">
+      <div className="mx-auto max-w-5xl">
+        <div className="grid gap-6 lg:grid-cols-[1.35fr_.65fr]">
+          <section className="rounded-[2rem] border border-white/10 bg-gradient-to-br from-violet-950/70 via-zinc-950 to-cyan-950/30 p-7 md:p-10">
+            <span className="inline-flex rounded-full border border-violet-400/20 bg-violet-400/10 px-3 py-1 text-xs text-violet-200">
+              Group coworking session
+            </span>
+
+            <h1 className="mt-5 text-4xl font-semibold tracking-tight md:text-6xl">
+              {session.title}
+            </h1>
+
+            <p className="mt-4 text-zinc-400">Hosted by {hostName}</p>
+
+            {session.description && (
+              <p className="mt-7 max-w-2xl text-lg leading-8 text-zinc-300">
+                {session.description}
+              </p>
+            )}
+
+            <div className="mt-8 grid gap-3 sm:grid-cols-2">
+              <Info icon={<CalendarDays className="h-5 w-5" />} title="Starts" value={new Date(session.startsAt).toLocaleString()} />
+              <Info icon={<Clock3 className="h-5 w-5" />} title="Ends" value={new Date(session.endsAt).toLocaleString()} />
+              <Info icon={<MapPin className="h-5 w-5" />} title="Workspace" value={session.venue.name} />
+              <Info icon={<UsersRound className="h-5 w-5" />} title="Attendance" value={`${going.length}${session.maxGuests ? ` / ${session.maxGuests}` : ""} going`} />
+            </div>
+
+            <div className="mt-8 flex flex-wrap gap-3">
+              <button onClick={() => respond("GOING")} className="rounded-xl bg-violet-600 px-5 py-3 font-medium hover:bg-violet-500">
+                I’m going
+              </button>
+              <button onClick={() => respond("MAYBE")} className="rounded-xl border border-white/10 bg-white/5 px-5 py-3 font-medium hover:bg-white/10">
+                Maybe
+              </button>
+              <button onClick={share} className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-5 py-3 font-medium hover:bg-white/10">
+                <Share2 className="h-4 w-4" /> Share
+              </button>
+            </div>
+
+            {message && <p className="mt-4 text-sm text-violet-200">{message}</p>}
+          </section>
+
+          <aside className="space-y-6">
+            <div className="rounded-[2rem] border border-white/10 bg-white/[0.04] p-6">
+              <h2 className="text-lg font-semibold">Location</h2>
+              <p className="mt-2 text-sm text-zinc-400">{session.venue.address}</p>
+
+              <div className="mt-5 rounded-2xl border border-white/10 bg-black/20 p-4 text-sm text-zinc-300">
+                <div>Lat: {session.venue.latitude.toFixed(5)}</div>
+                <div className="mt-1">Lng: {session.venue.longitude.toFixed(5)}</div>
+              </div>
+
+              <a
+                href={`https://www.openstreetmap.org/?mlat=${session.venue.latitude}&mlon=${session.venue.longitude}#map=17/${session.venue.latitude}/${session.venue.longitude}`}
+                target="_blank"
+                rel="noreferrer"
+                className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-cyan-500/10 px-4 py-3 text-sm font-medium text-cyan-200 hover:bg-cyan-500/15"
+              >
+                <Navigation className="h-4 w-4" />
+                Open route map
+              </a>
+            </div>
+
+            <div className="rounded-[2rem] border border-white/10 bg-white/[0.04] p-6">
+              <h2 className="text-lg font-semibold">Who’s going</h2>
+              <div className="mt-4 space-y-3">
+                {going.map((item) => {
+                  const name =
+                    [item.user.firstName, item.user.lastName].filter(Boolean).join(" ") ||
+                    "WorkSphere member";
+
+                  return (
+                    <div key={item.user.id} className="flex items-center gap-3">
+                      <span className="flex h-9 w-9 items-center justify-center rounded-full bg-violet-500/15 text-violet-200">
+                        <Check className="h-4 w-4" />
+                      </span>
+                      <span className="text-sm text-zinc-300">{name}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+function Info({
+  icon,
+  title,
+  value,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  value: string;
+}) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
+      <div className="flex items-center gap-2 text-violet-300">
+        {icon}
+        <span className="text-xs uppercase tracking-wider">{title}</span>
+      </div>
+      <p className="mt-2 text-sm text-zinc-300">{value}</p>
+    </div>
+  );
+}

--- a/src/app/social/page.tsx
+++ b/src/app/social/page.tsx
@@ -1,0 +1,18 @@
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+import SocialWorkspaceClient from "./social-workspace-client";
+
+export const metadata = {
+  title: "Work Together | WorkSphere",
+  description: "Share work status and plan coworking sessions with your people.",
+};
+
+export default async function SocialPage() {
+  const { userId } = await auth();
+
+  if (!userId) {
+    redirect("/sign-in");
+  }
+
+  return <SocialWorkspaceClient />;
+}

--- a/src/app/social/social-workspace-client.tsx
+++ b/src/app/social/social-workspace-client.tsx
@@ -1,0 +1,480 @@
+"use client";
+
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import {
+  CalendarDays,
+  CheckCircle2,
+  Clock3,
+  Copy,
+  ExternalLink,
+  MapPin,
+  RefreshCw,
+  Share2,
+  Sparkles,
+  UserRoundCheck,
+  UsersRound,
+  X,
+} from "lucide-react";
+
+type Venue = {
+  id: string;
+  name: string;
+  address: string | null;
+  latitude: number;
+  longitude: number;
+  category: string;
+  imageUrl?: string | null;
+};
+
+type Status = {
+  id: string;
+  note: string | null;
+  until: string;
+  user: {
+    id: string;
+    firstName: string | null;
+    lastName: string | null;
+  };
+  venue: Venue;
+};
+
+type Session = {
+  id: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  startsAt: string;
+  endsAt: string;
+  maxGuests: number | null;
+  venue: Venue;
+  host: {
+    id: string;
+    firstName: string | null;
+    lastName: string | null;
+  };
+  _count: {
+    rsvps: number;
+  };
+};
+
+function displayName(user: { firstName: string | null; lastName: string | null }) {
+  return [user.firstName, user.lastName].filter(Boolean).join(" ") || "WorkSphere member";
+}
+
+function formatDate(value: string) {
+  return new Date(value).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+export default function SocialWorkspaceClient() {
+  const [statuses, setStatuses] = useState<Status[]>([]);
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [venues, setVenues] = useState<Venue[]>([]);
+  const [tab, setTab] = useState<"pulse" | "sessions">("pulse");
+  const [statusOpen, setStatusOpen] = useState(false);
+  const [sessionOpen, setSessionOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState("");
+
+  async function load() {
+    const [statusResponse, sessionResponse, venueResponse] = await Promise.all([
+      fetch("/api/social/status", { cache: "no-store" }),
+      fetch("/api/social/sessions", { cache: "no-store" }),
+      fetch("/api/venues", { cache: "no-store" }),
+    ]);
+
+    if (statusResponse.ok) setStatuses(await statusResponse.json());
+    if (sessionResponse.ok) setSessions(await sessionResponse.json());
+
+    if (venueResponse.ok) {
+      const venuePayload = await venueResponse.json();
+      setVenues(Array.isArray(venuePayload) ? venuePayload : venuePayload.venues ?? []);
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function submitStatus(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setBusy(true);
+    setMessage("");
+
+    const form = new FormData(event.currentTarget);
+
+    const response = await fetch("/api/social/status", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        venueId: form.get("venueId"),
+        note: form.get("note"),
+        until: form.get("until"),
+        isPublic: true,
+      }),
+    });
+
+    const payload = await response.json();
+
+    if (!response.ok) {
+      setMessage(payload.error ?? "Unable to publish status");
+    } else {
+      setStatusOpen(false);
+      setMessage("Your Work Buddy status is live.");
+      await load();
+    }
+
+    setBusy(false);
+  }
+
+  async function submitSession(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setBusy(true);
+    setMessage("");
+
+    const form = new FormData(event.currentTarget);
+
+    const response = await fetch("/api/social/sessions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: form.get("title"),
+        description: form.get("description"),
+        venueId: form.get("venueId"),
+        startsAt: form.get("startsAt"),
+        endsAt: form.get("endsAt"),
+        maxGuests: Number(form.get("maxGuests")) || null,
+      }),
+    });
+
+    const payload = await response.json();
+
+    if (!response.ok) {
+      setMessage(payload.error ?? "Unable to create session");
+    } else {
+      setSessionOpen(false);
+      setMessage("Coworking session created.");
+      await load();
+    }
+
+    setBusy(false);
+  }
+
+  const activeCount = useMemo(() => statuses.length, [statuses]);
+
+  return (
+    <main className="min-h-screen bg-[#07070a] text-white">
+      <div className="pointer-events-none fixed inset-0 overflow-hidden">
+        <div className="absolute -left-40 top-20 h-96 w-96 rounded-full bg-violet-700/20 blur-[130px]" />
+        <div className="absolute -right-40 top-1/3 h-96 w-96 rounded-full bg-cyan-700/10 blur-[130px]" />
+      </div>
+
+      <div className="relative mx-auto max-w-7xl px-5 py-8 md:px-8">
+        <header className="mb-8 flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-violet-400/20 bg-violet-400/10 px-3 py-1 text-xs text-violet-200">
+              <Sparkles className="h-3.5 w-3.5" />
+              Work together, not just nearby
+            </div>
+            <h1 className="text-4xl font-semibold tracking-tight md:text-5xl">
+              Coworking Social Hub
+            </h1>
+            <p className="mt-3 max-w-2xl text-zinc-400">
+              Share where you are working, discover work buddies nearby, and turn a good workspace into a group session.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <button
+              onClick={() => setStatusOpen(true)}
+              className="rounded-2xl border border-white/10 bg-white/[0.06] px-4 py-3 text-sm font-medium transition hover:bg-white/[0.1]"
+            >
+              Share my status
+            </button>
+            <button
+              onClick={() => setSessionOpen(true)}
+              className="rounded-2xl bg-violet-600 px-4 py-3 text-sm font-medium transition hover:bg-violet-500"
+            >
+              Create group session
+            </button>
+          </div>
+        </header>
+
+        {message && (
+          <div className="mb-6 rounded-2xl border border-violet-400/20 bg-violet-400/10 px-4 py-3 text-sm text-violet-100">
+            {message}
+          </div>
+        )}
+
+        <section className="mb-6 grid gap-4 sm:grid-cols-3">
+          <div className="rounded-3xl border border-white/10 bg-white/[0.04] p-5">
+            <UserRoundCheck className="mb-4 h-6 w-6 text-emerald-300" />
+            <div className="text-3xl font-semibold">{activeCount}</div>
+            <div className="mt-1 text-sm text-zinc-500">active work statuses</div>
+          </div>
+          <div className="rounded-3xl border border-white/10 bg-white/[0.04] p-5">
+            <UsersRound className="mb-4 h-6 w-6 text-violet-300" />
+            <div className="text-3xl font-semibold">{sessions.length}</div>
+            <div className="mt-1 text-sm text-zinc-500">upcoming group sessions</div>
+          </div>
+          <div className="rounded-3xl border border-white/10 bg-white/[0.04] p-5">
+            <MapPin className="mb-4 h-6 w-6 text-cyan-300" />
+            <div className="text-3xl font-semibold">{venues.length}</div>
+            <div className="mt-1 text-sm text-zinc-500">available workspace locations</div>
+          </div>
+        </section>
+
+        <div className="mb-6 flex items-center justify-between">
+          <div className="flex rounded-2xl border border-white/10 bg-white/[0.04] p-1">
+            <button
+              onClick={() => setTab("pulse")}
+              className={`rounded-xl px-4 py-2 text-sm transition ${tab === "pulse" ? "bg-white text-black" : "text-zinc-400"}`}
+            >
+              Work Buddy pulse
+            </button>
+            <button
+              onClick={() => setTab("sessions")}
+              className={`rounded-xl px-4 py-2 text-sm transition ${tab === "sessions" ? "bg-white text-black" : "text-zinc-400"}`}
+            >
+              Group sessions
+            </button>
+          </div>
+
+          <button onClick={load} className="rounded-xl p-2 text-zinc-400 transition hover:bg-white/5 hover:text-white">
+            <RefreshCw className="h-5 w-5" />
+          </button>
+        </div>
+
+        {tab === "pulse" ? (
+          <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {statuses.map((status) => (
+              <article key={status.id} className="rounded-3xl border border-white/10 bg-white/[0.04] p-5 backdrop-blur">
+                <div className="mb-4 flex items-start justify-between">
+                  <div>
+                    <div className="font-medium">{displayName(status.user)}</div>
+                    <div className="mt-1 text-sm text-zinc-500">is working now</div>
+                  </div>
+                  <span className="h-3 w-3 rounded-full bg-emerald-400 shadow-[0_0_18px_rgba(52,211,153,.8)]" />
+                </div>
+
+                <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
+                  <div className="flex gap-3">
+                    <MapPin className="mt-0.5 h-5 w-5 shrink-0 text-violet-300" />
+                    <div>
+                      <div className="font-medium">{status.venue.name}</div>
+                      <div className="mt-1 text-xs text-zinc-500">{status.venue.address}</div>
+                    </div>
+                  </div>
+                  <div className="mt-3 flex items-center gap-2 text-xs text-zinc-400">
+                    <Clock3 className="h-4 w-4" />
+                    until {new Date(status.until).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+                  </div>
+                </div>
+
+                {status.note && (
+                  <p className="mt-4 text-sm leading-6 text-zinc-300">“{status.note}”</p>
+                )}
+
+                <a
+                  href={`https://www.openstreetmap.org/?mlat=${status.venue.latitude}&mlon=${status.venue.longitude}#map=17/${status.venue.latitude}/${status.venue.longitude}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="mt-4 inline-flex items-center gap-2 text-sm text-violet-300 hover:text-violet-200"
+                >
+                  Open location <ExternalLink className="h-4 w-4" />
+                </a>
+              </article>
+            ))}
+
+            {statuses.length === 0 && (
+              <div className="col-span-full rounded-3xl border border-dashed border-white/10 p-10 text-center text-zinc-500">
+                No one has shared a Work Buddy status yet.
+              </div>
+            )}
+          </section>
+        ) : (
+          <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {sessions.map((session) => (
+              <article key={session.id} className="overflow-hidden rounded-3xl border border-white/10 bg-white/[0.04]">
+                <div className="p-5">
+                  <div className="mb-3 flex items-center justify-between gap-4">
+                    <span className="rounded-full bg-violet-400/10 px-3 py-1 text-xs text-violet-300">
+                      {session.venue.category}
+                    </span>
+                    <span className="text-xs text-zinc-500">
+                      {session._count.rsvps} going
+                    </span>
+                  </div>
+
+                  <h2 className="text-xl font-semibold">{session.title}</h2>
+                  <p className="mt-2 text-sm text-zinc-400">
+                    Hosted by {displayName(session.host)}
+                  </p>
+
+                  {session.description && (
+                    <p className="mt-4 line-clamp-3 text-sm leading-6 text-zinc-300">
+                      {session.description}
+                    </p>
+                  )}
+
+                  <div className="mt-5 space-y-3 border-t border-white/10 pt-4 text-sm">
+                    <div className="flex gap-3 text-zinc-300">
+                      <MapPin className="h-5 w-5 shrink-0 text-cyan-300" />
+                      <div>
+                        <div>{session.venue.name}</div>
+                        <div className="mt-1 text-xs text-zinc-500">{session.venue.address}</div>
+                      </div>
+                    </div>
+                    <div className="flex gap-3 text-zinc-300">
+                      <CalendarDays className="h-5 w-5 shrink-0 text-violet-300" />
+                      <span>{formatDate(session.startsAt)}</span>
+                    </div>
+                  </div>
+
+                  <div className="mt-5 flex gap-2">
+                    <a
+                      href={`/sessions/${session.slug}`}
+                      className="flex-1 rounded-xl bg-violet-600 px-4 py-2.5 text-center text-sm font-medium hover:bg-violet-500"
+                    >
+                      View & RSVP
+                    </a>
+                    <button
+                      onClick={() => navigator.clipboard.writeText(`${window.location.origin}/sessions/${session.slug}`)}
+                      className="rounded-xl border border-white/10 px-3 hover:bg-white/5"
+                      title="Copy share link"
+                    >
+                      <Copy className="h-4 w-4" />
+                    </button>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </section>
+        )}
+      </div>
+
+      {statusOpen && (
+        <Modal title="Share your Work Buddy status" onClose={() => setStatusOpen(false)}>
+          <form onSubmit={submitStatus} className="space-y-4">
+            <Field label="Workspace">
+              <select name="venueId" required className="input">
+                <option value="">Choose a workspace</option>
+                {venues.map((venue) => (
+                  <option key={venue.id} value={venue.id}>
+                    {venue.name}
+                  </option>
+                ))}
+              </select>
+            </Field>
+            <Field label="What are you working on?">
+              <input name="note" maxLength={160} placeholder="Deep work on a launch plan..." className="input" />
+            </Field>
+            <Field label="Working until">
+              <input name="until" type="datetime-local" required className="input" />
+            </Field>
+            <button disabled={busy} className="w-full rounded-xl bg-violet-600 px-4 py-3 font-medium hover:bg-violet-500 disabled:opacity-50">
+              {busy ? "Publishing..." : "Publish status"}
+            </button>
+          </form>
+        </Modal>
+      )}
+
+      {sessionOpen && (
+        <Modal title="Create a group coworking session" onClose={() => setSessionOpen(false)}>
+          <form onSubmit={submitSession} className="space-y-4">
+            <Field label="Session title">
+              <input name="title" required maxLength={100} placeholder="Friday focus sprint" className="input" />
+            </Field>
+            <Field label="Workspace">
+              <select name="venueId" required className="input">
+                <option value="">Choose a workspace</option>
+                {venues.map((venue) => (
+                  <option key={venue.id} value={venue.id}>
+                    {venue.name}
+                  </option>
+                ))}
+              </select>
+            </Field>
+            <div className="grid grid-cols-2 gap-3">
+              <Field label="Starts">
+                <input name="startsAt" type="datetime-local" required className="input" />
+              </Field>
+              <Field label="Ends">
+                <input name="endsAt" type="datetime-local" required className="input" />
+              </Field>
+            </div>
+            <Field label="Description">
+              <textarea name="description" rows={3} maxLength={500} placeholder="Bring headphones. We'll do two focus blocks and a coffee break." className="input resize-none" />
+            </Field>
+            <Field label="Maximum guests (optional)">
+              <input name="maxGuests" type="number" min={1} max={100} className="input" />
+            </Field>
+            <button disabled={busy} className="w-full rounded-xl bg-violet-600 px-4 py-3 font-medium hover:bg-violet-500 disabled:opacity-50">
+              {busy ? "Creating..." : "Create shareable session"}
+            </button>
+          </form>
+        </Modal>
+      )}
+
+      <style jsx global>{`
+        .input {
+          width: 100%;
+          border-radius: 0.75rem;
+          border: 1px solid rgba(255, 255, 255, 0.1);
+          background: rgba(255, 255, 255, 0.05);
+          padding: 0.75rem;
+          color: white;
+          outline: none;
+        }
+        .input:focus {
+          border-color: rgba(167, 139, 250, 0.7);
+          box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.14);
+        }
+        .input option {
+          background: #111114;
+        }
+      `}</style>
+    </main>
+  );
+}
+
+function Modal({
+  title,
+  onClose,
+  children,
+}: {
+  title: string;
+  onClose: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm">
+      <div className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-3xl border border-white/10 bg-[#111114] p-6 shadow-2xl">
+        <div className="mb-5 flex items-center justify-between">
+          <h2 className="text-xl font-semibold">{title}</h2>
+          <button onClick={onClose} className="rounded-xl p-2 text-zinc-400 hover:bg-white/5 hover:text-white">
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className="block">
+      <span className="mb-2 block text-sm text-zinc-400">{label}</span>
+      {children}
+    </label>
+  );
+}

--- a/src/components/VenueCard.tsx
+++ b/src/components/VenueCard.tsx
@@ -1,5 +1,5 @@
 "use client";
-
+import { VenueShareButton } from "@/components/social/VenueShareButton";
 import { MapMarker } from "@/types/map";
 import { Star, Wifi, Zap, Volume2, Navigation, Heart, MessageSquare, Clock, ExternalLink, Loader2, TreePine, Accessibility } from "lucide-react";
 import { useState, useEffect } from "react";
@@ -251,6 +251,12 @@ export function VenueCard({
               <ExternalLink className="w-4 h-4" />
             </a>
           )}
+          {enrichData?.venueId && (
+  <VenueShareButton
+    venueId={enrichData.venueId}
+    venueName={venue.name}
+  />
+)}
         </div>
       </div>
     </div>

--- a/src/components/social/VenueShareButton.tsx
+++ b/src/components/social/VenueShareButton.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Share2 } from "lucide-react";
+import { useState } from "react";
+
+type Props = {
+  venueId: string;
+  venueName: string;
+};
+
+export function VenueShareButton({ venueId, venueName }: Props) {
+  const [copied, setCopied] = useState(false);
+
+  async function share() {
+    const url = `${window.location.origin}/social?venue=${encodeURIComponent(venueId)}`;
+    const data = {
+      title: `${venueName} on WorkSphere`,
+      text: `Check out ${venueName} as a place to work.`,
+      url,
+    };
+
+    try {
+      if (navigator.share) {
+        await navigator.share(data);
+        return;
+      }
+
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1800);
+    } catch (error) {
+      if ((error as Error).name !== "AbortError") {
+        console.error("Unable to share venue", error);
+      }
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={share}
+      className="inline-flex items-center justify-center gap-2 rounded-lg bg-violet-600 px-3 py-2 text-sm font-medium text-white transition hover:bg-violet-500"
+    >
+      <Share2 className="h-4 w-4" />
+      {copied ? "Link copied" : "Share"}
+    </button>
+  );
+}

--- a/src/lib/social.ts
+++ b/src/lib/social.ts
@@ -1,0 +1,18 @@
+export function createSessionSlug(title: string) {
+  const base = title
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 48);
+
+  return `${base || "coworking-session"}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+export function getAppUrl() {
+  return (
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.VERCEL_URL?.replace(/^/, "https://") ||
+    "http://localhost:3000"
+  );
+}


### PR DESCRIPTION
## Description

This PR introduces social workspace collaboration features to WorkSphere, allowing remote workers to share where they are working and plan coworking sessions directly inside the platform.

### Features added

- Workspace share button with native Web Share API support.
- Clipboard fallback when native sharing is unavailable.
- Dynamic venue share-card image endpoint for social previews.
- Work Buddy status:
  - share current workspace
  - optional activity note
  - automatic expiry time
  - public active-status feed
- Group coworking sessions:
  - create sessions at WorkSphere venues
  - future start/end times
  - optional guest capacity
  - shareable session URLs
  - workspace address and coordinates
  - route-map link
- RSVP workflow:
  - Going
  - Maybe
  - Declined
  - capacity protection for full sessions
- Dedicated `/social` collaboration hub.
- Public `/sessions/[slug]` session detail pages.

## Related Issue

Fixes #39

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Breaking Changes

- [ ] Yes
- [x] No
