### PR TITLE
[Feature]: Add Collection Metrics Widget and Comparison Tool

### DIFF
--- a/src/app/api/webhooks/worker/route.ts
+++ b/src/app/api/webhooks/worker/route.ts
@@ -36,7 +36,7 @@ export async function POST(req: NextRequest) {
         // We'll call Svix API.
         
         try {
-          const response = await svix.message.create(event.userId, {
+          await svix.message.create(event.userId, {
             eventType: event.type,
             eventId: event.id,
             payload: event.data,

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft, Users, Link as LinkIcon, Trash2, MapPin, Loader2, RefreshCw 
 import { useRouter } from "next/navigation";
 import usePartySocket from "partysocket/react";
 import Image from "next/image";
+import { ComparisonTool } from "@/components/collections/ComparisonTool";
 
 export default function FolderDetailsPage({ params }: { params: Promise<{ id: string }> }) {
   const resolvedParams = use(params);
@@ -122,6 +123,8 @@ export default function FolderDetailsPage({ params }: { params: Promise<{ id: st
               )}
            </div>
         </div>
+
+        <ComparisonTool currentFolder={folder} />
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           <div className="md:col-span-2 space-y-4">

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -2,8 +2,8 @@
 
 import { useEffect, useState, useCallback, use } from "react";
 import Link from "next/link";
-import { ArrowLeft, Users, Link as LinkIcon, Trash2, MapPin, Loader2, RefreshCw } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { ArrowLeft, Users, Link as LinkIcon, Trash2, MapPin, Loader2 } from "lucide-react";
+
 import usePartySocket from "partysocket/react";
 import Image from "next/image";
 import { ComparisonTool } from "@/components/collections/ComparisonTool";
@@ -11,7 +11,6 @@ import { ComparisonTool } from "@/components/collections/ComparisonTool";
 export default function FolderDetailsPage({ params }: { params: Promise<{ id: string }> }) {
   const resolvedParams = use(params);
   const { id } = resolvedParams;
-  const router = useRouter();
   
   const [folder, setFolder] = useState<any>(null);
   const [loading, setLoading] = useState(true);
@@ -31,7 +30,7 @@ export default function FolderDetailsPage({ params }: { params: Promise<{ id: st
       } else {
         setError(data.error || "Failed to load folder");
       }
-    } catch (e) {
+    } catch {
       setError("An error occurred");
     } finally {
       setLoading(false);
@@ -52,7 +51,7 @@ export default function FolderDetailsPage({ params }: { params: Promise<{ id: st
         if (data.type === "refresh") {
           fetchFolder();
         }
-      } catch (e) {
+      } catch {
         // ignore
       }
     },

--- a/src/components/chat/VenueDetailDialog.tsx
+++ b/src/components/chat/VenueDetailDialog.tsx
@@ -107,7 +107,7 @@ export function VenueDetailDialog({
             let targetLanguageName = "English";
             try {
                 targetLanguageName = new Intl.DisplayNames(['en'], { type: 'language' }).of(langCode) || langCode;
-            } catch (e) {
+            } catch {
                 targetLanguageName = langCode;
             }
 
@@ -143,7 +143,7 @@ export function VenueDetailDialog({
                 const response = await fetch(`/api/venues/${venueId}/amenity-votes`);
                 if (response.ok) {
                     const data = await response.json();
-                    setVoteMetrics((prev) => ({
+                    setVoteMetrics(() => ({
                         wifi: { confidenceScore: 100, upvotes: 0, downvotes: 0, hidden: false, userVote: null },
                         outlets: { confidenceScore: 100, upvotes: 0, downvotes: 0, hidden: false, userVote: null },
                         silentRoom: { confidenceScore: 100, upvotes: 0, downvotes: 0, hidden: false, userVote: null },

--- a/src/components/collections/ComparisonTool.tsx
+++ b/src/components/collections/ComparisonTool.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import React, { useState, useEffect } from 'react';
+import { MetricsWidget } from './MetricsWidget';
+import { Loader2, ArrowRightLeft } from 'lucide-react';
+
+interface ComparisonToolProps {
+  currentFolder: any; // The current folder object with venues
+}
+
+export function ComparisonTool({ currentFolder }: ComparisonToolProps) {
+  const [folders, setFolders] = useState<any[]>([]);
+  const [selectedFolderId, setSelectedFolderId] = useState<string>('');
+  const [compareFolder, setCompareFolder] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    // Fetch all folders for the dropdown
+    async function fetchFolders() {
+      try {
+        const res = await fetch('/api/folders');
+        const data = await res.json();
+        if (data.folders) {
+          // Exclude current folder
+          setFolders(data.folders.filter((f: any) => f.id !== currentFolder.id));
+        }
+      } catch (e) {
+        console.error("Failed to fetch folders", e);
+      }
+    }
+    fetchFolders();
+  }, [currentFolder.id]);
+
+  useEffect(() => {
+    if (!selectedFolderId) {
+      setCompareFolder(null);
+      return;
+    }
+
+    async function fetchCompareFolder() {
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/folders/${selectedFolderId}`);
+        const data = await res.json();
+        if (data.folder) {
+          setCompareFolder(data.folder);
+        }
+      } catch (e) {
+        console.error("Failed to fetch compare folder", e);
+      } finally {
+        setLoading(false);
+      }
+    }
+    
+    fetchCompareFolder();
+  }, [selectedFolderId]);
+
+  return (
+    <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-6 shadow-sm mb-6">
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-lg font-semibold text-zinc-900 dark:text-white flex items-center gap-2">
+          <ArrowRightLeft className="w-5 h-5 text-indigo-500" /> Compare Collections
+        </h2>
+        
+        <div className="flex items-center gap-3">
+          <label htmlFor="compare-select" className="text-sm font-medium text-zinc-600 dark:text-zinc-400">
+            Compare with:
+          </label>
+          <select
+            id="compare-select"
+            value={selectedFolderId}
+            onChange={(e) => setSelectedFolderId(e.target.value)}
+            className="bg-zinc-50 dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 text-zinc-900 dark:text-zinc-100 text-sm rounded-xl focus:ring-blue-500 focus:border-blue-500 block w-48 p-2.5"
+          >
+            <option value="">Select a collection...</option>
+            {folders.map(f => (
+              <option key={f.id} value={f.id}>{f.name}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 relative">
+        <MetricsWidget venues={currentFolder.venues} title={currentFolder.name} isCompact />
+        
+        {loading ? (
+          <div className="bg-zinc-50 dark:bg-zinc-950/50 border border-zinc-100 dark:border-zinc-800/50 rounded-2xl p-5 flex items-center justify-center">
+            <Loader2 className="w-6 h-6 animate-spin text-zinc-400" />
+          </div>
+        ) : compareFolder ? (
+          <MetricsWidget venues={compareFolder.venues} title={compareFolder.name} isCompact />
+        ) : (
+          <div className="bg-zinc-50 dark:bg-zinc-950/50 border border-dashed border-zinc-300 dark:border-zinc-700 rounded-2xl p-5 flex flex-col items-center justify-center text-zinc-400">
+            <ArrowRightLeft className="w-8 h-8 mb-2 opacity-50" />
+            <p className="text-sm">Select a collection above to compare</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/collections/MetricsWidget.tsx
+++ b/src/components/collections/MetricsWidget.tsx
@@ -54,8 +54,6 @@ export function calculateMetrics(venues: { venue: Venue }[]) {
 }
 
 export function MetricsWidget({ venues, title = "Collection Metrics", isCompact = false }: MetricsWidgetProps) {
-  const unusedVariableToTriggerLintError = "Hello World";
-  
   const { speed, quietness, outlets } = calculateMetrics(venues);
 
   return (

--- a/src/components/collections/MetricsWidget.tsx
+++ b/src/components/collections/MetricsWidget.tsx
@@ -54,6 +54,8 @@ export function calculateMetrics(venues: { venue: Venue }[]) {
 }
 
 export function MetricsWidget({ venues, title = "Collection Metrics", isCompact = false }: MetricsWidgetProps) {
+  const unusedVariableToTriggerLintError = "Hello World";
+  
   const { speed, quietness, outlets } = calculateMetrics(venues);
 
   return (

--- a/src/components/collections/MetricsWidget.tsx
+++ b/src/components/collections/MetricsWidget.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { Wifi, VolumeX, Plug, Activity } from 'lucide-react';
+
+interface Venue {
+  wifiSpeed?: number | null;
+  noiseLevel?: string | null;
+  hasOutlets?: boolean;
+}
+
+interface MetricsWidgetProps {
+  venues: { venue: Venue }[];
+  title?: string;
+  isCompact?: boolean;
+}
+
+export function calculateMetrics(venues: { venue: Venue }[]) {
+  if (!venues || venues.length === 0) return { speed: null, quietness: null, outlets: null };
+
+  let totalSpeed = 0;
+  let speedCount = 0;
+
+  let totalQuietness = 0;
+  let quietnessCount = 0;
+
+  let outletsCount = 0;
+
+  venues.forEach((v) => {
+    const venue = v.venue;
+    if (venue.wifiSpeed !== null && venue.wifiSpeed !== undefined) {
+      totalSpeed += venue.wifiSpeed;
+      speedCount++;
+    }
+    
+    if (venue.noiseLevel) {
+      const level = venue.noiseLevel.toLowerCase();
+      let score = 3;
+      if (level === 'quiet') score = 5;
+      if (level === 'moderate') score = 3;
+      if (level === 'loud') score = 1;
+      totalQuietness += score;
+      quietnessCount++;
+    }
+
+    if (venue.hasOutlets) {
+      outletsCount++;
+    }
+  });
+
+  const speed = speedCount > 0 ? Math.round(totalSpeed / speedCount) : null;
+  const quietness = quietnessCount > 0 ? Number((totalQuietness / quietnessCount).toFixed(1)) : null;
+  const outlets = Math.round((outletsCount / venues.length) * 100);
+
+  return { speed, quietness, outlets };
+}
+
+export function MetricsWidget({ venues, title = "Collection Metrics", isCompact = false }: MetricsWidgetProps) {
+  const { speed, quietness, outlets } = calculateMetrics(venues);
+
+  return (
+    <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-5 shadow-sm h-full flex flex-col justify-center">
+      {!isCompact && (
+        <h3 className="text-lg font-semibold text-zinc-900 dark:text-white flex items-center gap-2 mb-4">
+          <Activity className="w-5 h-5 text-indigo-500" /> {title}
+        </h3>
+      )}
+      
+      <div className={`grid ${isCompact ? 'grid-cols-1 gap-3' : 'grid-cols-3 gap-4'}`}>
+        <div className="flex flex-col items-center justify-center p-3 bg-zinc-50 dark:bg-zinc-950 rounded-xl border border-zinc-100 dark:border-zinc-800">
+          <Wifi className="w-6 h-6 text-blue-500 mb-2" />
+          <div className="text-xl font-bold text-zinc-900 dark:text-white">
+            {speed !== null ? `${speed} Mbps` : '--'}
+          </div>
+          <div className="text-xs text-zinc-500 font-medium">Avg Speed</div>
+        </div>
+
+        <div className="flex flex-col items-center justify-center p-3 bg-zinc-50 dark:bg-zinc-950 rounded-xl border border-zinc-100 dark:border-zinc-800">
+          <VolumeX className="w-6 h-6 text-purple-500 mb-2" />
+          <div className="text-xl font-bold text-zinc-900 dark:text-white flex items-center gap-1">
+            {quietness !== null ? quietness : '--'}
+            {quietness !== null && <span className="text-sm text-yellow-500">★</span>}
+          </div>
+          <div className="text-xs text-zinc-500 font-medium">Avg Quietness</div>
+        </div>
+
+        <div className="flex flex-col items-center justify-center p-3 bg-zinc-50 dark:bg-zinc-950 rounded-xl border border-zinc-100 dark:border-zinc-800">
+          <Plug className="w-6 h-6 text-green-500 mb-2" />
+          <div className="text-xl font-bold text-zinc-900 dark:text-white">
+            {outlets !== null ? `${outlets}%` : '--'}
+          </div>
+          <div className="text-xs text-zinc-500 font-medium">Outlet Avail.</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/collections/MetricsWidget.tsx
+++ b/src/components/collections/MetricsWidget.tsx
@@ -55,7 +55,6 @@ export function calculateMetrics(venues: { venue: Venue }[]) {
 
 export function MetricsWidget({ venues, title = "Collection Metrics", isCompact = false }: MetricsWidgetProps) {
   const { speed, quietness, outlets } = calculateMetrics(venues);
-
   return (
     <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-5 shadow-sm h-full flex flex-col justify-center">
       {!isCompact && (


### PR DESCRIPTION
- closes #197

### Description
This PR introduces a new metrics dashboard and comparison tool for collections/folders. It addresses the issue of users having to manually calculate summary ratings across their curated venues by providing automatic, real-time aggregate analysis directly on the collection page.

### Key Features
- **Aggregate Analysis**: Automatically calculates average WiFi speed, quietness rating, and outlet availability percentage for all venues inside a collection.
- **Visual Dashboard**: Displays a clean, responsive metrics summary block at the top of the collection page.
- **Comparison Tool**: Allows users to select another collection they own (or are a member of) via a dropdown to compare metrics side-by-side.

### Components Created/Modified
- `src/components/collections/MetricsWidget.tsx`: **[NEW]** Reusable component for calculating and displaying collection metrics.
- `src/components/collections/ComparisonTool.tsx`: **[NEW]** Tool handling folder selection and side-by-side metrics rendering.
- `src/app/collections/[id]/page.tsx`: **[MODIFIED]** Integrated the `ComparisonTool` directly below the collection header.

### Screenshot 

<img width="2880" height="1800" alt="Screenshot 2026-07-13 022535" src="https://github.com/user-attachments/assets/2694b9d6-5c4d-4738-b172-0f0f8da85fe4" />

### Validation & Testing
- Verified metrics calculation accuracy (e.g., properly ignores null/missing data fields).
- Validated that the side-by-side comparison successfully fetches and renders secondary folder data.
- Successfully tested UI rendering, responsiveness, and layout behavior in Chrome.

