### PR TITLE
fix: add color-mix fallback for older Android WebView rendering

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -151,3 +151,43 @@ html {
 ::selection {
   background: rgba(59, 130, 246, 0.3);
 }
+
+/* ------------------------------------------------------------------
+   Fallback for older Android WebView engines that do not support the
+   CSS color-mix() function, which Tailwind v4 uses internally to
+   generate opacity-modifier utilities (e.g. bg-blue-700/10). Without
+   this fallback, unsupported color-mix() values fail and the affected
+   elements render as flat black instead of the intended translucent
+   neon gradient/border colors.
+
+   Scope: the "neon blur blob" backgrounds and glowing card borders
+   described in issue #153. Modern browsers are unaffected and keep
+   using Tailwind's normal color-mix()-based output, since this block
+   only applies inside @supports not (...).
+   ------------------------------------------------------------------ */
+@supports not (background: color-mix(in oklab, red, red)) {
+  /* Neon blur blobs - background/error/marketing pages */
+  .bg-blue-700\/10   { background-color: rgba(29, 78, 216, 0.1); }
+  .bg-blue-700\/20   { background-color: rgba(29, 78, 216, 0.2); }
+  .bg-purple-700\/10 { background-color: rgba(126, 34, 206, 0.1); }
+  .bg-purple-700\/15 { background-color: rgba(126, 34, 206, 0.15); }
+  .bg-red-700\/10    { background-color: rgba(185, 28, 28, 0.1); }
+  .bg-orange-700\/10 { background-color: rgba(194, 65, 12, 0.1); }
+  .bg-cyan-700\/10   { background-color: rgba(14, 116, 144, 0.1); }
+  .bg-violet-700\/15 { background-color: rgba(109, 40, 217, 0.15); }
+  .bg-violet-700\/20 { background-color: rgba(109, 40, 217, 0.2); }
+  .bg-amber-500\/10  { background-color: rgba(245, 158, 11, 0.1); }
+  .bg-amber-500\/20  { background-color: rgba(245, 158, 11, 0.2); }
+  .bg-red-500\/10    { background-color: rgba(239, 68, 68, 0.1); }
+  .bg-red-500\/20    { background-color: rgba(239, 68, 68, 0.2); }
+
+  /* Glowing card borders */
+  .border-amber-500\/30  { border-color: rgba(245, 158, 11, 0.3); }
+  .border-red-500\/30    { border-color: rgba(239, 68, 68, 0.3); }
+  .border-blue-500\/30   { border-color: rgba(59, 130, 246, 0.3); }
+  .border-purple-500\/30 { border-color: rgba(168, 85, 247, 0.3); }
+  .border-violet-400\/20 { border-color: rgba(167, 139, 250, 0.2); }
+  .border-emerald-400\/20 { border-color: rgba(52, 211, 153, 0.2); }
+}
+
+


### PR DESCRIPTION
## Description

Fixes #153. Older Android WebView engines don't support the CSS color-mix() function, which Tailwind v4 uses internally to compile opacity-modifier utilities (e.g. bg-blue-700/10). This caused the neon blur blob backgrounds and glowing card borders to render as flat black instead of their intended translucent colors.

Adds an @supports not (color-mix(...)) fallback block to globals.css providing explicit rgba() equivalents for the affected neon backgrounds and borders. Modern browsers are unaffected — they continue using Tailwind's normal color-mix()-based output; only browsers lacking color-mix() support fall back to the plain rgba() values.

Scope note: the codebase uses many more opacity-modifier utilities beyond what's covered here (60+ unique combinations across the app). This PR targets the specific neon blur blobs and card borders described in the bug report. A broader audit/fix for all opacity-modifier utilities may be worth a separate follow-up issue if needed.

## Related Issue


Fixes #153

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

Ran the app locally (npm run dev, Next.js 15.5.9) and verified the homepage, cards, and glowing borders render normally in a modern browser (Chrome) — confirming the @supports not (...) fallback correctly stays inactive and doesn't affect standard rendering. Could not directly test on an actual older Android WebView device; verification relies on the @supports feature-detection approach being browser-correct per spec.

## Breaking Changes

- [ ] Yes (please describe below)
- [ x] No
