### PR TITLE
Fix PWA background sync crashes and corrupted IndexedDB states

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,5 @@
 // Service Worker for WorkSphere PWA
-const CACHE_NAME = "worksphere-v2";
+const CACHE_NAME = "worksphere-v3";
 const OFFLINE_URL = "/offline";
 
 // Assets to cache on install
@@ -216,15 +216,36 @@ async function syncRatings() {
 // IndexedDB helpers
 function openIndexedDB() {
   return new Promise((resolve, reject) => {
-    const request = indexedDB.open("worksphere-offline", 1);
+    const request = indexedDB.open("worksphere-offline", 2);
 
     request.onerror = () => reject(request.error);
     request.onsuccess = () => resolve(request.result);
 
     request.onupgradeneeded = (event) => {
       const db = event.target.result;
-      if (!db.objectStoreNames.contains("pending-actions")) {
-        db.createObjectStore("pending-actions", {
+      
+      // Venues store
+      if (!db.objectStoreNames.contains('venues')) {
+        const venuesStore = db.createObjectStore('venues', { keyPath: 'id' });
+        venuesStore.createIndex('type', 'type', { unique: false });
+        venuesStore.createIndex('savedAt', 'savedAt', { unique: false });
+      }
+
+      // Favorites store
+      if (!db.objectStoreNames.contains('favorites')) {
+        const favoritesStore = db.createObjectStore('favorites', { keyPath: 'id' });
+        favoritesStore.createIndex('savedAt', 'savedAt', { unique: false });
+      }
+
+      // Search history store
+      if (!db.objectStoreNames.contains('searches')) {
+        const searchesStore = db.createObjectStore('searches', { keyPath: 'query' });
+        searchesStore.createIndex('timestamp', 'timestamp', { unique: false });
+      }
+
+      // Pending actions store (unified name)
+      if (!db.objectStoreNames.contains("pendingActions")) {
+        db.createObjectStore("pendingActions", {
           keyPath: "id",
           autoIncrement: true,
         });
@@ -235,8 +256,8 @@ function openIndexedDB() {
 
 function getPendingActions(db, type) {
   return new Promise((resolve, reject) => {
-    const tx = db.transaction("pending-actions", "readonly");
-    const store = tx.objectStore("pending-actions");
+    const tx = db.transaction("pendingActions", "readonly");
+    const store = tx.objectStore("pendingActions");
     const request = store.getAll();
 
     request.onerror = () => reject(request.error);
@@ -249,8 +270,8 @@ function getPendingActions(db, type) {
 
 function removePendingAction(db, type, id) {
   return new Promise((resolve, reject) => {
-    const tx = db.transaction("pending-actions", "readwrite");
-    const store = tx.objectStore("pending-actions");
+    const tx = db.transaction("pendingActions", "readwrite");
+    const store = tx.objectStore("pendingActions");
     const request = store.delete(id);
 
     request.onerror = () => reject(request.error);

--- a/src/lib/offlineStorage.ts
+++ b/src/lib/offlineStorage.ts
@@ -21,7 +21,7 @@ userDoc.on('update', async (update: Uint8Array) => {
 
 
 const DB_NAME = 'worksphere-offline';
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 
 export interface OfflineVenue {
   id: string;


### PR DESCRIPTION
## Description
Users loading the PWA offline were experiencing data corruption and crashes due to a mismatch between the Service Worker and the frontend IndexedDB schema initialization. 

**Changes:**
- Unified the object store name to `pendingActions` across both `offlineStorage.ts` and `public/sw.js`.
- Replicated the full schema definition in the Service Worker's `onupgradeneeded` block to prevent partial schema locks.
- Bumped `DB_VERSION` to 2 to force existing corrupted clients to run a clean database upgrade.
- Bumped Service Worker `CACHE_NAME` to immediately deploy the fixed script.

## Related Issue

Fixes #147

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots / Screen Recordings (if applicable)

N/A - Background Sync/IndexedDB fix.

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No
