### PR TITLE
fix: handle Overpass API request timeouts gracefully

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -261,13 +261,20 @@ async function dataAgent(
   let overpassFailed = true;
 
   for (const endpoint of endpoints) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => {
+      controller.abort();
+    }, 10000);
     try {
       const response = await fetch(endpoint, {
         method: "POST",
         body: `data=${encodeURIComponent(query)}`,
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        signal: controller.signal,
       });
-
+      
       if (!response.ok) continue;
       const data = await response.json();
       overpassFailed = false;
@@ -355,8 +362,14 @@ async function dataAgent(
         reasoning: `Found ${venues.length} venues within ${radius}m`,
       };
     } catch (error) {
-      console.error("Data agent error:", error);
+      if (error instanceof Error && error.name === "AbortError") {
+        console.warn(`Overpass API request to ${endpoint} timed out after 10 seconds.`);
+      } else {
+        console.error("Data agent error:", error);
+      }
       continue;
+    } finally {
+      clearTimeout(timeout);
     }
   }
 


### PR DESCRIPTION
## Description

This PR improves the handling of Overpass API request timeouts to prevent long-running requests from hanging indefinitely.

### Changes
- Added a 10-second timeout for Overpass API requests using `AbortController`.
- Added timeout-specific logging for easier debugging.
- Ensured request timers are always cleaned up using a `finally` block.

These changes help the application fail gracefully when the Overpass API is slow or unavailable.

## Related Issue

Fixes #274

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

N/A (Backend change)

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No