### PR TITLE
fix: add linear-gradient fallback for mobile chrome #103

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,9 @@ To keep the repository clean and manageable, please follow this flow:
 
 1. **Fork** the repository and clone it locally.
 2. **Create a branch** using a descriptive naming convention:
-   - `feature/your-feature-name` for new features.
-   - `bugfix/issue-description` for bug fixes.
-   - `docs/topic-name` for documentation updates.
+   - `feature/your-feature-name` for new features.
+   - `bugfix/issue-description` for bug fixes.
+   - `docs/topic-name` for documentation updates.
 3. **Write code** and ensure all [testing](#3-testing-conventions-jest--rtl) and [pre-commit checks](#5-pre-commit-quality-verification-checklist) pass.
 4. **Commit** your changes with clear, structured commit messages (e.g., `feat: add map route coordinates validation`).
 5. **Push** to your fork and open a **Pull Request (PR)** against the `main` branch.
@@ -54,9 +54,9 @@ All unit and integration tests for React components, hooks, utility functions, a
 ### Directory Structure
 ```
 src/__tests__/
-├── api/             # API route handler tests
-├── components/      # React UI component tests
-└── lib/             # Utility and library helper tests
+├── api/             # API route handler tests
+├── components/      # React UI component tests
+└── lib/             # Utility and library helper tests
 ```
 
 ### File Naming Convention
@@ -66,13 +66,13 @@ Test files must reside inside `src/__tests__/` and be named matching their targe
 
 ### Running Jest Tests
 - **Run all unit/integration tests**:
-  ```bash
-  npm test
-  ```
+  ```bash
+  npm test
+  ```
 - **Run tests in watch mode** (useful during active development):
-  ```bash
-  npm run test:watch
-  ```
+  ```bash
+  npm run test:watch
+  ```
 
 ### Mocking Dependencies & External APIs
 When writing tests for pages or components that interact with external services (like Clerk authentication, Leaflet maps, Groq AI SDK, or databases), you must mock these dependencies to keep unit tests isolated and fast.
@@ -81,16 +81,16 @@ When writing tests for pages or components that interact with external services 
 For components or pages requiring user auth or sessions, mock the `useUser` hook at the top of your test file:
 ```typescript
 jest.mock('@clerk/nextjs', () => ({
-  useUser: () => ({
-    isLoaded: true,
-    isSignedIn: true,
-    user: {
-      id: 'test-user-id',
-      fullName: 'John Doe',
-      primaryEmailAddress: { emailAddress: 'john.doe@example.com' },
-      imageUrl: 'https://example.com/avatar.jpg',
-    },
-  }),
+  useUser: () => ({
+    isLoaded: true,
+    isSignedIn: true,
+    user: {
+      id: 'test-user-id',
+      fullName: 'John Doe',
+      primaryEmailAddress: { emailAddress: 'john.doe@example.com' },
+      imageUrl: 'https://example.com/avatar.jpg',
+    },
+  }),
 }));
 ```
 
@@ -102,44 +102,44 @@ const mockSetView = jest.fn();
 const mockFlyTo = jest.fn();
 
 jest.mock('react-leaflet', () => ({
-  MapContainer: ({ children, center, zoom, style }: any) => (
-    <div data-testid="map-container" data-center={JSON.stringify(center)} data-zoom={zoom} style={style}>
-      {children}
-    </div>
-  ),
-  TileLayer: ({ url, attribution }: any) => (
-    <div data-testid="tile-layer" data-url={url} data-attribution={attribution} />
-  ),
-  Marker: ({ children, position, icon }: any) => (
-    <div data-testid="marker" data-position={JSON.stringify(position)} data-icon={icon?.options?.className}>
-      {children}
-    </div>
-  ),
-  Popup: ({ children }: any) => <div data-testid="popup">{children}</div>,
-  Polyline: ({ children, positions, pathOptions }: any) => (
-    <div data-testid="polyline" data-positions={JSON.stringify(positions)} data-color={pathOptions?.color}>
-      {children}
-    </div>
-  ),
-  useMap: () => ({
-    setView: mockSetView,
-    flyTo: mockFlyTo,
-  }),
+  MapContainer: ({ children, center, zoom, style }: any) => (
+    <div data-testid="map-container" data-center={JSON.stringify(center)} data-zoom={zoom} style={style}>
+      {children}
+    </div>
+  ),
+  TileLayer: ({ url, attribution }: any) => (
+    <div data-testid="tile-layer" data-url={url} data-attribution={attribution} />
+  ),
+  Marker: ({ children, position, icon }: any) => (
+    <div data-testid="marker" data-position={JSON.stringify(position)} data-icon={icon?.options?.className}>
+      {children}
+    </div>
+  ),
+  Popup: ({ children }: any) => <div data-testid="popup">{children}</div>,
+  Polyline: ({ children, positions, pathOptions }: any) => (
+    <div data-testid="polyline" data-positions={JSON.stringify(positions)} data-color={pathOptions?.color}>
+      {children}
+    </div>
+  ),
+  useMap: () => ({
+    setView: mockSetView,
+    flyTo: mockFlyTo,
+  }),
 }));
 
 // Mock the underlying leaflet library
 jest.mock('leaflet', () => ({
-  icon: jest.fn(() => ({ options: { className: 'default-icon' } })),
-  divIcon: jest.fn((options) => ({ options })),
-  latLngBounds: jest.fn(() => ({
-    extend: jest.fn(),
-  })),
-  Icon: {
-    Default: {
-      prototype: {},
-      mergeOptions: jest.fn(),
-    },
-  },
+  icon: jest.fn(() => ({ options: { className: 'default-icon' } })),
+  divIcon: jest.fn((options) => ({ options })),
+  latLngBounds: jest.fn(() => ({
+    extend: jest.fn(),
+  })),
+  Icon: {
+    Default: {
+      prototype: {},
+      mergeOptions: jest.fn(),
+    },
+  },
 }));
 ```
 
@@ -154,13 +154,13 @@ End-to-end tests simulate actual user interactions inside the browser. These tes
 
 ### Running Playwright Tests
 - **Run all E2E tests in headless mode** (runs behind the scenes):
-  ```bash
-  npm run test:e2e
-  ```
+  ```bash
+  npm run test:e2e
+  ```
 - **Run E2E tests with Playwright UI** (highly recommended for debugging):
-  ```bash
-  npm run test:e2e:ui
-  ```
+  ```bash
+  npm run test:e2e:ui
+  ```
 
 ### Dev Server Integration
 Our E2E suite is configured to automatically launch the Next.js dev server (`npm run dev`) on `http://localhost:3000` before running tests. It handles server cleanup once tests complete.
@@ -168,9 +168,9 @@ Our E2E suite is configured to automatically launch the Next.js dev server (`npm
 ### Configuring Headless/Headed Modes manually
 By default, Playwright runs tests in headless mode (no browser window opens). 
 - To run tests in **headed mode** via command line, pass the `--headed` flag:
-  ```bash
-  npx playwright test --headed
-  ```
+  ```bash
+  npx playwright test --headed
+  ```
 - To customize browser options or add multiple browsers (e.g., Firefox, WebKit), edit the `projects` section inside [playwright.config.ts](file:///C:/Users/Rajasekar/.gemini/antigravity/scratch/WorkSphere/playwright.config.ts).
 
 ---
@@ -190,3 +190,4 @@ Before pushing changes to GitHub, you **MUST** verify that all the checks below 
 
 ### 2. Vercel Build Verification
 Vercel builds use `npm run build` which runs `prisma generate && next build`. If this step fails locally, it **will** fail on Vercel deployment. Make sure you run `npm run build` successfully before submitting your PR!
+ 

--- a/src/app/ai/page.tsx
+++ b/src/app/ai/page.tsx
@@ -378,7 +378,10 @@ function AppPage() {
 
   if (!location || isLoadingLocation) {
     return (
-      <div className="flex items-center justify-center h-screen bg-gradient-to-br from-zinc-50 via-blue-50/30 to-zinc-50 dark:from-black dark:via-blue-950/10 dark:to-black">
+      <div 
+        className="flex items-center justify-center h-screen bg-gradient-to-br from-zinc-50 via-blue-50/30 to-zinc-50 dark:from-black dark:via-blue-950/10 dark:to-black"
+        style={{ backgroundImage: "linear-gradient(135deg, #fafafa 0%, rgba(219, 234, 254, 0.3) 50%, #fafafa 100%)" }}
+      >
         <div className="text-center p-8 max-w-md">
           <div className="relative mx-auto mb-6 w-20 h-20">
             <div className="w-20 h-20 rounded-full bg-gradient-to-br from-blue-500 to-purple-600 animate-pulse flex items-center justify-center">


### PR DESCRIPTION
## Description

Added a standard CSS inline style fallback for the background in `src/app/ai/page.tsx` to prevent the Tailwind 4.0 opacity bug from turning the loading screen black on mobile Chrome.

## Related Issue

Fixes #103

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules