### PR TITLE
[Feature]: add calendar export options for hot desk bookings

### DIFF
--- a/src/app/reserve/[venueId]/reservation-client.tsx
+++ b/src/app/reserve/[venueId]/reservation-client.tsx
@@ -10,7 +10,11 @@ import {
   Sparkles,
   UsersRound,
   Zap,
+  CalendarPlus,
+  Mail,
+  Download,
 } from "lucide-react";
+import { getCalendarUrls, downloadICS } from "@/lib/calendar";
 
 type Seat = {
   id: string;
@@ -52,6 +56,7 @@ export default function ReservationClient({ venue }: { venue: Venue }) {
   const [loading, setLoading] = useState(true);
   const [booking, setBooking] = useState(false);
   const [message, setMessage] = useState("");
+  const [confirmationId, setConfirmationId] = useState<string | null>(null);
 
   const loadAvailability = useCallback(async () => {
     setLoading(true);
@@ -150,6 +155,7 @@ export default function ReservationClient({ venue }: { venue: Venue }) {
 
     setBooking(true);
     setMessage("");
+    setConfirmationId(null);
 
     const response = await fetch("/api/reservations/book", {
       method: "POST",
@@ -176,6 +182,7 @@ export default function ReservationClient({ venue }: { venue: Venue }) {
     setMessage(
       `${selected.seatNumber} confirmed. Reference: ${payload.confirmationId}`,
     );
+    setConfirmationId(payload.confirmationId);
     setSelectedSeat(null);
     setBooking(false);
     await loadAvailability();
@@ -200,8 +207,34 @@ export default function ReservationClient({ venue }: { venue: Venue }) {
         </header>
 
         {message && (
-          <div className="mb-6 rounded-2xl border border-violet-400/20 bg-violet-400/10 px-4 py-3 text-sm text-violet-100">
-            {message}
+          <div className="mb-6 rounded-2xl border border-violet-400/20 bg-violet-400/10 p-5 text-sm text-violet-100">
+            <p className="font-semibold">{message}</p>
+            {confirmationId && (
+              <div className="mt-4 flex flex-wrap items-center gap-3">
+                <a
+                  href={getCalendarUrls(venue.name, venue.address || "", date, time).googleUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-2 rounded-xl bg-violet-600/20 border border-violet-500/30 px-4 py-2 hover:bg-violet-600/40 transition-colors"
+                >
+                  <CalendarPlus className="h-4 w-4" /> Add to Google
+                </a>
+                <a
+                  href={getCalendarUrls(venue.name, venue.address || "", date, time).outlookUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-2 rounded-xl bg-violet-600/20 border border-violet-500/30 px-4 py-2 hover:bg-violet-600/40 transition-colors"
+                >
+                  <Mail className="h-4 w-4" /> Add to Outlook
+                </a>
+                <button
+                  onClick={() => downloadICS(venue.name, venue.address || "", date, time)}
+                  className="flex items-center gap-2 rounded-xl bg-white/5 border border-white/10 px-4 py-2 hover:bg-white/10 transition-colors text-zinc-300"
+                >
+                  <Download className="h-4 w-4" /> Download .ics
+                </button>
+              </div>
+            )}
           </div>
         )}
 

--- a/src/components/chat/BookingModal.tsx
+++ b/src/components/chat/BookingModal.tsx
@@ -10,48 +10,7 @@ import { useState, useEffect } from "react";
 import { Venue } from "./ChatMessages";
 import { trackEvent } from "@/lib/analytics";
 
-const formatDateTimeForCalendar = (dateStr: string, timeStr: string) => {
-    if (!dateStr || !timeStr) return { start: "", end: "" };
-    const start = new Date(`${dateStr}T${timeStr}`);
-    if (isNaN(start.getTime())) return { start: "", end: "" };
-    const end = new Date(start.getTime() + 60 * 60 * 1000);
-    
-    const format = (d: Date) => d.toISOString().replace(/-|:|\.\d\d\d/g, "");
-    
-    return {
-        start: format(start),
-        end: format(end)
-    };
-};
-
-const getCalendarUrls = (venueName: string, venueAddress: string, dateStr: string, timeStr: string) => {
-    const { start, end } = formatDateTimeForCalendar(dateStr, timeStr);
-    const title = encodeURIComponent(`Booking at ${venueName}`);
-    const details = encodeURIComponent(`Hot desk booking at ${venueName}`);
-    const location = encodeURIComponent(venueAddress);
-
-    const googleUrl = `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${title}&dates=${start}/${end}&details=${details}&location=${location}`;
-    const outlookUrl = `https://outlook.live.com/calendar/0/deeplink/compose?path=/calendar/action/compose&rru=addevent&subject=${title}&startdt=${start}&enddt=${end}&body=${details}&location=${location}`;
-    
-    return { googleUrl, outlookUrl, start, end };
-};
-
-const downloadICS = (venueName: string, venueAddress: string, dateStr: string, timeStr: string) => {
-    const { start, end } = formatDateTimeForCalendar(dateStr, timeStr);
-    if (!start) return;
-    const title = `Booking at ${venueName}`;
-    const description = `Hot desk booking at ${venueName}`;
-    
-    const icsContent = `BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nDTSTART:${start}\nDTEND:${end}\nSUMMARY:${title}\nDESCRIPTION:${description}\nLOCATION:${venueAddress}\nEND:VEVENT\nEND:VCALENDAR`;
-
-    const blob = new Blob([icsContent], { type: 'text/calendar;charset=utf-8' });
-    const link = document.createElement('a');
-    link.href = URL.createObjectURL(blob);
-    link.download = `booking-${venueName.replace(/\\s+/g, '-').toLowerCase()}.ics`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-};
+import { getCalendarUrls, downloadICS } from "@/lib/calendar";
 
 interface Booking {
     id: string;

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -1,0 +1,42 @@
+export const formatDateTimeForCalendar = (dateStr: string, timeStr: string) => {
+    if (!dateStr || !timeStr) return { start: "", end: "" };
+    const start = new Date(`${dateStr}T${timeStr}`);
+    if (isNaN(start.getTime())) return { start: "", end: "" };
+    const end = new Date(start.getTime() + 60 * 60 * 1000);
+    
+    const format = (d: Date) => d.toISOString().replace(/-|:|\.\d\d\d/g, "");
+    
+    return {
+        start: format(start),
+        end: format(end)
+    };
+};
+
+export const getCalendarUrls = (venueName: string, venueAddress: string, dateStr: string, timeStr: string) => {
+    const { start, end } = formatDateTimeForCalendar(dateStr, timeStr);
+    const title = encodeURIComponent(`Booking at ${venueName}`);
+    const details = encodeURIComponent(`Hot desk booking at ${venueName}`);
+    const location = encodeURIComponent(venueAddress);
+
+    const googleUrl = `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${title}&dates=${start}/${end}&details=${details}&location=${location}`;
+    const outlookUrl = `https://outlook.live.com/calendar/0/deeplink/compose?path=/calendar/action/compose&rru=addevent&subject=${title}&startdt=${start}&enddt=${end}&body=${details}&location=${location}`;
+    
+    return { googleUrl, outlookUrl, start, end };
+};
+
+export const downloadICS = (venueName: string, venueAddress: string, dateStr: string, timeStr: string) => {
+    const { start, end } = formatDateTimeForCalendar(dateStr, timeStr);
+    if (!start) return;
+    const title = `Booking at ${venueName}`;
+    const description = `Hot desk booking at ${venueName}`;
+    
+    const icsContent = `BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nDTSTART:${start}\nDTEND:${end}\nSUMMARY:${title}\nDESCRIPTION:${description}\nLOCATION:${venueAddress}\nEND:VEVENT\nEND:VCALENDAR`;
+
+    const blob = new Blob([icsContent], { type: 'text/calendar;charset=utf-8' });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = `booking-${venueName.replace(/\\s+/g, '-').toLowerCase()}.ics`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+};


### PR DESCRIPTION
- closes #144

### Description
This PR introduces automated calendar export functionality to help users block out their schedules and avoid double-booking conflicts when reserving hot desks.

Users can now add their confirmed bookings directly to Google Calendar, Outlook Web, or download a `.ics` file for desktop calendar clients.

### Changes Included
- **Extracted Calendar Utility**: Moved existing calendar generation logic from `BookingModal.tsx` into a new shared utility `src/lib/calendar.ts`.
- **Reservation Page Integration**: Added "Add to Google", "Add to Outlook", and "Download .ics" buttons to the success state on the dedicated reservation page (`/reserve/[venueId]`).
- **Data Auto-population**: Calendar links automatically populate with the booking title, selected date/time, venue address, and description notes.
- **Refactored Chat Booking**: Updated the existing chat booking modal to use the new shared utility, eliminating code duplication.
- **Linter Fixes**: Resolved unused import warnings that resulted from the refactor.

### Screenshot

<img width="2158" height="1803" alt="Screenshot 2026-07-12 090718" src="https://github.com/user-attachments/assets/e122ac94-37e9-4ecd-8907-eabf99de7f17" />

### Motivation and Context

- Previously, users had no automated way to block out their calendar schedules after making a booking. Manual additions were inconvenient and prone to date/time errors, leading to double-booking conflicts. This feature provides a seamless scheduling experience across multiple calendar platforms.
