### PR TITLE
fix(maps): recalculate spiderfy offsets relative to zoom level

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useUser } from "@clerk/nextjs";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   MapContainer,
   TileLayer,
@@ -97,6 +97,42 @@ function AutoCenter({
   return null;
 }
 
+// Tracks the map's settled zoom level so spiderfied marker offsets can be
+// recalculated relative to it. The `zoomend` handler is debounced so that
+// rapid zoom actions (e.g. zoom out then quickly double-click to zoom in)
+// don't trigger a recalculation on every intermediate animation frame -
+// only once the zoom transition has actually settled, avoiding the stale
+// pre-zoom offsets that caused clustered markers to render on top of each
+// other mid-transition.
+function ZoomWatcher({
+  onZoomSettled,
+  delay = 150,
+}: {
+  onZoomSettled: (zoom: number) => void;
+  delay?: number;
+}) {
+  const map = useMap();
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+
+    const scheduleUpdate = () => {
+      clearTimeout(timer);
+      timer = setTimeout(() => onZoomSettled(map.getZoom()), delay);
+    };
+
+    map.on("zoomend", scheduleUpdate);
+    scheduleUpdate(); // capture the initial zoom too
+
+    return () => {
+      clearTimeout(timer);
+      map.off("zoomend", scheduleUpdate);
+    };
+  }, [map, onZoomSettled, delay]);
+
+  return null;
+}
+
 // Subcomponent to handle rendering the Leaflet heatmap layer seamlessly
 function HeatmapOverlay({ points, visible }: { points: any[]; visible: boolean }) {
   const map = useMap();
@@ -144,6 +180,14 @@ const Map = ({
 }) => {
   const clerkUser = useUser();
   const { latitude, longitude } = location;
+
+  // Settled zoom level (debounced via ZoomWatcher), used to keep spiderfied
+  // marker offsets at a consistent on-screen pixel separation regardless of
+  // how far the user has zoomed in/out.
+  const [settledZoom, setSettledZoom] = useState<number>(13);
+  const handleZoomSettled = useCallback((zoom: number) => {
+    setSettledZoom(zoom);
+  }, []);
 
   // =========================================================================
   // MULTI-STOP ROUTING OPTIMIZER STATE PARAMETERS
@@ -227,11 +271,18 @@ const Map = ({
       } else {
         const centerLat = Number(groupItems[0].position.lat);
         const centerLng = Number(groupItems[0].position.lng);
-        // Base radius of ~200 meters to visually separate markers at default zoom
-        const baseRadius = 0.002;
-        // Expand slightly if many markers share the location
-        const radius = baseRadius + (0.0002 * n);
-        
+
+        // Keep a consistent ~24px on-screen separation between spiderfied
+        // markers at any zoom level, instead of a fixed degree offset that
+        // only looked right at the default zoom and collapsed to
+        // sub-pixel distances once the user zoomed out (Web Mercator
+        // meters-per-pixel formula).
+        const metersPerPixel =
+          (156543.03392 * Math.cos((centerLat * Math.PI) / 180)) /
+          Math.pow(2, settledZoom);
+        const targetPixelSeparation = 24 + 2 * n; // spread out a bit more if many markers share the location
+        const radius = (metersPerPixel * targetPixelSeparation) / 111320; // meters -> degrees latitude
+
         groupItems.forEach((item, index) => {
           const angle = (2 * Math.PI * index) / n;
           const offsetLat = centerLat + radius * Math.cos(angle);
@@ -245,7 +296,7 @@ const Map = ({
       }
     });
     return result;
-  }, [markers]);
+  }, [markers, settledZoom]);
 
 
   // Derive iconUrl directly from clerkUser state
@@ -409,6 +460,7 @@ const Map = ({
         />
         <MapController mapView={mapView} />
         <AutoCenter markers={markers} userLocation={center} />
+        <ZoomWatcher onZoomSettled={handleZoomSettled} />
 
         {customIcon && (
           <Marker position={center} icon={customIcon}>


### PR DESCRIPTION
## Description

Fixes marker clusters overlapping/stacking during rapid zoom transitions on the venue map (`src/components/Map.tsx`).

### Root cause

`Map.tsx` doesn't use a third-party clustering plugin — it groups markers that share (near-)identical coordinates and radially offsets ("spiderfies") them so they don't render on top of each other. The offset radius was a **fixed** lat/lng degree value (`0.002deg`, ~200m), previously bumped in #252 with the comment *"to visually separate markers at default zoom"*.

Because that offset:
1. never accounted for the map's current zoom level, and
2. was only recomputed when the `markers` prop changed — never on zoom,

the same degree offset collapsed to a sub-pixel screen distance once the user zoomed out, so clustered markers visually stacked and became unclickable. This was especially reproducible after a rapid zoom-out then fast zoom-in, as described in #204.

### Fix

- Added a small `ZoomWatcher` subcomponent (mirrors the existing `MapController`/`AutoCenter` pattern) that listens to Leaflet's `zoomend` event, **debounced ~150ms**, and reports the *settled* zoom level up to `Map`. Debouncing avoids recalculating on every intermediate animation frame during a fast zoom action, only recalculating once the transition has actually settled.
- The spiderfy radius is now derived from that settled zoom using the standard Web Mercator meters-per-pixel formula, keeping a consistent ~24px on-screen separation between clustered markers at any zoom level instead of a value tuned for one specific zoom.

This is a minimal, targeted change scoped to the spiderfy-radius calculation — no other map features (heatmap, routing, auto-center, popups) were touched.

## Related Issue

Fixes #204

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (not applicable)
- [x] My changes generate no new warnings (`npx eslint src/components/Map.tsx` passes clean)
- [ ] I have added tests that prove my fix is effective (no existing test infra covers spiderfy geometry; verified via lint + diff review — see note below)
- [ ] New and existing unit tests pass locally with my changes (pre-existing React 19 version mismatch breaks the whole Jest suite on `main`, unrelated to this change — same caveat noted in #252)
- [ ] Any dependent changes have been merged and published in downstream modules (not applicable)

## Screenshots / Screen Recordings (if applicable)

N/A — logic-only change; verified `npm run lint` passes and confirmed `npm run build` fails identically on unmodified `main` (pre-existing, unrelated `webhooks/ui` module-not-found errors), so this change introduces no new build issues.

## Breaking Changes

- [ ] Yes
- [x] No