### PR TITLE
feat(offline): support renaming/deleting conversation history while offline

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -15,6 +15,10 @@ if (typeof global.crypto === 'undefined' || !global.crypto.subtle) {
     configurable: true,
   });
 }
+if (typeof global.structuredClone === 'undefined') {
+  global.structuredClone = (val) => JSON.parse(JSON.stringify(val));
+}
+import 'fake-indexeddb/auto';
 
 // Mock Leaflet global variable L
 global.L = {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.10",
+    "fake-indexeddb": "^6.2.5",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.4.1",
     "tailwindcss": "^4",

--- a/public/sw.js
+++ b/public/sw.js
@@ -128,6 +128,9 @@ self.addEventListener("sync", (event) => {
   if (event.tag === "sync-ratings") {
     event.waitUntil(syncRatings());
   }
+  if (event.tag === "sync-conversations") {
+    event.waitUntil(syncConversations());
+  }
 });
 
 // Helper to convert Uint8Array to base64 for fetch
@@ -215,6 +218,57 @@ async function syncRatings() {
     }
   } catch (error) {
     console.error("Sync ratings failed:", error);
+  }
+}
+
+// Sync queued conversation renames/deletes when back online (issue #266)
+async function syncConversations() {
+  try {
+    const db = await openIndexedDB();
+    const tx = db.transaction("pendingActions", "readonly");
+    const store = tx.objectStore("pendingActions");
+    const allActions = await new Promise((resolve, reject) => {
+      const request = store.getAll();
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => resolve(request.result);
+    });
+
+    const pending = allActions
+      .filter((a) => a.type === "conversation-rename" || a.type === "conversation-delete")
+      .sort((a, b) => a.timestamp - b.timestamp);
+
+    // Defensive de-dupe in case a rename and a later delete for the same
+    // conversation both slipped into the queue (client-side queuing already
+    // guards against this, but the service worker reads independently).
+    const deletedIds = new Set(
+      pending.filter((a) => a.type === "conversation-delete").map((a) => a.conversationId)
+    );
+
+    for (const action of pending) {
+      if (action.type === "conversation-rename" && deletedIds.has(action.conversationId)) {
+        await removePendingAction(db, "pendingActions", action.id);
+        continue;
+      }
+
+      try {
+        const response =
+          action.type === "conversation-delete"
+            ? await fetch(`/api/conversations/${action.conversationId}`, { method: "DELETE" })
+            : await fetch(`/api/conversations/${action.conversationId}`, {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ title: action.title }),
+              });
+
+        if (response.ok) {
+          await removePendingAction(db, "pendingActions", action.id);
+        }
+      } catch (error) {
+        console.error("Failed to sync conversation edit:", error);
+      }
+    }
+  } catch (error) {
+    console.error("Sync conversations failed:", error);
   }
 }
 

