### PR TITLE
fix: resolve upstream main merge bracket errors and test case selectors (#187)

### DIFF
--- a/src/__tests__/components/VenueCard.test.tsx
+++ b/src/__tests__/components/VenueCard.test.tsx
@@ -61,7 +61,7 @@ describe('VenueCard', () => {
       />
     );
 
-    expect(screen.getByText(/WiFi/)).toBeInTheDocument();
+    expect(screen.getAllByText(/WiFi/)[0]).toBeInTheDocument();
   });
 
   it('shows Outlets indicator when venue has outlets', () => {
@@ -74,7 +74,7 @@ describe('VenueCard', () => {
       />
     );
 
-    expect(screen.getByText(/Outlets/)).toBeInTheDocument();
+    expect(screen.getAllByText(/Outlets/)[0]).toBeInTheDocument();
   });
 
   it('calls onGetDirections when Directions button is clicked', () => {

--- a/src/app/sessions/[slug]/session-detail-client.tsx
+++ b/src/app/sessions/[slug]/session-detail-client.tsx
@@ -172,6 +172,7 @@ export default function SessionDetailClient({ session }: Props) {
                   return (
                     <div key={item.user.id} className="flex items-center gap-3">
                       {item.user.imageUrl ? (
+                        /* eslint-disable-next-line @next/next/no-img-element */
                         <img 
                           src={item.user.imageUrl} 
                           alt={name} 

--- a/src/components/chat/VenueDetailDialog.tsx
+++ b/src/components/chat/VenueDetailDialog.tsx
@@ -46,6 +46,14 @@ export function VenueDetailDialog({
         outlets: { confidenceScore: 100, upvotes: 6, downvotes: 0 },
     });
 
+    // Tab and dynamic content states
+    const [activeTab, setActiveTab] = useState<"overview" | "reviews" | "menu">("overview");
+    const [reviews, setReviews] = useState<any[]>([]);
+    const [menuPhotos, setMenuPhotos] = useState<string[]>([]);
+    const [uploadingMenu, setUploadingMenu] = useState(false);
+    const [previewPhoto, setPreviewPhoto] = useState<string | null>(null);
+    const [wifiPredictions, setWifiPredictions] = useState<any[]>([]);
+
     const _submitAmenityVote = async (amenityKey: "wifi" | "outlets", isUpvote: boolean) => {
         if (!venue) return;
         try {
@@ -85,6 +93,8 @@ export function VenueDetailDialog({
         });
     }, [venue]);
 
+    useEffect(() => {
+        if (!venue) return;
         setLiveScore(venue.score ?? null);
         setPhotoLoading(true);
         setActiveTab("overview");
@@ -309,6 +319,7 @@ export function VenueDetailDialog({
                     {photoLoading ? (
                         <div className="w-full h-full bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
                     ) : (
+                        /* eslint-disable-next-line @next/next/no-img-element */
                         <img
                             src={displayPhoto}
                             alt={venue.name}
@@ -501,7 +512,7 @@ export function VenueDetailDialog({
                                     <p className="text-[10px] text-zinc-400 mt-1">Be the first to share your workspace rating.</p>
                                 </div>
                             ) : (
-                                reviews.map((review, idx) => (
+                                reviews.map((review: any, idx: number) => (
                                     <div key={idx} className="p-4 border border-zinc-100 dark:border-zinc-800 bg-zinc-50/50 dark:bg-zinc-800/20 rounded-2xl space-y-3">
                                         <div className="flex justify-between items-start">
                                             <div>
@@ -564,7 +575,7 @@ export function VenueDetailDialog({
                                 <p className="text-[10px] font-bold text-zinc-400 uppercase tracking-widest py-8 rounded-2xl border-2 border-dashed border-zinc-100 dark:border-zinc-800 text-center animate-pulse">No menu photos added yet</p>
                             ) : (
                                 <div className="grid grid-cols-2 gap-4">
-                                    {menuPhotos.map((photo, i) => (
+                                    {menuPhotos.map((photo: string, i: number) => (
                                         <div key={i} className="relative h-32 rounded-xl overflow-hidden border border-zinc-100 dark:border-zinc-800 group/item cursor-pointer" onClick={() => setPreviewPhoto(photo)}>
                                             {/* eslint-disable-next-line @next/next/no-img-element */}
                                             <img src={photo} alt={`Menu ${i+1}`} className="w-full h-full object-cover transition-transform group-hover/item:scale-105 duration-300" />


### PR DESCRIPTION
## Description
This PR resolves the build and test compilation failures introduced after merging upstream/main.

### Closes
Closes #187

### Key Changes:
1. **VenueDetailDialog.tsx Syntax Fix**:
   - Restored the missing `useEffect` block starter (accidentally removed during web conflict resolution).
   - Restored missing `activeTab`, `reviews`, `menuPhotos`, `uploadingMenu`, `previewPhoto`, and `wifiPredictions` state hooks.
   - Added type definitions (`any`, `number`, `string`) for inner map callbacks to avoid implicit-any compilation warnings.
   
2. **Test Suite Fixes (`VenueCard.test.tsx`)**:
   - Fixed query selector crash from `getByText(/WiFi/)` and `getByText(/Outlets/)` due to duplicate text matches inside `VenueCard`. Updated queries to utilize `getAllByText`.

3. **Lint image element bypass**:
   - Addressed Next.js image element warnings in `session-detail-client.tsx` and `VenueDetailDialog.tsx` by using standard javascript block comment bypass triggers inside JSX expressions.