### PR TITLE
fix: use network-first caching for /api/venues

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -36,11 +36,33 @@ self.addEventListener("fetch", (event) => {
     return;
   }
 
+  const isVenuesApi = event.request.url.includes("/api/venues");
   const isExternalAsset =
     event.request.url.includes("tile.openstreetmap.org") ||
     event.request.url.includes("images.unsplash.com");
 
-  if (isExternalAsset) {
+  if (isVenuesApi) {
+    // Network-First strategy for /api/venues
+    event.respondWith(
+      fetch(event.request)
+        .then((response) => {
+          if (response.ok) {
+            const responseClone = response.clone();
+            event.waitUntil(
+              caches.open(CACHE_NAME).then((cache) => {
+                return cache.put(event.request, responseClone);
+              })
+            );
+          }
+          return response;
+        })
+        .catch(async () => {
+          const cachedResponse = await caches.match(event.request);
+          if (cachedResponse) return cachedResponse;
+          return new Response("Offline", { status: 503 });
+        }),
+    );
+  } else if (isExternalAsset) {
     event.respondWith(
       caches.open(CACHE_NAME).then((cache) => {
         return cache.match(event.request).then((cachedResponse) => {
@@ -285,3 +307,4 @@ self.addEventListener("notificationclick", (event) => {
       }),
   );
 });
+


### PR DESCRIPTION
## Description

This PR fixes the caching strategy for `/api/venues` in the service worker.

Previously, requests to `/api/venues` used a cache-first strategy, which could cause newly added venues to remain stale until the service worker cache was cleared.

### Changes
- Switched `/api/venues` requests to a network-first caching strategy.
- Updates the cache after successful network responses.
- Falls back to the cached response when the network is unavailable.
- Leaves all other service worker caching strategies unchanged.

## Related Issue

Fixes #47 