### PR TITLE
feat: add ambient noise analyzer and venue noise metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "@testing-library/react": "^16.1.0",
         "@types/jest": "^29.5.14",
         "@types/leaflet": "^1.9.21",
+        "@types/leaflet.heat": "^0.2.5",
         "@types/node": "^26",
         "@types/nodemailer": "^7.0.11",
         "@types/pdfkit": "^0.17.5",
@@ -3787,6 +3788,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/leaflet.heat": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@types/leaflet.heat/-/leaflet.heat-0.2.5.tgz",
+      "integrity": "sha512-wmDePJPn2vhW9BScsWTV4pSfWayhdDwXuWIQzUuaJkvk5DCHsYsIegTD7tybo38E/0mxpuWODKV/LhsxPESWJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/leaflet": "^1.9"
       }
     },
     "node_modules/@types/node": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@testing-library/react": "^16.1.0",
     "@types/jest": "^29.5.14",
     "@types/leaflet": "^1.9.21",
+    "@types/leaflet.heat": "^0.2.5",
     "@types/node": "^26",
     "@types/nodemailer": "^7.0.11",
     "@types/pdfkit": "^0.17.5",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -72,6 +72,8 @@ model VenueRating {
   wifiSpeed     Int? // in Mbps
   comment       String?
   createdAt     DateTime @default(now())
+  avgDecibels   Float?
+  peakDecibels  Float?
 
   @@unique([userId, venueId])
   @@index([venueId])
@@ -134,6 +136,7 @@ model Booking {
 
   @@index([userId])
   @@index([venueId])
+  @@index([seatId])
 }
 
 enum BookingStatus {

--- a/src/app/api/venues/[venueId]/noise-metrics/route.ts
+++ b/src/app/api/venues/[venueId]/noise-metrics/route.ts
@@ -1,0 +1,104 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+type BucketKey = "morning" | "lunch" | "afternoon" | "evening";
+
+const bucketOrder: Array<{ key: BucketKey; label: string }> = [
+  { key: "morning", label: "Morning" },
+  { key: "lunch", label: "Lunch hour" },
+  { key: "afternoon", label: "Afternoon" },
+  { key: "evening", label: "Evening" },
+];
+
+function getBucket(hour: number): BucketKey {
+  if (hour < 11) return "morning";
+  if (hour < 14) return "lunch";
+  if (hour < 18) return "afternoon";
+  return "evening";
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ venueId: string }> },
+) {
+  const { venueId } = await params;
+
+  const venue = await prisma.venue.findFirst({
+    where: {
+      OR: [{ id: venueId }, { placeId: venueId }],
+    },
+    select: { id: true },
+  });
+
+  if (!venue) {
+    return NextResponse.json({ error: "Venue not found" }, { status: 404 });
+  }
+
+  const ratings = await prisma.venueRating.findMany({
+    where: {
+      venueId: venue.id,
+      avgDecibels: { not: null },
+    },
+    select: {
+      avgDecibels: true,
+      peakDecibels: true,
+      createdAt: true,
+    },
+    orderBy: { createdAt: "asc" },
+  });
+
+  const grouped: Record<
+    BucketKey,
+    { averages: number[]; peaks: number[] }
+  > = {
+    morning: { averages: [], peaks: [] },
+    lunch: { averages: [], peaks: [] },
+    afternoon: { averages: [], peaks: [] },
+    evening: { averages: [], peaks: [] },
+  };
+
+  for (const rating of ratings) {
+    if (rating.avgDecibels === null) continue;
+
+    const bucket = getBucket(rating.createdAt.getHours());
+
+    grouped[bucket].averages.push(rating.avgDecibels);
+
+    if (rating.peakDecibels !== null) {
+      grouped[bucket].peaks.push(rating.peakDecibels);
+    }
+  }
+
+  const buckets = bucketOrder.map(({ key, label }) => {
+    const averageValues = grouped[key].averages;
+    const peakValues = grouped[key].peaks;
+
+    const averageDb =
+      averageValues.length > 0
+        ? Math.round(
+            (averageValues.reduce((sum, value) => sum + value, 0) /
+              averageValues.length) *
+              10,
+          ) / 10
+        : null;
+
+    const peakDb =
+      peakValues.length > 0
+        ? Math.round(Math.max(...peakValues) * 10) / 10
+        : null;
+
+    return {
+      key,
+      label,
+      averageDb,
+      peakDb,
+      samples: averageValues.length,
+    };
+  });
+
+  return NextResponse.json({
+    venueId: venue.id,
+    buckets,
+    totalSamples: ratings.length,
+  });
+}

