### PR TITLE
feat: persist crowdsourced amenity validation with 60% hide threshold

### DIFF
--- a/src/app/api/venues/[venueId]/amenity-votes/route.ts
+++ b/src/app/api/venues/[venueId]/amenity-votes/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/prisma";
+
+const MIN_VOTES_TO_HIDE = 5;
+const HIDE_THRESHOLD = 60;
+
+// GET /api/venues/[venueId]/amenity-votes
+export async function GET(
+  _req: NextRequest,
+  context: { params: Promise<{ venueId: string }> }
+) {
+  try {
+    const { venueId } = await context.params;
+    const { userId } = await auth();
+
+    const validations = await prisma.amenityValidation.findMany({
+      where: { venueId },
+      include: {
+        votes: true,
+      },
+    });
+
+    const metrics: Record<string,
+      {
+        confidenceScore: number;
+        upvotes: number;
+        downvotes: number;
+        hidden: boolean;
+        userVote: boolean | null;
+      }
+    > = {};
+
+    for (const v of validations) {
+      const total = v.upvotes + v.downvotes;
+      const confidenceScore = total > 0 ? Math.round((v.upvotes / total) * 100) : 100;
+      const hidden = total >= MIN_VOTES_TO_HIDE && confidenceScore < HIDE_THRESHOLD;
+
+      const myVote = userId
+  ? v.votes.find((vote: { userId: string; isUpvote: boolean }) => vote.userId === userId)
+  : undefined;
+
+      metrics[v.amenity] = {
+        confidenceScore,
+        upvotes: v.upvotes,
+        downvotes: v.downvotes,
+        hidden,
+        userVote: myVote ? myVote.isUpvote : null,
+      };
+    }
+
+    return NextResponse.json({ success: true, metrics });
+  } catch (error: any) {
+    console.error("GET /api/venues/[venueId]/amenity-votes error:", error);
+    return NextResponse.json(
+      { success: false, error: error.message },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/venues/amenity-vote/route.ts
+++ b/src/app/api/venues/amenity-vote/route.ts
@@ -1,42 +1,91 @@
 import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/prisma";
 
-// Simulating an in-memory database to store amenity votes dynamically for testing
-const globalVoteCache: Record<string, { upvotes: number; downvotes: number }> = {};
+const MIN_VOTES_TO_HIDE = 5;
+const HIDE_THRESHOLD = 60;
+
+function buildResponse(amenity: string, upvotes: number, downvotes: number) {
+  const totalVotes = upvotes + downvotes;
+  const confidenceScore =
+    totalVotes > 0 ? Math.round((upvotes / totalVotes) * 100) : 100;
+  const hidden = totalVotes >= MIN_VOTES_TO_HIDE && confidenceScore < HIDE_THRESHOLD;
+
+  return { success: true, amenity, upvotes, downvotes, confidenceScore, hidden };
+}
 
 export async function POST(request: Request) {
   try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json(
+        { success: false, error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
     const { venueId, amenity, isUpvote } = await request.json();
 
-    if (!venueId || !amenity) {
-      return NextResponse.json({ success: false, error: "Missing required parameters" }, { status: 400 });
+    if (!venueId || !amenity || typeof isUpvote !== "boolean") {
+      return NextResponse.json(
+        { success: false, error: "Missing required parameters" },
+        { status: 400 }
+      );
     }
 
-    const cacheKey = `${venueId}-${amenity}`;
-    
-    // Initialize weights if they don't exist yet
-    if (!globalVoteCache[cacheKey]) {
-      globalVoteCache[cacheKey] = { upvotes: 10, downvotes: 2 }; // Start with a safe 83% confidence
-    }
-
-    // Increment based on user choice
-    if (isUpvote) {
-      globalVoteCache[cacheKey].upvotes += 1;
-    } else {
-      globalVoteCache[cacheKey].downvotes += 1;
-    }
-
-    const { upvotes, downvotes } = globalVoteCache[cacheKey];
-    const totalVotes = upvotes + downvotes;
-    const confidenceScore = totalVotes > 0 ? (upvotes / totalVotes) * 100 : 100;
-
-    return NextResponse.json({
-      success: true,
-      amenity,
-      upvotes,
-      downvotes,
-      confidenceScore: Math.round(confidenceScore)
+    const validation = await prisma.amenityValidation.upsert({
+      where: { venueId_amenity: { venueId, amenity } },
+      update: {},
+      create: { venueId, amenity, upvotes: 0, downvotes: 0 },
     });
+
+    const existingVote = await prisma.amenityVote.findUnique({
+      where: { userId_validationId: { userId, validationId: validation.id } },
+    });
+
+    if (existingVote) {
+      if (existingVote.isUpvote === isUpvote) {
+        return NextResponse.json(
+          buildResponse(amenity, validation.upvotes, validation.downvotes)
+        );
+      }
+
+      await prisma.amenityVote.update({
+        where: { id: existingVote.id },
+        data: { isUpvote },
+      });
+
+      const updated = await prisma.amenityValidation.update({
+        where: { id: validation.id },
+        data: isUpvote
+          ? { upvotes: { increment: 1 }, downvotes: { decrement: 1 } }
+          : { upvotes: { decrement: 1 }, downvotes: { increment: 1 } },
+      });
+
+      return NextResponse.json(
+        buildResponse(amenity, updated.upvotes, updated.downvotes)
+      );
+    }
+
+    await prisma.amenityVote.create({
+      data: { validationId: validation.id, userId, isUpvote },
+    });
+
+    const updated = await prisma.amenityValidation.update({
+      where: { id: validation.id },
+      data: isUpvote
+        ? { upvotes: { increment: 1 } }
+        : { downvotes: { increment: 1 } },
+    });
+
+    return NextResponse.json(
+      buildResponse(amenity, updated.upvotes, updated.downvotes)
+    );
   } catch (error: any) {
-    return NextResponse.json({ success: false, error: error.message }, { status: 500 });
+    console.error("POST /api/venues/amenity-vote error:", error);
+    return NextResponse.json(
+      { success: false, error: error.message },
+      { status: 500 }
+    );
   }
 }

--- a/src/components/VenueCard.tsx
+++ b/src/components/VenueCard.tsx
@@ -36,6 +36,8 @@ interface VoteMetricState {
   confidenceScore: number;
   upvotes: number;
   downvotes: number;
+  hidden: boolean;
+  userVote: boolean | null;
 }
 
 export function VenueCard({
@@ -49,16 +51,33 @@ export function VenueCard({
   const [isLoading, setIsLoading] = useState(false);
   const [photoIndex, setPhotoIndex] = useState(0);
 
-  // =========================================================================
+ // =========================================================================
   // COMMUNITY VERIFICATION VOTE STATE TRACKING SYSTEM
   // =========================================================================
   const [voteMetrics, setVoteMetrics] = useState<Record<string, VoteMetricState>>({
-    wifi: { confidenceScore: 100, upvotes: 6, downvotes: 0 },
-    outlets: { confidenceScore: 100, upvotes: 6, downvotes: 0 },
+    wifi: { confidenceScore: 100, upvotes: 0, downvotes: 0, hidden: false, userVote: null },
+    outlets: { confidenceScore: 100, upvotes: 0, downvotes: 0, hidden: false, userVote: null },
+    ergonomic: { confidenceScore: 100, upvotes: 0, downvotes: 0, hidden: false, userVote: null },
   });
 
+  // Load real vote metrics from the database on mount
+  useEffect(() => {
+    async function loadVoteMetrics() {
+      try {
+        const response = await fetch(`/api/venues/${venue.id}/amenity-votes`);
+        if (response.ok) {
+          const data = await response.json();
+          setVoteMetrics((prev) => ({ ...prev, ...data.metrics }));
+        }
+      } catch (error) {
+        console.error("Failed to load amenity vote metrics:", error);
+      }
+    }
+    loadVoteMetrics();
+  }, [venue.id]);
+
   // Async dynamic vote submittal query processor
-  const submitAmenityVote = async (amenityKey: "wifi" | "outlets", isUpvote: boolean) => {
+  const submitAmenityVote = async (amenityKey: "wifi" | "outlets" | "ergonomic", isUpvote: boolean) => {
     try {
       const response = await fetch("/api/venues/amenity-vote", {
         method: "POST",
@@ -78,6 +97,8 @@ export function VenueCard({
             confidenceScore: data.confidenceScore,
             upvotes: data.upvotes,
             downvotes: data.downvotes,
+            hidden: data.hidden,
+            userVote: isUpvote,
           },
         }));
       }
@@ -131,8 +152,9 @@ export function VenueCard({
   const amenities = enrichData?.amenities;
 
   // Determine low confidence threshold parameters to trigger notice blocks
-  const wifiLowConfidence = venue.wifiQuality && voteMetrics.wifi.confidenceScore < 50;
-  const outletsLowConfidence = venue.hasOutlets && voteMetrics.outlets.confidenceScore < 50;
+  const wifiLowConfidence = venue.wifiQuality && voteMetrics.wifi.hidden;
+  const outletsLowConfidence = venue.hasOutlets && voteMetrics.outlets.hidden;
+  const ergonomicLowConfidence = venue.amenities?.hasErgonomic && voteMetrics.ergonomic.hidden;
 
   return (
     <div className="relative border border-zinc-200 dark:border-zinc-800 rounded-xl overflow-hidden bg-white dark:bg-zinc-900 hover:shadow-lg transition-all">
@@ -148,6 +170,12 @@ export function VenueCard({
         <div className="flex items-center gap-2 bg-amber-500/10 border-b border-amber-500/20 px-4 py-2 text-xs text-amber-600 dark:text-amber-400 font-medium">
           <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
           <span>Users report **Power Outlets** might be broken or missing.</span>
+        </div>
+      )}
+      {ergonomicLowConfidence && (
+        <div className="flex items-center gap-2 bg-amber-500/10 border-b border-amber-500/20 px-4 py-2 text-xs text-amber-600 dark:text-amber-400 font-medium">
+          <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
+          <span>Users report **ergonomic seating** may not be available here.</span>
         </div>
       )}
 
@@ -260,9 +288,9 @@ export function VenueCard({
           
           <div className="flex flex-wrap gap-2">
             {/* WiFi Tag Check Node */}
-            {venue.wifiQuality && (
+            {venue.wifiQuality && !voteMetrics.wifi.hidden && (
               <div className={`flex items-center gap-1.5 px-2.5 py-1 rounded-lg border text-xs transition-all ${
-                voteMetrics.wifi.confidenceScore < 50 
+                voteMetrics.wifi.confidenceScore < 60 
                   ? "border-amber-500/30 bg-amber-500/5 text-amber-500" 
                   : "border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900 text-zinc-700 dark:text-zinc-300"
               }`}>
@@ -270,16 +298,22 @@ export function VenueCard({
                 <span className="font-medium font-mono text-[11px]">WiFi ({voteMetrics.wifi.confidenceScore}%)</span>
                 
                 <div className="ml-1 flex items-center border-l border-zinc-300 dark:border-zinc-700 pl-1.5 gap-1 text-[10px]">
-                  <button onClick={() => submitAmenityVote("wifi", true)} className="hover:text-green-500 transition-colors">👍</button>
-                  <button onClick={() => submitAmenityVote("wifi", false)} className="hover:text-red-500 transition-colors">👎</button>
+                  <button
+                    onClick={() => submitAmenityVote("wifi", true)}
+                    className={`transition-colors ${voteMetrics.wifi.userVote === true ? "text-green-500" : "hover:text-green-500"}`}
+                  >👍</button>
+                  <button
+                    onClick={() => submitAmenityVote("wifi", false)}
+                    className={`transition-colors ${voteMetrics.wifi.userVote === false ? "text-red-500" : "hover:text-red-500"}`}
+                  >👎</button>
                 </div>
               </div>
             )}
 
             {/* Outlets Tag Check Node */}
-            {venue.hasOutlets && (
+            {venue.hasOutlets && !voteMetrics.outlets.hidden && (
               <div className={`flex items-center gap-1.5 px-2.5 py-1 rounded-lg border text-xs transition-all ${
-                voteMetrics.outlets.confidenceScore < 50 
+                voteMetrics.outlets.confidenceScore < 60 
                   ? "border-amber-500/30 bg-amber-500/5 text-amber-500" 
                   : "border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900 text-zinc-700 dark:text-zinc-300"
               }`}>
@@ -287,8 +321,37 @@ export function VenueCard({
                 <span className="font-medium font-mono text-[11px]">Outlets ({voteMetrics.outlets.confidenceScore}%)</span>
                 
                 <div className="ml-1 flex items-center border-l border-zinc-300 dark:border-zinc-700 pl-1.5 gap-1 text-[10px]">
-                  <button onClick={() => submitAmenityVote("outlets", true)} className="hover:text-green-500 transition-colors">👍</button>
-                  <button onClick={() => submitAmenityVote("outlets", false)} className="hover:text-red-500 transition-colors">👎</button>
+                  <button
+                    onClick={() => submitAmenityVote("outlets", true)}
+                    className={`transition-colors ${voteMetrics.outlets.userVote === true ? "text-green-500" : "hover:text-green-500"}`}
+                  >👍</button>
+                  <button
+                    onClick={() => submitAmenityVote("outlets", false)}
+                    className={`transition-colors ${voteMetrics.outlets.userVote === false ? "text-red-500" : "hover:text-red-500"}`}
+                  >👎</button>
+                </div>
+              </div>
+            )}
+
+            {/* Ergonomic Seating Tag Check Node */}
+            {venue.amenities?.hasErgonomic && !voteMetrics.ergonomic.hidden && (
+              <div className={`flex items-center gap-1.5 px-2.5 py-1 rounded-lg border text-xs transition-all ${
+                voteMetrics.ergonomic.confidenceScore < 60 
+                  ? "border-amber-500/30 bg-amber-500/5 text-amber-500" 
+                  : "border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900 text-zinc-700 dark:text-zinc-300"
+              }`}>
+                <Accessibility className="w-3.5 h-3.5 text-purple-500" />
+                <span className="font-medium font-mono text-[11px]">Ergonomic ({voteMetrics.ergonomic.confidenceScore}%)</span>
+                
+                <div className="ml-1 flex items-center border-l border-zinc-300 dark:border-zinc-700 pl-1.5 gap-1 text-[10px]">
+                  <button
+                    onClick={() => submitAmenityVote("ergonomic", true)}
+                    className={`transition-colors ${voteMetrics.ergonomic.userVote === true ? "text-green-500" : "hover:text-green-500"}`}
+                  >👍</button>
+                  <button
+                    onClick={() => submitAmenityVote("ergonomic", false)}
+                    className={`transition-colors ${voteMetrics.ergonomic.userVote === false ? "text-red-500" : "hover:text-red-500"}`}
+                  >👎</button>
                 </div>
               </div>
             )}


### PR DESCRIPTION
<!-- Provide a clear and concise description of what this PR does and why it is needed. -->
This PR implements a persisted crowdsourced amenity validation system, replacing a prototype in `src/app/api/venues/amenity-vote/route.ts` that stored votes in an in-memory object (wiped on every deploy/cold start) and had no auth check or per-user vote deduplication.

Changes:
1. **`src/app/api/venues/amenity-vote/route.ts`** — rewritten to require `auth()`, and to persist votes via the existing `AmenityValidation`/`AmenityVote` Prisma models instead of an in-memory cache. A user's repeat vote now updates their existing `AmenityVote` (enforced by the `@@unique([userId, validationId])` constraint) instead of being uncapped.
2. **`src/app/api/venues/[venueId]/amenity-votes/route.ts`** (new) — `GET` endpoint that returns real confidence scores, vote counts, and the current user's existing vote (if any) for a venue, so the UI no longer starts from hardcoded placeholder numbers.
3. **`src/components/VenueCard.tsx`** — fetches real vote metrics on mount, adds a third tracked amenity (`ergonomic`, mapped to `hasErgonomic`), and changes the confidence behavior from "show a warning below 50%" to "hide the amenity badge once it has 5+ votes and drops below 60% confidence," per the feature request. Vote buttons now also reflect the signed-in user's own prior vote.

## Related Issue
Fixes #136 

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)
<!-- Add a screenshot/recording of the vote buttons + confidence % badges on a venue card, and ideally one showing a low-confidence amenity disappearing after enough downvotes. -->

## Breaking Changes
- [x] No