### PR TITLE
fix: add maxRetries and timeout to Groq client to prevent infinite lo…

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -14,6 +14,12 @@ function getGroqClient(): Groq {
   if (!groq) {
     groq = new Groq({
       apiKey: process.env.GROQ_API_KEY || '',
+      // Explicit bounds so sustained rate-limit exhaustion (HTTP 429)
+      // fails fast with a catchable error instead of the SDK's default
+      // internal retry behavior hanging the request indefinitely,
+      // which was surfacing as an infinite loading state on the client.
+      maxRetries: 2,
+      timeout: 20000, // 20s
     });
   }
   return groq;


### PR DESCRIPTION
…ader on rate-limit exhaustion

## Description

Fixes #146. The Groq client was initialized with no maxRetries or timeout configuration, relying on the SDK's internal defaults. Under sustained rate-limit exhaustion (HTTP 429), the SDK's automatic internal retry behavior could cause the request to hang far longer than expected instead of failing with a catchable error — which surfaced as an infinite loading state on the frontend, since the outer try/catch never got a chance to run and return a proper error response.

Adds explicit maxRetries: 2 and timeout: 20000 (20s) to the Groq client constructor in getGroqClient(), so a sustained rate-limit situation fails fast and predictably, allowing the existing error handling and loading-state cleanup (setIsLoading(false) in EnhancedChatbot.tsx) to run as intended.

## Related Issue


Fixes #146

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

N/A — backend configuration change, no UI changes. Tested locally (npm run dev) that normal chat requests still work correctly with the new client config. Could not directly simulate sustained Groq rate-limit exhaustion locally to observe the exact before/after behavior; the fix is based on tracing the code path (getGroqClient() → responseStream → ReadableStream) and identifying the missing bounds on the SDK's retry/timeout behavior.

## Breaking Changes

- [ ] Yes (please describe below)
- [ x] No