--- a/src/app/api/venues/[venueId]/rate/route.ts
+++ b/src/app/api/venues/[venueId]/rate/route.ts
@@ -28,7 +28,17 @@ export async function POST(
       return NextResponse.json({ error: validation.error }, { status: 400 });
     }
 
-    const { wifiQuality, hasOutlets, noiseLevel, comment, hasErgonomic, outletDensity, wifiSpeed } = validation.data;
+    const {
+  wifiQuality,
+  hasOutlets,
+  noiseLevel,
+  avgDecibels,
+  peakDecibels,
+  comment,
+  hasErgonomic,
+  outletDensity,
+  wifiSpeed,
+} = validation.data;
     const { venue: venueData } = body; // venue data for creating new venues
 
     const targetPlaceId = venueData?.placeId || venueId;
@@ -62,20 +72,24 @@ export async function POST(
         },
       },
       update: {
-        wifiQuality,
-        hasOutlets,
-        noiseLevel,
-        hasErgonomic,
-        outletDensity,
-        wifiSpeed,
-        comment,
-      },
+  wifiQuality,
+  hasOutlets,
+  noiseLevel,
+  avgDecibels,
+  peakDecibels,
+  hasErgonomic,
+  outletDensity,
+  wifiSpeed,
+  comment,
+},
       create: {
         userId,
         venueId: finalVenueId,
         wifiQuality,
         hasOutlets,
         noiseLevel,
+        avgDecibels: avgDecibels || null,
+        peakDecibels: peakDecibels || null,
         hasErgonomic: hasErgonomic || false,
         outletDensity: outletDensity || "none",
         wifiSpeed: wifiSpeed || null,

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -10,15 +10,14 @@ import {
   Polyline,
   useMap,
 } from "react-leaflet";
-import L from "leaflet";
 
-// @ts-expect-error - styles are handled by next built-in CSS loader
+import L from "leaflet";
 import "leaflet/dist/leaflet.css";
+import "leaflet.heat";
 import { MapMarker, MapRoute, MapView } from "@/types/map";
 
 // Import Leaflet Heatmap Plugin safely only on client-side
 if (typeof window !== "undefined") {
-  // @ts-ignore
   require("leaflet.heat");
 }
 

--- a/src/components/VenueCard.tsx
+++ b/src/components/VenueCard.tsx
@@ -4,6 +4,7 @@ import { MapMarker } from "@/types/map";
 import { Star, Wifi, Zap, Volume2, Navigation, Heart, MessageSquare, Clock, ExternalLink, Loader2, TreePine, Accessibility } from "lucide-react";
 import { useState, useEffect } from "react";
 import Image from "next/image";
+import { NoiseTimeChart } from "@/components/noise/NoiseTimeChart";
 
 interface VenueEnrichData {
   found: boolean;
@@ -223,6 +224,11 @@ export function VenueCard({
               📏 {venue.distance}
             </div>
           )}
+          {enrichData?.venueId && (
+  <div className="mt-4">
+    <NoiseTimeChart venueId={enrichData.venueId} />
+  </div>
+)}
         </div>
 
         {/* Actions */}

--- a/src/components/VenueRatingDialog.tsx
+++ b/src/components/VenueRatingDialog.tsx
@@ -1,8 +1,12 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
-import { X, Star } from "lucide-react";
+import { Star, X } from "lucide-react";
+import {
+  NoiseMeasurement,
+  NoiseMeter,
+} from "@/components/noise/NoiseMeter";
 
 interface VenueRatingDialogProps {
   venueName: string;
@@ -13,6 +17,8 @@ interface VenueRatingDialogProps {
     wifiQuality: number;
     hasOutlets: boolean;
     noiseLevel: "quiet" | "moderate" | "loud";
+    avgDecibels?: number;
+    peakDecibels?: number;
     comment?: string;
     hasErgonomic: boolean;
     outletDensity: "every_table" | "some_tables" | "wall_seats" | "none";
@@ -29,11 +35,16 @@ export function VenueRatingDialog({
 }: VenueRatingDialogProps) {
   const [wifiQuality, setWifiQuality] = useState(3);
   const [hasOutlets, setHasOutlets] = useState<boolean | null>(null);
-  const [noiseLevel, setNoiseLevel] = useState<"quiet" | "moderate" | "loud">("moderate");
+  const [noiseLevel, setNoiseLevel] = useState<
+    "quiet" | "moderate" | "loud"
+  >("moderate");
+  const [measurement, setMeasurement] = useState<NoiseMeasurement | null>(null);
   const [comment, setComment] = useState("");
   const [hasErgonomic, setHasErgonomic] = useState(false);
-  const [outletDensity, setOutletDensity] = useState<"every_table" | "some_tables" | "wall_seats" | "none">("none");
-  const [wifiSpeed, setWifiSpeed] = useState<string>("");
+  const [outletDensity, setOutletDensity] = useState<
+    "every_table" | "some_tables" | "wall_seats" | "none"
+  >("none");
+  const [wifiSpeed, setWifiSpeed] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [mounted, setMounted] = useState(false);
 
@@ -41,31 +52,33 @@ export function VenueRatingDialog({
     setMounted(true);
   }, []);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+
     if (hasOutlets === null) {
       alert("Please indicate if outlets are available");
       return;
     }
 
     setIsSubmitting(true);
-    
+
     try {
       await onSubmit({
         wifiQuality,
         hasOutlets,
         noiseLevel,
+        avgDecibels: measurement?.averageDb,
+        peakDecibels: measurement?.peakDb,
         comment: comment.trim() || undefined,
         hasErgonomic,
         outletDensity,
         wifiSpeed: wifiSpeed ? parseInt(wifiSpeed, 10) : undefined,
       });
-      
-      // Reset form
+
       setWifiQuality(3);
       setHasOutlets(null);
       setNoiseLevel("moderate");
+      setMeasurement(null);
       setComment("");
       setHasErgonomic(false);
       setOutletDensity("none");
@@ -80,194 +93,201 @@ export function VenueRatingDialog({
 
   if (!isOpen || !mounted) return null;
 
-  const dialogContent = (
-    <div className="fixed inset-0 z-[9999] flex items-center justify-center p-4 bg-black/50">
-      <div className="bg-white dark:bg-zinc-900 rounded-lg shadow-xl max-w-md w-full max-h-[90vh] overflow-y-auto">
-        {/* Header */}
-        <div className="flex items-center justify-between p-4 border-b border-zinc-200 dark:border-zinc-800">
-          <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">
-            Rate {venueName}
-          </h2>
+  return createPortal(
+    <div className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm">
+      <div className="max-h-[92vh] w-full max-w-xl overflow-y-auto rounded-2xl border border-zinc-200 bg-white shadow-2xl dark:border-zinc-700 dark:bg-zinc-900">
+        <div className="sticky top-0 z-10 flex items-center justify-between border-b border-zinc-200 bg-white/95 px-5 py-4 backdrop-blur dark:border-zinc-700 dark:bg-zinc-900/95">
+          <div>
+            <h2 className="text-xl font-semibold text-zinc-900 dark:text-white">
+              Rate {venueName}
+            </h2>
+            <p className="text-xs text-zinc-500">
+              Add subjective feedback and optional measured noise data.
+            </p>
+          </div>
+
           <button
+            type="button"
             onClick={onClose}
-            className="p-1 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg transition-colors"
+            className="rounded-lg p-2 text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-800"
           >
-            <X className="w-5 h-5 text-zinc-600 dark:text-zinc-400" />
+            <X className="h-5 w-5" />
           </button>
         </div>
 
-        {/* Form */}
-        <form onSubmit={handleSubmit} className="p-4 space-y-6">
-          {/* WiFi Quality */}
-          <div>
-            <label className="block text-sm font-medium text-zinc-900 dark:text-zinc-50 mb-2">
+        <form onSubmit={handleSubmit} className="space-y-6 p-5">
+          <section>
+            <label className="mb-2 block text-sm font-medium">
               WiFi Quality
             </label>
+
             <div className="flex items-center gap-2">
               {[1, 2, 3, 4, 5].map((rating) => (
                 <button
                   key={rating}
                   type="button"
                   onClick={() => setWifiQuality(rating)}
-                  className={`p-2 rounded-lg transition-colors ${
+                  className={`rounded-lg p-2 transition ${
                     rating <= wifiQuality
-                      ? "bg-blue-100 dark:bg-blue-900/20"
-                      : "bg-zinc-100 dark:bg-zinc-800"
+                      ? "bg-blue-100 text-blue-600 dark:bg-blue-900/30"
+                      : "bg-zinc-100 text-zinc-400 dark:bg-zinc-800"
                   }`}
                 >
-                  <Star
-                    className={`w-6 h-6 ${
-                      rating <= wifiQuality
-                        ? "text-blue-600 fill-current"
-                        : "text-zinc-400"
-                    }`}
-                  />
+                  <Star className="h-5 w-5 fill-current" />
                 </button>
               ))}
-              <span className="ml-2 text-sm text-zinc-600 dark:text-zinc-400">
+
+              <span className="ml-2 text-sm text-zinc-500">
                 {wifiQuality}/5
               </span>
             </div>
-          </div>
+          </section>
 
-          {/* Outlets */}
-          <div>
-            <label className="block text-sm font-medium text-zinc-900 dark:text-zinc-50 mb-2">
+          <section>
+            <label className="mb-2 block text-sm font-medium">
               Power Outlets Available?
             </label>
+
             <div className="flex gap-2">
               <button
                 type="button"
                 onClick={() => setHasOutlets(true)}
-                className={`flex-1 px-4 py-2 rounded-lg font-medium transition-colors ${
+                className={`flex-1 rounded-lg px-4 py-2 font-medium ${
                   hasOutlets === true
                     ? "bg-green-600 text-white"
-                    : "bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300"
+                    : "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
                 }`}
               >
                 Yes
               </button>
+
               <button
                 type="button"
                 onClick={() => setHasOutlets(false)}
-                className={`flex-1 px-4 py-2 rounded-lg font-medium transition-colors ${
+                className={`flex-1 rounded-lg px-4 py-2 font-medium ${
                   hasOutlets === false
                     ? "bg-red-600 text-white"
-                    : "bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300"
+                    : "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
                 }`}
               >
                 No
               </button>
             </div>
-          </div>
+          </section>
 
-          {/* Noise Level */}
-          <div>
-            <label className="block text-sm font-medium text-zinc-900 dark:text-zinc-50 mb-2">
-              Noise Level
+          <section>
+            <label className="mb-2 block text-sm font-medium">
+              Subjective Noise Level
             </label>
+
             <div className="grid grid-cols-3 gap-2">
               {(["quiet", "moderate", "loud"] as const).map((level) => (
                 <button
                   key={level}
                   type="button"
                   onClick={() => setNoiseLevel(level)}
-                  className={`px-4 py-2 rounded-lg font-medium capitalize transition-colors ${
+                  className={`rounded-lg px-4 py-2 font-medium capitalize ${
                     noiseLevel === level
                       ? level === "quiet"
                         ? "bg-green-600 text-white"
                         : level === "moderate"
-                        ? "bg-orange-600 text-white"
-                        : "bg-red-600 text-white"
-                      : "bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300"
+                          ? "bg-orange-600 text-white"
+                          : "bg-red-600 text-white"
+                      : "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
                   }`}
                 >
                   {level}
                 </button>
               ))}
             </div>
-          </div>
+          </section>
 
-          {/* Wi-Fi Speed (Mbps) */}
-          <div>
-            <label className="block text-sm font-medium text-zinc-900 dark:text-zinc-50 mb-2">
+          <NoiseMeter onMeasured={setMeasurement} />
+
+          <section>
+            <label className="mb-2 block text-sm font-medium">
               Verified Wi-Fi Speed (Mbps - Optional)
             </label>
+
             <input
               type="number"
               value={wifiSpeed}
-              onChange={(e) => setWifiSpeed(e.target.value)}
+              onChange={(event) => setWifiSpeed(event.target.value)}
               placeholder="e.g. 80"
-              className="w-full px-3 py-2 rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-50 placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 dark:border-zinc-700 dark:bg-zinc-800"
             />
-          </div>
+          </section>
 
-          {/* Power Outlet Density */}
-          <div>
-            <label className="block text-sm font-medium text-zinc-900 dark:text-zinc-50 mb-2">
+          <section>
+            <label className="mb-2 block text-sm font-medium">
               Power Outlet Density
             </label>
+
             <select
               value={outletDensity}
-              onChange={(e) => setOutletDensity(e.target.value as any)}
-              className="w-full px-3 py-2 rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              onChange={(event) =>
+                setOutletDensity(
+                  event.target.value as
+                    | "every_table"
+                    | "some_tables"
+                    | "wall_seats"
+                    | "none",
+                )
+              }
+              className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 dark:border-zinc-700 dark:bg-zinc-800"
             >
               <option value="none">None / No Outlets</option>
               <option value="every_table">Every Table</option>
               <option value="some_tables">Some Tables</option>
               <option value="wall_seats">Wall Seats Only</option>
             </select>
-          </div>
+          </section>
 
-          {/* Ergonomic Setup */}
-          <div className="flex items-center justify-between p-1">
-            <label className="text-sm font-medium text-zinc-900 dark:text-zinc-50">
-              Features Ergonomic Seating/Desks?
-            </label>
+          <label className="flex items-center gap-3 text-sm">
             <input
               type="checkbox"
               checked={hasErgonomic}
-              onChange={(e) => setHasErgonomic(e.target.checked)}
-              className="w-4 h-4 rounded border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-blue-600 focus:ring-blue-500"
+              onChange={(event) => setHasErgonomic(event.target.checked)}
+              className="h-4 w-4 rounded"
             />
-          </div>
+            Features Ergonomic Seating/Desks?
+          </label>
 
-          {/* Comment */}
-          <div>
-            <label className="block text-sm font-medium text-zinc-900 dark:text-zinc-50 mb-2">
+          <section>
+            <label className="mb-2 block text-sm font-medium">
               Comments (optional)
             </label>
+
             <textarea
               value={comment}
-              onChange={(e) => setComment(e.target.value)}
+              onChange={(event) => setComment(event.target.value)}
               placeholder="Share your experience..."
               rows={3}
-              className="w-full px-3 py-2 rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-50 placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 dark:border-zinc-700 dark:bg-zinc-800"
             />
-          </div>
+          </section>
 
-          {/* Submit */}
           <div className="flex gap-2">
             <button
               type="button"
               onClick={onClose}
               disabled={isSubmitting}
-              className="flex-1 px-4 py-2 rounded-lg font-medium text-zinc-700 dark:text-zinc-300 bg-zinc-100 dark:bg-zinc-800 hover:bg-zinc-200 dark:hover:bg-zinc-700 disabled:opacity-50 transition-colors"
+              className="flex-1 rounded-lg bg-zinc-100 px-4 py-2 font-medium text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
             >
               Cancel
             </button>
+
             <button
               type="submit"
               disabled={isSubmitting || hasOutlets === null}
-              className="flex-1 px-4 py-2 rounded-lg font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="flex-1 rounded-lg bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700 disabled:opacity-50"
             >
               {isSubmitting ? "Submitting..." : "Submit Rating"}
             </button>
           </div>
         </form>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
-
-  return createPortal(dialogContent, document.body);
 }

--- a/src/components/noise/NoiseMeter.tsx
+++ b/src/components/noise/NoiseMeter.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Mic, Square, Volume2 } from "lucide-react";
+
+export type NoiseMeasurement = {
+  averageDb: number;
+  peakDb: number;
+};
+
+type Props = {
+  onMeasured: (measurement: NoiseMeasurement) => void;
+};
+
+function rmsToApproxDb(rms: number) {
+  if (rms <= 0.00001) return 20;
+
+  const dbfs = 20 * Math.log10(rms);
+  return Math.max(20, Math.min(120, Math.round((dbfs + 100) * 10) / 10));
+}
+
+export function NoiseMeter({ onMeasured }: Props) {
+  const [status, setStatus] = useState<
+    "idle" | "requesting" | "measuring" | "done" | "error"
+  >("idle");
+  const [remaining, setRemaining] = useState(5);
+  const [liveDb, setLiveDb] = useState(0);
+  const [result, setResult] = useState<NoiseMeasurement | null>(null);
+  const cleanupRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    return () => cleanupRef.current?.();
+  }, []);
+
+  async function measure() {
+    setStatus("requesting");
+    setResult(null);
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          echoCancellation: false,
+          noiseSuppression: false,
+          autoGainControl: false,
+        },
+      });
+
+      const AudioContextClass =
+        window.AudioContext ||
+        (
+          window as typeof window & {
+            webkitAudioContext?: typeof AudioContext;
+          }
+        ).webkitAudioContext;
+
+      if (!AudioContextClass) {
+        throw new Error("Web Audio API is not supported in this browser.");
+      }
+
+      const audioContext = new AudioContextClass();
+      const source = audioContext.createMediaStreamSource(stream);
+      const analyser = audioContext.createAnalyser();
+
+      analyser.fftSize = 2048;
+      analyser.smoothingTimeConstant = 0.25;
+      source.connect(analyser);
+
+      const samples = new Float32Array(analyser.fftSize);
+      const values: number[] = [];
+      let animationFrame = 0;
+      let timer = 5;
+
+      const cleanup = () => {
+        cancelAnimationFrame(animationFrame);
+        stream.getTracks().forEach((track) => track.stop());
+        audioContext.close().catch(() => {});
+      };
+
+      cleanupRef.current = cleanup;
+      setStatus("measuring");
+      setRemaining(timer);
+
+      const tick = () => {
+        analyser.getFloatTimeDomainData(samples);
+
+        let sumSquares = 0;
+        for (let i = 0; i < samples.length; i += 1) {
+          sumSquares += samples[i] * samples[i];
+        }
+
+        const rms = Math.sqrt(sumSquares / samples.length);
+        const db = rmsToApproxDb(rms);
+
+        values.push(db);
+        setLiveDb(db);
+
+        animationFrame = requestAnimationFrame(tick);
+      };
+
+      tick();
+
+      const countdown = window.setInterval(() => {
+        timer -= 1;
+        setRemaining(Math.max(timer, 0));
+      }, 1000);
+
+      window.setTimeout(() => {
+        window.clearInterval(countdown);
+        cleanup();
+        cleanupRef.current = null;
+
+        const usable = values.filter((value) => Number.isFinite(value));
+
+        if (usable.length === 0) {
+          setStatus("error");
+          return;
+        }
+
+        const averageDb =
+          Math.round(
+            (usable.reduce((sum, value) => sum + value, 0) / usable.length) * 10,
+          ) / 10;
+
+        const peakDb = Math.round(Math.max(...usable) * 10) / 10;
+
+        const measurement = { averageDb, peakDb };
+
+        setResult(measurement);
+        setStatus("done");
+        onMeasured(measurement);
+      }, 5000);
+    } catch (error) {
+      console.error("Noise measurement failed:", error);
+      setStatus("error");
+    }
+  }
+
+  return (
+    <div className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800/60">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="font-medium text-zinc-900 dark:text-zinc-100">
+            Ambient Noise Measurement
+          </p>
+          <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+            Captures a 5-second local microphone sample. Raw audio is not uploaded.
+          </p>
+        </div>
+
+        <Volume2 className="h-5 w-5 text-blue-500" />
+      </div>
+
+      {status === "measuring" && (
+        <div className="mt-4">
+          <div className="flex items-end justify-between">
+            <span className="text-sm text-zinc-500">
+              Measuring… {remaining}s
+            </span>
+            <span className="text-3xl font-semibold text-zinc-900 dark:text-white">
+              {liveDb.toFixed(1)}
+              <span className="ml-1 text-sm font-normal text-zinc-500">dB</span>
+            </span>
+          </div>
+
+          <div className="mt-3 h-2 overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-700">
+            <div
+              className="h-full rounded-full bg-blue-500 transition-all"
+              style={{
+                width: `${Math.min(100, Math.max(5, ((liveDb - 20) / 100) * 100))}%`,
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      {result && (
+        <div className="mt-4 grid grid-cols-2 gap-3">
+          <div className="rounded-xl bg-white p-3 dark:bg-zinc-900">
+            <p className="text-xs text-zinc-500">Average</p>
+            <p className="mt-1 text-xl font-semibold">
+              {result.averageDb.toFixed(1)} dB
+            </p>
+          </div>
+
+          <div className="rounded-xl bg-white p-3 dark:bg-zinc-900">
+            <p className="text-xs text-zinc-500">Peak</p>
+            <p className="mt-1 text-xl font-semibold">
+              {result.peakDb.toFixed(1)} dB
+            </p>
+          </div>
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={measure}
+        disabled={status === "requesting" || status === "measuring"}
+        className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-blue-600 px-4 py-2.5 text-sm font-medium text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {status === "measuring" ? (
+          <>
+            <Square className="h-4 w-4" />
+            Measuring ambient sound
+          </>
+        ) : (
+          <>
+            <Mic className="h-4 w-4" />
+            {result ? "Measure again" : "Measure Noise"}
+          </>
+        )}
+      </button>
+
+      {status === "error" && (
+        <p className="mt-3 text-xs text-red-500">
+          Microphone access failed. Check browser permission and try again.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/noise/NoiseTimeChart.tsx
+++ b/src/components/noise/NoiseTimeChart.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Volume2 } from "lucide-react";
+
+type Bucket = {
+  label: string;
+  averageDb: number | null;
+  peakDb: number | null;
+  samples: number;
+};
+
+export function NoiseTimeChart({ venueId }: { venueId: string }) {
+  const [buckets, setBuckets] = useState<Bucket[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+
+    fetch(`/api/venues/${encodeURIComponent(venueId)}/noise-metrics`)
+      .then(async (response) => {
+        const payload = await response.json();
+
+        if (!response.ok) {
+          throw new Error(payload.error ?? "Unable to load noise metrics");
+        }
+
+        if (active) {
+          setBuckets(payload.buckets);
+        }
+      })
+      .catch((error) => console.error(error))
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [venueId]);
+
+  const values = buckets.filter((bucket) => bucket.averageDb !== null);
+  const maxDb = Math.max(...values.map((bucket) => bucket.peakDb ?? 0), 100);
+
+  return (
+    <section className="rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+      <div className="flex items-center gap-2">
+        <Volume2 className="h-5 w-5 text-blue-500" />
+        <div>
+          <h3 className="font-semibold text-zinc-900 dark:text-white">
+            Community Noise Pattern
+          </h3>
+          <p className="text-xs text-zinc-500">
+            Crowdsourced measured noise by time of day
+          </p>
+        </div>
+      </div>
+
+      {loading ? (
+        <p className="mt-5 text-sm text-zinc-500">Loading noise data…</p>
+      ) : values.length === 0 ? (
+        <p className="mt-5 text-sm text-zinc-500">
+          No measured noise samples yet. Be the first contributor.
+        </p>
+      ) : (
+        <div className="mt-5 space-y-4">
+          {buckets.map((bucket) => {
+            const width = bucket.averageDb
+              ? Math.max(8, Math.min(100, (bucket.averageDb / maxDb) * 100))
+              : 0;
+
+            return (
+              <div key={bucket.label}>
+                <div className="mb-1.5 flex items-center justify-between gap-3 text-sm">
+                  <span className="text-zinc-700 dark:text-zinc-300">
+                    {bucket.label}
+                  </span>
+
+                  <span className="text-xs text-zinc-500">
+                    {bucket.averageDb !== null
+                      ? `${bucket.averageDb.toFixed(1)} dB avg · ${bucket.samples} sample${bucket.samples === 1 ? "" : "s"}`
+                      : "No samples"}
+                  </span>
+                </div>
+
+                <div className="h-2 overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-800">
+                  <div
+                    className="h-full rounded-full bg-blue-500 transition-all"
+                    style={{ width: `${width}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -51,6 +51,8 @@ export const venueRatingSchema = z.object({
   hasErgonomic: z.boolean().optional().default(false),
   outletDensity: z.enum(["every_table", "some_tables", "wall_seats", "none"]).optional().default("none"),
   wifiSpeed: z.number().min(0).max(10000).optional().nullable(),
+  avgDecibels: z.number().min(20).max(130).optional().nullable(),
+  peakDecibels: z.number().min(20).max(140).optional().nullable(),
 });
 
 // Conversation schemas


### PR DESCRIPTION
## Description

This PR adds a client-side ambient noise analyzer and crowdsourced audio metrics to WorkSphere.

Users can now take a short 5-second microphone sample while rating a venue. The measurement is analyzed locally in the browser using the Web Audio API, and only the calculated average and peak noise values are stored.

### Features Added

- Added a 5-second ambient noise measurement flow.
- Added live approximate dB feedback during measurement.
- Added average and peak dB calculation.
- Added browser microphone permission/error handling.
- Added privacy-first local audio analysis:
  - no raw audio upload
  - no audio recording storage
  - no waveform persistence
- Extended `VenueRating` with:
  - `avgDecibels`
  - `peakDecibels`
- Added validation for submitted dB values.
- Extended the venue rating API to persist measured values.
- Added a venue noise metrics API.
- Added time-of-day aggregation:
  - Morning
  - Lunch hour
  - Afternoon
  - Evening
- Added a Community Noise Pattern chart for venue details.

## Related Issue

Fixes #41

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)
<img width="1344" height="983" alt="Screenshot 2026-07-11 130025" src="https://github.com/user-attachments/assets/66b90a40-9754-42a9-9d2c-1f75626f5984" />
<img width="1040" height="939" alt="Screenshot 2026-07-11 130054" src="https://github.com/user-attachments/assets/bb22ad5a-05fb-4d78-8dbd-001802ff710c" />
<img width="949" height="937" alt="Screenshot 2026-07-11 130128" src="https://github.com/user-attachments/assets/2facb95d-d1e3-4a1c-918a-3276f8d1532b" />


## Breaking Changes

- [ ] Yes
- [x] No