--- a/src/__tests__/lib/offlineConversationSync.test.ts
+++ b/src/__tests__/lib/offlineConversationSync.test.ts
@@ -1,0 +1,101 @@
+import "fake-indexeddb/auto";
+
+// Mock navigator.serviceWorker / SyncManager so registerConversationSync's
+// feature-detect branch is exercised without a real service worker.
+Object.defineProperty(global.navigator, "serviceWorker", {
+  value: {
+    ready: Promise.resolve({
+      sync: { register: jest.fn().mockResolvedValue(undefined) },
+    }),
+  },
+  configurable: true,
+});
+(global as any).SyncManager = function SyncManager() {};
+
+import {
+  queueConversationRename,
+  queueConversationDelete,
+  getPendingConversationEdits,
+  applyPendingConversationEdits,
+  flushConversationEditQueue,
+} from "../../lib/offlineStorage";
+
+describe("offline conversation edit queue", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) })) as any;
+  });
+
+  it("queues a rename action", async () => {
+    await queueConversationRename("conv-1", "New Title");
+    const pending = await getPendingConversationEdits();
+    expect(pending).toHaveLength(1);
+    expect(pending[0]).toMatchObject({
+      type: "conversation-rename",
+      conversationId: "conv-1",
+      title: "New Title",
+    });
+  });
+
+  it("collapses repeated renames of the same conversation into the latest one", async () => {
+    await queueConversationRename("conv-2", "First");
+    await queueConversationRename("conv-2", "Second");
+    await queueConversationRename("conv-2", "Third");
+
+    const pending = await getPendingConversationEdits();
+    const renamesForConv2 = pending.filter((a) => a.conversationId === "conv-2");
+    expect(renamesForConv2).toHaveLength(1);
+    expect(renamesForConv2[0].title).toBe("Third");
+  });
+
+  it("drops a pending rename when a delete is queued for the same conversation", async () => {
+    await queueConversationRename("conv-3", "Renamed");
+    await queueConversationDelete("conv-3");
+
+    const pending = await getPendingConversationEdits();
+    const actionsForConv3 = pending.filter((a) => a.conversationId === "conv-3");
+    expect(actionsForConv3).toHaveLength(1);
+    expect(actionsForConv3[0].type).toBe("conversation-delete");
+  });
+
+  it("applies pending edits on top of a server list: renames title and removes deleted items", () => {
+    const serverList = [
+      { id: "a", title: "Old A" },
+      { id: "b", title: "Old B" },
+      { id: "c", title: "Old C" },
+    ];
+    const pendingEdits = [
+      { id: 1, type: "conversation-rename" as const, conversationId: "a", title: "New A", timestamp: 1 },
+      { id: 2, type: "conversation-delete" as const, conversationId: "b", timestamp: 2 },
+    ];
+
+    const merged = applyPendingConversationEdits(serverList, pendingEdits);
+
+    expect(merged).toEqual([
+      { id: "a", title: "New A" },
+      { id: "c", title: "Old C" },
+    ]);
+  });
+
+  it("flushes queued edits to the server and clears the queue on success", async () => {
+    await queueConversationRename("conv-4", "Flushed Title");
+
+    await flushConversationEditQueue();
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/conversations/conv-4",
+      expect.objectContaining({ method: "PATCH" })
+    );
+    const pending = await getPendingConversationEdits();
+    expect(pending.filter((a) => a.conversationId === "conv-4")).toHaveLength(0);
+  });
+
+  it("leaves an action queued if the flush request fails", async () => {
+    global.fetch = jest.fn(() => Promise.resolve({ ok: false, json: () => Promise.resolve({}) })) as any;
+    await queueConversationDelete("conv-5");
+
+    await flushConversationEditQueue();
+
+    const pending = await getPendingConversationEdits();
+    expect(pending.some((a) => a.conversationId === "conv-5")).toBe(true);
+  });
+});

--- a/src/components/EnhancedChatbot.tsx
+++ b/src/components/EnhancedChatbot.tsx
@@ -21,6 +21,11 @@ import {
   saveSearchOffline,
   getSearchOffline,
   getAllSearchesOffline,
+  queueConversationRename,
+  queueConversationDelete,
+  getPendingConversationEdits,
+  applyPendingConversationEdits,
+  flushConversationEditQueue,
 } from "@/lib/offlineStorage";
 
 // Types
