### PR TITLE
fix: add explicit gradient fallback for Safari

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -131,6 +131,9 @@ export default function Home() {
               <Link
                 href="/sign-up"
                 className="group px-8 py-4 rounded-2xl bg-gradient-to-r from-blue-600 to-purple-600 text-white font-semibold text-base hover:shadow-2xl hover:shadow-blue-500/30 transition-all hover:scale-105 flex items-center justify-center gap-2"
+                style={{
+                  backgroundImage: "linear-gradient(to right, #2563eb, #7c3aed)",
+                }}
               >
                 Start for Free
                 <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
@@ -146,6 +149,9 @@ export default function Home() {
               <Link
                 href="/ai"
                 className="group px-8 py-4 rounded-2xl bg-gradient-to-r from-blue-600 to-purple-600 text-white font-semibold text-base hover:shadow-2xl hover:shadow-blue-500/30 transition-all hover:scale-105 flex items-center justify-center gap-2"
+                style={{
+                  backgroundImage: "linear-gradient(to right, #2563eb, #7c3aed)",
+                }}
               >
                 Open Dashboard
                 <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />


### PR DESCRIPTION
## Description

This PR improves Safari compatibility for the primary landing page CTA buttons by adding an explicit CSS gradient fallback. The change helps ensure gradient backgrounds render consistently on Safari while preserving the existing appearance across other browsers.

## Related Issue

Fixes #209

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

N/A (Safari compatibility fix)

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No