### PR TITLE
bug: fix PDF generation errors on non-Latin unicode characters and em…

### DIFF
--- a/src/app/api/bookings/[bookingId]/download/route.ts
+++ b/src/app/api/bookings/[bookingId]/download/route.ts
@@ -27,6 +27,7 @@ export async function GET(
             },
             include: {
                 venue: true,
+                user: true,
             },
         });
 
@@ -43,47 +44,64 @@ export async function GET(
         const { width, height } = page.getSize();
         let yPosition = height - 50;
 
+        const customerName = booking.user ? `${booking.user.firstName || ""} ${booking.user.lastName || ""}`.trim() : "";
+
         // Helper to sanitize text
         const safeText = (text: string) => text ? text.replace(/[^\x00-\x7F]/g, "?") : "";
+
+        // Helper to draw text with absolute safety against encoding crashes
+        const drawSafeText = (text: string, options: any) => {
+            try {
+                page.drawText(text, options);
+            } catch (err) {
+                console.warn("[PDF drawText warning]: Failed to draw text, retrying with strict sanitization", err);
+                try {
+                    const strictText = text.replace(/[^\x20-\x7E]/g, "?");
+                    page.drawText(strictText, options);
+                } catch (fallbackErr) {
+                    console.error("[PDF drawText critical error]: Failed to draw text even with strict sanitization", fallbackErr);
+                }
+            }
+        };
 
         // Top blue bar
         page.drawRectangle({ x: 0, y: height - 10, width, height: 10, color: rgb(0.23, 0.51, 0.96) });
         yPosition -= 60;
 
         // Title
-        page.drawText("WORKSPHERE CONFIRMATION", { x: 150, y: yPosition, size: 24, font: boldFont, color: rgb(0, 0, 0) });
+        drawSafeText("WORKSPHERE CONFIRMATION", { x: 150, y: yPosition, size: 24, font: boldFont, color: rgb(0, 0, 0) });
         yPosition -= 15;
-        page.drawText("SECURE NEURAL TRANSACTION RECEIPT", { x: 180, y: yPosition, size: 8, font, color: rgb(0.5, 0.5, 0.5) });
+        drawSafeText("SECURE NEURAL TRANSACTION RECEIPT", { x: 180, y: yPosition, size: 8, font, color: rgb(0.5, 0.5, 0.5) });
         yPosition -= 50;
 
         // Booking Details
-        page.drawText("BOOKING DETAILS:", { x: 50, y: yPosition, size: 12, font: boldFont });
+        drawSafeText("BOOKING DETAILS:", { x: 50, y: yPosition, size: 12, font: boldFont });
         yPosition -= 15;
-        page.drawText("-".repeat(50), { x: 50, y: yPosition, size: 10, font });
+        drawSafeText("-".repeat(50), { x: 50, y: yPosition, size: 10, font });
         yPosition -= 20;
-        page.drawText(`REFERENCE ID: ${booking.confirmationId || `WS-#${booking.id}`}`, { x: 50, y: yPosition, size: 10, font });
+        drawSafeText(`REFERENCE ID: ${safeText(booking.confirmationId || `WS-#${booking.id}`)}`, { x: 50, y: yPosition, size: 10, font });
         yPosition -= 18;
-        page.drawText(`VENUE: ${safeText(booking.venue.name)}`, { x: 50, y: yPosition, size: 10, font });
+        drawSafeText(`VENUE: ${safeText(booking.venue.name)}`, { x: 50, y: yPosition, size: 10, font });
         yPosition -= 18;
-        page.drawText(`CATEGORY: ${safeText(booking.venue.category?.toUpperCase() || "WORKSPACE")}`, { x: 50, y: yPosition, size: 10, font });
+        drawSafeText(`CATEGORY: ${safeText(booking.venue.category?.toUpperCase() || "WORKSPACE")}`, { x: 50, y: yPosition, size: 10, font });
         yPosition -= 18;
-        page.drawText(`ADDRESS: ${safeText(booking.venue.address || "Verified Workspace")}`, { x: 50, y: yPosition, size: 10, font });
+        drawSafeText(`ADDRESS: ${safeText(booking.venue.address || "Verified Workspace")}`, { x: 50, y: yPosition, size: 10, font });
         yPosition -= 18;
-        page.drawText(`SCHEDULE: ${booking.date} @ ${booking.time}`, { x: 50, y: yPosition, size: 10, font });
+        drawSafeText(`SCHEDULE: ${safeText(booking.date)} @ ${safeText(booking.time)}`, { x: 50, y: yPosition, size: 10, font });
         yPosition -= 18;
-        page.drawText(`CUSTOMER: ${safeText(booking.customerEmail || "N/A")}`, { x: 50, y: yPosition, size: 10, font });
+        drawSafeText(`CUSTOMER: ${safeText(customerName || booking.customerEmail || "N/A")}`, { x: 50, y: yPosition, size: 10, font });
         yPosition -= 40;
 
         // Security Protocol
-        page.drawText("SECURITY PROTOCOL:", { x: 50, y: yPosition, size: 12, font: boldFont });
+        drawSafeText("SECURITY PROTOCOL:", { x: 50, y: yPosition, size: 12, font: boldFont });
         yPosition -= 18;
-        page.drawText("ZERO-FEE ACCESS PROTOCOL ACTIVE", { x: 50, y: yPosition, size: 10, font });
+        drawSafeText("ZERO-FEE ACCESS PROTOCOL ACTIVE", { x: 50, y: yPosition, size: 10, font });
         yPosition -= 18;
-        page.drawText("ENCRYPTED VIA WORKSPHERE L3", { x: 50, y: yPosition, size: 10, font });
+        drawSafeText("ENCRYPTED VIA WORKSPHERE L3", { x: 50, y: yPosition, size: 10, font });
         yPosition -= 80;
 
         // Footer
-        page.drawText("Thank you for choosing WorkSphere. Your workspace is ready for you.", { x: 100, y: yPosition, size: 8, font, color: rgb(0.4, 0.4, 0.4) });
+        drawSafeText("Thank you for choosing WorkSphere. Your workspace is ready for you.", { x: 100, y: yPosition, size: 8, font, color: rgb(0.4, 0.4, 0.4) });
 
         const pdfBytes = await pdfDoc.save();
 

--- a/src/app/api/bookings/confirm/route.ts
+++ b/src/app/api/bookings/confirm/route.ts
@@ -19,7 +19,7 @@ export async function POST(req: Request) {
         }
 
         // 0. Ensure Identity 💎
-        await ensureUserExists(userId);
+        const dbUser = await ensureUserExists(userId);
 
         const { venue, date, time, customerEmail, customerPhone } = await req.json();
 
@@ -73,45 +73,64 @@ export async function POST(req: Request) {
         const { width, height } = page.getSize();
         let yPosition = height - 50;
 
+        const customerName = dbUser ? `${dbUser.firstName || ""} ${dbUser.lastName || ""}`.trim() : "";
+
         // Helper to sanitize text
         const safeText = (text: string) => text ? text.replace(/[^\x00-\x7F]/g, "?") : "";
+
+        // Helper to draw text with absolute safety against encoding crashes
+        const drawSafeText = (text: string, options: any) => {
+            try {
+                page.drawText(text, options);
+            } catch (err) {
+                console.warn("[PDF drawText warning]: Failed to draw text, retrying with strict sanitization", err);
+                try {
+                    const strictText = text.replace(/[^\x20-\x7E]/g, "?");
+                    page.drawText(strictText, options);
+                } catch (fallbackErr) {
+                    console.error("[PDF drawText critical error]: Failed to draw text even with strict sanitization", fallbackErr);
+                }
+            }
+        };
 
         // Top blue bar
         page.drawRectangle({ x: 0, y: height - 10, width, height: 10, color: rgb(0.23, 0.51, 0.96) });
         yPosition -= 60;
 
         // Title
-        page.drawText("WORKSPHERE CONFIRMATION", { x: 150, y: yPosition, size: 24, font: boldFont, color: rgb(0, 0, 0) });
+        drawSafeText("WORKSPHERE CONFIRMATION", { x: 150, y: yPosition, size: 24, font: boldFont, color: rgb(0, 0, 0) });
         yPosition -= 15;
-        page.drawText("SECURE NEURAL TRANSACTION RECEIPT", { x: 180, y: yPosition, size: 8, font, color: rgb(0.5, 0.5, 0.5) });
+        drawSafeText("SECURE NEURAL TRANSACTION RECEIPT", { x: 180, y: yPosition, size: 8, font, color: rgb(0.5, 0.5, 0.5) });
         yPosition -= 50;
 
         // Booking Details
-        page.drawText("BOOKING DETAILS:", { x: 50, y: yPosition, size: 12, font: boldFont });
+        drawSafeText("BOOKING DETAILS:", { x: 50, y: yPosition, size: 12, font: boldFont });
         yPosition -= 15;
-        page.drawText("-".repeat(50), { x: 50, y: yPosition, size: 10, font });
+        drawSafeText("-".repeat(50), { x: 50, y: yPosition, size: 10, font });
         yPosition -= 20;
-        page.drawText(`REFERENCE ID: ${confirmationId}`, { x: 50, y: yPosition, size: 10, font });
+        drawSafeText(`REFERENCE ID: ${safeText(confirmationId)}`, { x: 50, y: yPosition, size: 10, font });
         yPosition -= 18;
-        page.drawText(`VENUE: ${safeText(venue.name)}`, { x: 50, y: yPosition, size: 10, font });
+        drawSafeText(`VENUE: ${safeText(venue.name)}`, { x: 50, y: yPosition, size: 10, font });
         yPosition -= 18;
-        page.drawText(`CATEGORY: ${safeText(venue.category?.toUpperCase() || "WORKSPACE")}`, { x: 50, y: yPosition, size: 10, font });
+        drawSafeText(`CATEGORY: ${safeText(venue.category?.toUpperCase() || "WORKSPACE")}`, { x: 50, y: yPosition, size: 10, font });
         yPosition -= 18;
-        page.drawText(`ADDRESS: ${safeText(venue.address || "Verified Workspace")}`, { x: 50, y: yPosition, size: 10, font });
+        drawSafeText(`ADDRESS: ${safeText(venue.address || "Verified Workspace")}`, { x: 50, y: yPosition, size: 10, font });
         yPosition -= 18;
-        page.drawText(`SCHEDULE: ${date} @ ${time}`, { x: 50, y: yPosition, size: 10, font });
+        drawSafeText(`SCHEDULE: ${safeText(date)} @ ${safeText(time)}`, { x: 50, y: yPosition, size: 10, font });
+        yPosition -= 18;
+        drawSafeText(`CUSTOMER: ${safeText(customerName || customerEmail || "N/A")}`, { x: 50, y: yPosition, size: 10, font });
         yPosition -= 40;
 
         // Security Protocol
-        page.drawText("SECURITY PROTOCOL:", { x: 50, y: yPosition, size: 12, font: boldFont });
+        drawSafeText("SECURITY PROTOCOL:", { x: 50, y: yPosition, size: 12, font: boldFont });
         yPosition -= 18;
-        page.drawText("ZERO-FEE ACCESS PROTOCOL ACTIVE", { x: 50, y: yPosition, size: 10, font });
+        drawSafeText("ZERO-FEE ACCESS PROTOCOL ACTIVE", { x: 50, y: yPosition, size: 10, font });
         yPosition -= 18;
-        page.drawText("ENCRYPTED VIA WORKSPHERE L3", { x: 50, y: yPosition, size: 10, font });
+        drawSafeText("ENCRYPTED VIA WORKSPHERE L3", { x: 50, y: yPosition, size: 10, font });
         yPosition -= 80;
 
         // Footer
-        page.drawText("Thank you for choosing WorkSphere. Your workspace is ready for you.", { x: 100, y: yPosition, size: 8, font, color: rgb(0.4, 0.4, 0.4) });
+        drawSafeText("Thank you for choosing WorkSphere. Your workspace is ready for you.", { x: 100, y: yPosition, size: 8, font, color: rgb(0.4, 0.4, 0.4) });
 
         const pdfBuffer = Buffer.from(await pdfDoc.save());
 


### PR DESCRIPTION
## Description

This PR resolves Issue #149 by introducing safe font rendering and character sanitization wrappers in the PDF receipt compiler:
1. **drawSafeText Helper**: A defensive `try/catch` wrapper in `confirm/route.ts` and `download/route.ts` that catches any font-encoding errors inside `pdf-lib` (e.g. Cyrillic, Arabic, Kanji, emojis) and automatically sanitizes the string to printable ASCII characters to prevent crashes.
2. **Customer Name Inclusion**: Queries the database `User` schema in both routes to resolve and safely draw the customer's name on the receipt.
3. **Strict Parameter Sanitization**: Runs all drawn text parameters (Reference ID, Venue Name, Category, Address, Schedule, Customer Name) through standard ASCII sanitization.

## Related Issue

Fixes #149

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Breaking Changes

- [ ] Yes
- [x] No
