### PR TITLE
bug: fix realtime event source freeze during inactive tab suspension

### DIFF
--- a/src/app/reserve/[venueId]/reservation-client.tsx
+++ b/src/app/reserve/[venueId]/reservation-client.tsx
@@ -100,19 +100,41 @@ export default function ReservationClient({ venue }: { venue: Venue }) {
   }, [date, time, duration]);
 
   useEffect(() => {
-    const events = new EventSource(
-      `/api/reservations/events?venueId=${encodeURIComponent(venue.id)}`,
-    );
+    let events: EventSource | null = null;
 
-    events.addEventListener("availability", () => {
-      loadAvailability();
-    });
+    const connect = () => {
+      if (events) {
+        events.close();
+      }
+      events = new EventSource(
+        `/api/reservations/events?venueId=${encodeURIComponent(venue.id)}`,
+      );
 
-    events.onerror = () => {
-      // EventSource reconnects automatically.
+      events.addEventListener("availability", () => {
+        loadAvailability();
+      });
+
+      events.onerror = () => {
+        // EventSource reconnects automatically.
+      };
     };
 
-    return () => events.close();
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        console.log("[Reservation] Tab visible, resetting connection");
+        connect();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    connect();
+
+    return () => {
+      if (events) {
+        events.close();
+      }
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
   }, [venue.id, loadAvailability]);
 
   const selected = useMemo(

--- a/src/components/chat/VenueDetailDialog.tsx
+++ b/src/components/chat/VenueDetailDialog.tsx
@@ -64,27 +64,47 @@ export function VenueDetailDialog({
     useEffect(() => {
         if (!isOpen || !venue) return;
 
-        console.log(`[SSE] Connecting to live stream for venue: ${venue.id}`);
-        const eventSource = new EventSource(`/api/venues/stream?id=${encodeURIComponent(venue.id)}`);
+        let eventSource: EventSource | null = null;
 
-        eventSource.onmessage = (event) => {
-            try {
-                const data = JSON.parse(event.data);
-                if (data && typeof data.score === 'number') {
-                    setLiveScore(data.score);
+        const connect = () => {
+            if (eventSource) {
+                eventSource.close();
+            }
+            console.log(`[SSE] Connecting to live stream for venue: ${venue.id}`);
+            eventSource = new EventSource(`/api/venues/stream?id=${encodeURIComponent(venue.id)}`);
+
+            eventSource.onmessage = (event) => {
+                try {
+                    const data = JSON.parse(event.data);
+                    if (data && typeof data.score === 'number') {
+                        setLiveScore(data.score);
+                    }
+                } catch (err) {
+                    console.error("Error parsing SSE data:", err);
                 }
-            } catch (err) {
-                console.error("Error parsing SSE data:", err);
+            };
+
+            eventSource.onerror = (error) => {
+                console.error("SSE Connection Error:", error);
+            };
+        };
+
+        const handleVisibilityChange = () => {
+            if (document.visibilityState === "visible") {
+                console.log(`[SSE] Tab visible, resetting connection for venue: ${venue.id}`);
+                connect();
             }
         };
 
-        eventSource.onerror = (error) => {
-            console.error("SSE Connection Error:", error);
-        };
+        document.addEventListener("visibilitychange", handleVisibilityChange);
+        connect();
 
         return () => {
             console.log(`[SSE] Terminating active stream for venue: ${venue.id}`);
-            eventSource.close();
+            if (eventSource) {
+                eventSource.close();
+            }
+            document.removeEventListener("visibilitychange", handleVisibilityChange);
         };
     }, [venue, isOpen]);
 

--- a/src/hooks/useRealTime.tsx
+++ b/src/hooks/useRealTime.tsx
@@ -110,8 +110,20 @@ export function useRealTimeUpdates(options: UseRealTimeUpdatesOptions = {}) {
       clearTimeout(reconnectTimeout);
     };
 
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        console.log("[RealTime] Tab became visible, resetting connection");
+        currentBackoff = 1000;
+        if (eventSource) {
+          eventSource.close();
+        }
+        connect();
+      }
+    };
+
     window.addEventListener("online", handleOnline);
     window.addEventListener("offline", handleOffline);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
 
     connect();
 
@@ -120,6 +132,7 @@ export function useRealTimeUpdates(options: UseRealTimeUpdatesOptions = {}) {
       clearTimeout(reconnectTimeout);
       window.removeEventListener("online", handleOnline);
       window.removeEventListener("offline", handleOffline);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, [venueIdsKey, enabled]);
 


### PR DESCRIPTION
## Description

This PR resolves Issue #154 by resetting Server-Sent Events (SSE) connections when a suspended browser tab returns to the foreground:
1. **useRealTime Updates Hook**: Resets connection and exponential backoff state on `visibilitychange` transitioning to `visible`.
2. **Reservation Client**: Refactors the availability SSE stream to re-initialize when tab focus returns.
3. **Venue Detail Dialog**: Forces live score SSE stream reconnection on tab reactivation.

## Related Issue

Fixes #154

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Breaking Changes

- [ ] Yes
- [x] No
