### PR TITLE
docs: add localization validation guidelines #219

### DIFF
--- a/docs/LOCALIZED_VALIDATION.md
+++ b/docs/LOCALIZED_VALIDATION.md
@@ -1,0 +1,25 @@
+# Localization Guidelines for Custom Validation Messages
+
+This document outlines the standard architecture for translating input validation schemas, managing internationalized schema error states, and verifying localized API validation payloads within the application engine.
+
+---
+
+## 1. Localized Validation Keys Structure
+
+All form-level translation tokens must follow a flat, standardized dot-notation syntax matching their schema property mappings. Translation keys are organized inside the locale directories (e.g., `messages/en.json`, `messages/hi.json`).
+
+### Standard Structure Example (`messages/en.json`)
+
+```json
+{
+  "validation": {
+    "auth": {
+      "email_invalid": "Please enter a valid business email address.",
+      "password_too_short": "Password must contain a minimum of 8 characters."
+    },
+    "workspace": {
+      "name_required": "Workspace moniker cannot be blank.",
+      "radius_exceeded": "Coordinates must fall within verified boundary fences."
+    }
+  }
+}


### PR DESCRIPTION
## Description
This PR introduces comprehensive guidelines defining how to structure localized translation keys, link them dynamically to standard Zod runtime validation maps, and test internationalization payload outputs using client language headers. 

As applications support diverse geographic developer circles, explicit tracking rules for message schemas are vital for standardized runtime UI feedback loops.

## Related Issue
Fixes #219

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Breaking Changes
- [ ] Yes 
- [x] No