@@ -261,7 +266,13 @@ export function EnhancedChatbot({ onMapUpdate, onOpenDetails, onBook, userLocati
       const res = await fetch("/api/conversations");
       if (res.ok) {
         const data = await res.json();
-        setConversations(data.conversations || []);
+        const rawConversations: Conversation[] = data.conversations || [];
+        // Apply any not-yet-synced offline renames/deletes on top of the
+        // server (or SW-cached) list, so a reload while offline — or before
+        // background sync has run — doesn't revert local edits. See #266.
+        const pendingEdits = await getPendingConversationEdits();
+        const merged = applyPendingConversationEdits(rawConversations, pendingEdits);
+        setConversations(merged);
       }
     } catch (e) {
       console.error("Failed to load conversations:", e);
@@ -309,17 +320,65 @@ export function EnhancedChatbot({ onMapUpdate, onOpenDetails, onBook, userLocati
   };
 
   const deleteConversation = async (id: string) => {
+    // Reflect the change in the sidebar immediately regardless of connectivity,
+    // so the UI never feels unresponsive while offline (see #266).
+    setConversations((prev) => prev.filter((c) => c.id !== id));
+    if (currentConversationId === id) {
+      setCurrentConversationId(null);
+      setMessages([]);
+    }
+
+    if (!navigator.onLine) {
+      await queueConversationDelete(id);
+      return;
+    }
+
     try {
-      await fetch(`/api/conversations/${id}`, { method: "DELETE" });
-      await loadConversations();
-      if (currentConversationId === id) {
-        setCurrentConversationId(null);
-        setMessages([]);
-      }
+      const res = await fetch(`/api/conversations/${id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error(`Delete failed with status ${res.status}`);
     } catch (e) {
-      console.error("Failed to delete conversation:", e);
+      console.error("Failed to delete conversation, queuing for retry:", e);
+      await queueConversationDelete(id);
     }
   };
+
+  const renameConversation = async (id: string, title: string) => {
+    const trimmed = title.trim();
+    if (!trimmed) return;
+
+    setConversations((prev) => prev.map((c) => (c.id === id ? { ...c, title: trimmed } : c)));
+
+    if (!navigator.onLine) {
+      await queueConversationRename(id, trimmed);
+      return;
+    }
+
+    try {
+      const res = await fetch(`/api/conversations/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: trimmed }),
+      });
+      if (!res.ok) throw new Error(`Rename failed with status ${res.status}`);
+    } catch (e) {
+      console.error("Failed to rename conversation, queuing for retry:", e);
+      await queueConversationRename(id, trimmed);
+    }
+  };
+
+  // Flush any queued offline conversation edits as soon as connectivity
+  // returns — a foreground fallback alongside the service worker's
+  // Background Sync registration (which some browsers, e.g. Safari, don't
+  // support at all).
+  useEffect(() => {
+    const handleOnline = () => {
+      flushConversationEditQueue().then(() => {
+        if (isSignedIn) loadConversations();
+      });
+    };
+    window.addEventListener("online", handleOnline);
+    return () => window.removeEventListener("online", handleOnline);
+  }, [isSignedIn]);
 
   const startNewChat = () => {
     setCurrentConversationId(null);
@@ -833,6 +892,7 @@ try {
         conversations={conversations}
         onLoadConversation={loadConversation}
         onDeleteConversation={deleteConversation}
+        onRenameConversation={renameConversation}
         roomId={roomId || currentConversationId}
         onShareSession={() => {
           let sessionToShare = roomId || currentConversationId;

--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -21,7 +21,10 @@ import {
     Volume2,
     BarChart3,
     Inbox,
-    Share2
+    Share2,
+    Pencil,
+    Check,
+    X
 } from "lucide-react";
 import { UserButton } from "@clerk/nextjs";
 import { useState } from "react";
@@ -58,6 +61,7 @@ interface ChatHeaderProps {
     conversations: Conversation[];
     onLoadConversation: (id: string) => void;
     onDeleteConversation: (id: string) => void;
+    onRenameConversation: (id: string, title: string) => void;
     onShowBookings: () => void;
     roomId?: string | null;
     onShareSession?: () => void;
@@ -86,11 +90,27 @@ export function ChatHeader({
     conversations,
     onLoadConversation,
     onDeleteConversation,
+    onRenameConversation,
     onShowBookings,
     roomId: _roomId,
     onShareSession
 }: ChatHeaderProps) {
     const [isHubOpen, setIsHubOpen] = useState(false);
+    const [renamingId, setRenamingId] = useState<string | null>(null);
+    const [renameValue, setRenameValue] = useState("");
+
+    const startRenaming = (conv: Conversation) => {
+        setRenamingId(conv.id);
+        setRenameValue(conv.title);
+    };
+
+    const commitRename = (id: string) => {
+        const trimmed = renameValue.trim();
+        if (trimmed) {
+            onRenameConversation(id, trimmed);
+        }
+        setRenamingId(null);
+    };
 
     const getActiveHubName = () => {
         if (!userLocation) return "Global Hubs";
@@ -397,31 +417,67 @@ export function ChatHeader({
                             <div className="divide-y divide-zinc-200 dark:divide-zinc-800">
                                 {conversations.map((conv) => (
                                     <div key={conv.id} className="group flex items-center justify-between p-3 hover:bg-white dark:hover:bg-zinc-800 transition-colors">
-                                        <button
-                                            onClick={() => onLoadConversation(conv.id)}
-                                            className="flex-1 text-left min-w-0"
-                                        >
-                                            <p className="text-[11px] font-bold text-zinc-900 dark:text-zinc-100 truncate uppercase tracking-tight">
-                                                {conv.title}
-                                            </p>
-                                            <p className="text-[9px] text-zinc-500 font-medium">
-                                                {new Date(conv.updatedAt).toLocaleDateString()}
-                                            </p>
-                                        </button>
-                                        <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                                            <button
-                                                onClick={() => onDeleteConversation(conv.id)}
-                                                className="p-1.5 rounded-md text-zinc-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20"
-                                            >
-                                                <Trash2 className="w-3.5 h-3.5" />
-                                            </button>
-                                            <button
-                                                onClick={() => onLoadConversation(conv.id)}
-                                                className="p-1.5 rounded-md text-zinc-400 hover:text-blue-500 hover:bg-blue-50 dark:hover:bg-blue-900/20"
-                                            >
-                                                <ChevronRight className="w-3.5 h-3.5" />
-                                            </button>
-                                        </div>
+                                        {renamingId === conv.id ? (
+                                            <div className="flex-1 flex items-center gap-1.5 min-w-0">
+                                                <input
+                                                    autoFocus
+                                                    value={renameValue}
+                                                    onChange={(e) => setRenameValue(e.target.value)}
+                                                    onKeyDown={(e) => {
+                                                        if (e.key === "Enter") commitRename(conv.id);
+                                                        if (e.key === "Escape") setRenamingId(null);
+                                                    }}
+                                                    onBlur={() => commitRename(conv.id)}
+                                                    className="flex-1 min-w-0 text-[11px] font-bold uppercase tracking-tight bg-white dark:bg-zinc-900 border border-purple-400 rounded px-2 py-1 text-zinc-900 dark:text-zinc-100 outline-none"
+                                                />
+                                                <button
+                                                    onMouseDown={(e) => { e.preventDefault(); commitRename(conv.id); }}
+                                                    className="p-1.5 rounded-md text-zinc-400 hover:text-green-500 hover:bg-green-50 dark:hover:bg-green-900/20"
+                                                >
+                                                    <Check className="w-3.5 h-3.5" />
+                                                </button>
+                                                <button
+                                                    onMouseDown={(e) => { e.preventDefault(); setRenamingId(null); }}
+                                                    className="p-1.5 rounded-md text-zinc-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20"
+                                                >
+                                                    <X className="w-3.5 h-3.5" />
+                                                </button>
+                                            </div>
+                                        ) : (
+                                            <>
+                                                <button
+                                                    onClick={() => onLoadConversation(conv.id)}
+                                                    className="flex-1 text-left min-w-0"
+                                                >
+                                                    <p className="text-[11px] font-bold text-zinc-900 dark:text-zinc-100 truncate uppercase tracking-tight">
+                                                        {conv.title}
+                                                    </p>
+                                                    <p className="text-[9px] text-zinc-500 font-medium">
+                                                        {new Date(conv.updatedAt).toLocaleDateString()}
+                                                    </p>
+                                                </button>
+                                                <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                                                    <button
+                                                        onClick={() => startRenaming(conv)}
+                                                        className="p-1.5 rounded-md text-zinc-400 hover:text-purple-500 hover:bg-purple-50 dark:hover:bg-purple-900/20"
+                                                    >
+                                                        <Pencil className="w-3.5 h-3.5" />
+                                                    </button>
+                                                    <button
+                                                        onClick={() => onDeleteConversation(conv.id)}
+                                                        className="p-1.5 rounded-md text-zinc-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20"
+                                                    >
+                                                        <Trash2 className="w-3.5 h-3.5" />
+                                                    </button>
+                                                    <button
+                                                        onClick={() => onLoadConversation(conv.id)}
+                                                        className="p-1.5 rounded-md text-zinc-400 hover:text-blue-500 hover:bg-blue-50 dark:hover:bg-blue-900/20"
+                                                    >
+                                                        <ChevronRight className="w-3.5 h-3.5" />
+                                                    </button>
+                                                </div>
+                                            </>
+                                        )}
                                     </div>
                                 ))}
                             </div>

--- a/src/lib/offlineStorage.ts
+++ b/src/lib/offlineStorage.ts
@@ -393,6 +393,196 @@ export async function processPendingActions(): Promise<Array<{
 }
 
 /**
+ * Conversation history offline edits (issue #266)
+ *
+ * Renaming/deleting a conversation while offline queues a "conversation-rename"
+ * or "conversation-delete" pendingAction, exactly like favorites/ratings already
+ * do. A Background Sync tag ("sync-conversations") is registered so the service
+ * worker flushes the queue as soon as connectivity returns; `flushConversationEditQueue`
+ * below is a foreground fallback for browsers (Safari/iOS) that don't support the
+ * Background Sync API.
+ */
+
+export interface ConversationEditAction {
+  id: number;
+  type: "conversation-rename" | "conversation-delete";
+  conversationId: string;
+  title?: string;
+  timestamp: number;
+}
+
+/**
+ * Queue a rename. If an earlier queued rename for the same conversation hasn't
+ * synced yet, it's replaced (only the latest title matters) rather than piling
+ * up redundant sync work.
+ */
+export async function queueConversationRename(conversationId: string, title: string): Promise<void> {
+  const database = await initOfflineDB();
+
+  await new Promise<void>((resolve, reject) => {
+    const transaction = database.transaction(["pendingActions"], "readwrite");
+    const store = transaction.objectStore("pendingActions");
+    const request = store.getAll();
+
+    request.onsuccess = () => {
+      const existing = (request.result as ConversationEditAction[]).filter(
+        (a) => a.type === "conversation-rename" && a.conversationId === conversationId
+      );
+      existing.forEach((a) => store.delete(a.id));
+
+      store.add({
+        type: "conversation-rename",
+        conversationId,
+        title,
+        timestamp: Date.now(),
+      });
+    };
+    request.onerror = () => reject(request.error);
+
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error);
+  });
+
+  await registerConversationSync();
+}
+
+/**
+ * Queue a delete. Any pending rename for the same conversation is dropped —
+ * there's no point syncing a title change for a thread that's about to be
+ * deleted anyway.
+ */
+export async function queueConversationDelete(conversationId: string): Promise<void> {
+  const database = await initOfflineDB();
+
+  await new Promise<void>((resolve, reject) => {
+    const transaction = database.transaction(["pendingActions"], "readwrite");
+    const store = transaction.objectStore("pendingActions");
+    const request = store.getAll();
+
+    request.onsuccess = () => {
+      const staleRenames = (request.result as ConversationEditAction[]).filter(
+        (a) => a.type === "conversation-rename" && a.conversationId === conversationId
+      );
+      staleRenames.forEach((a) => store.delete(a.id));
+
+      store.add({
+        type: "conversation-delete",
+        conversationId,
+        timestamp: Date.now(),
+      });
+    };
+    request.onerror = () => reject(request.error);
+
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error);
+  });
+
+  await registerConversationSync();
+}
+
+async function registerConversationSync(): Promise<void> {
+  if ("serviceWorker" in navigator && "SyncManager" in window) {
+    try {
+      const swRegistration = await navigator.serviceWorker.ready;
+      await (swRegistration as any).sync.register("sync-conversations");
+    } catch (err) {
+      console.error("Background Sync registration failed:", err);
+    }
+  }
+}
+
+/**
+ * All queued (not-yet-synced) conversation rename/delete actions, oldest first.
+ */
+export async function getPendingConversationEdits(): Promise<ConversationEditAction[]> {
+  const database = await initOfflineDB();
+
+  return new Promise((resolve, reject) => {
+    const transaction = database.transaction(["pendingActions"], "readonly");
+    const store = transaction.objectStore("pendingActions");
+    const request = store.getAll();
+
+    request.onsuccess = () => {
+      const actions = (request.result as ConversationEditAction[])
+        .filter((a) => a.type === "conversation-rename" || a.type === "conversation-delete")
+        .sort((a, b) => a.timestamp - b.timestamp);
+      resolve(actions);
+    };
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/**
+ * Applies queued rename/delete edits on top of a server-fetched (possibly
+ * stale/cached) conversation list, so a reload while offline — or before the
+ * background sync has fired — still reflects the user's local edits instead
+ * of reverting them.
+ */
+export function applyPendingConversationEdits<T extends { id: string; title: string }>(
+  conversations: T[],
+  pendingEdits: ConversationEditAction[]
+): T[] {
+  const deletedIds = new Set(
+    pendingEdits.filter((a) => a.type === "conversation-delete").map((a) => a.conversationId)
+  );
+  const latestTitleById = new Map<string, string>();
+  for (const edit of pendingEdits) {
+    if (edit.type === "conversation-rename" && edit.title !== undefined) {
+      latestTitleById.set(edit.conversationId, edit.title);
+    }
+  }
+
+  return conversations
+    .filter((c) => !deletedIds.has(c.id))
+    .map((c) => (latestTitleById.has(c.id) ? { ...c, title: latestTitleById.get(c.id)! } : c));
+}
+
+async function removePendingActionById(id: number): Promise<void> {
+  const database = await initOfflineDB();
+
+  return new Promise((resolve, reject) => {
+    const transaction = database.transaction(["pendingActions"], "readwrite");
+    const store = transaction.objectStore("pendingActions");
+    const request = store.delete(id);
+
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/**
+ * Foreground fallback: sends every queued conversation edit to the server and
+ * removes it from the queue on success. Safe to call opportunistically (e.g.
+ * on the browser's `online` event) in addition to the service worker's
+ * Background Sync handler — both simply no-op once the queue is empty.
+ */
+export async function flushConversationEditQueue(): Promise<void> {
+  const pending = await getPendingConversationEdits();
+
+  for (const action of pending) {
+    try {
+      let response: Response;
+      if (action.type === "conversation-delete") {
+        response = await fetch(`/api/conversations/${action.conversationId}`, { method: "DELETE" });
+      } else {
+        response = await fetch(`/api/conversations/${action.conversationId}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title: action.title }),
+        });
+      }
+
+      if (response.ok) {
+        await removePendingActionById(action.id);
+      }
+    } catch (err) {
+      // Still offline or request failed — leave it queued for the next attempt.
+      console.error("Failed to sync conversation edit:", err);
+    }
+  }
+}
+
+/**
  * Clear old cached data
  */
 export async function cleanupOldData(maxAge: number = 7 * 24 * 60 * 60 * 1000): Promise<void> {


### PR DESCRIPTION
## Description

Adds offline support for conversation history edits (rename + delete) — the sidebar no longer errors out when renaming/deleting while offline.

- Renaming/deleting while offline queues the action in the existing `pendingActions` IndexedDB store (same pattern as favorites/ratings).
- Sidebar updates instantly regardless of connectivity — never waits on the network.
- New `sync-conversations` Background Sync tag flushes the queue when connection returns, with a foreground `online`-event fallback for browsers without Background Sync (Safari/iOS).
- Adds inline rename UI to the history sidebar (previously delete-only).
- Queued edits are re-applied on top of the loaded list, so a reload while offline doesn't lose local changes.

## Related Issue

Closes #266

Note: #266 was previously auto-closed by #340, which only contained two unrelated fix commits and not this implementation. Relinking with the actual code here.

## Testing

Added `src/__tests__/lib/offlineConversationSync.test.ts` (queueing, de-duplication, delete-overrides-rename, merge-on-load, flush success/failure). `npx jest` passes with no new failures (3 pre-existing, unrelated React version-mismatch failures in `VenueCard`/`skeleton`/`Map` tests, present on main already).

## Breaking Changes

- [ ] Yes
- [x] No