### PR TITLE
fix: resolve unresolved merge conflict markers in schema.prisma + sync package-lock.json [skip-issue], (e.g. 'Fixes #123') ,'typo' / 'chore' 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.2.10",
+        "fake-indexeddb": "^6.2.5",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.4.1",
         "tailwindcss": "^4",
@@ -12416,6 +12417,16 @@
       "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
       "license": "MIT"
     },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/fast-check": {
       "version": "3.23.2",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
@@ -17255,7 +17266,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,33 +23,19 @@ model User {
   memories           UserMemory[]
   crdtState          Bytes?
   preferencesSummary String?
-<<<<<<< HEAD
-  createdVenues  Venue[]            @relation("VenueCreator")
-  workStatus     WorkBuddyStatus?
-  hostedSessions CoworkingSession[] @relation("SessionHost")
-  sessionRsvps   SessionRsvp[]
-  isAdmin        Boolean            @default(false)
-  flagsReported  FlaggedItem[]
-  adminAuditLogs AdminAuditLog[]
-  ownedFolders   Folder[]           @relation("FolderOwner")
-  folderMemberships FolderMember[]  @relation("FolderMembership")
-  addedFolderVenues FolderVenue[]   @relation("FolderVenueAdder")
+createdVenues     Venue[]            @relation("VenueCreator")
+  workStatus        WorkBuddyStatus?
+  hostedSessions    CoworkingSession[] @relation("SessionHost")
+  sessionRsvps      SessionRsvp[]
+  isAdmin           Boolean            @default(false)
+  flagsReported     FlaggedItem[]
+  adminAuditLogs    AdminAuditLog[]
+  ownedFolders      Folder[]           @relation("FolderOwner")
+  folderMemberships FolderMember[]     @relation("FolderMembership")
+  addedFolderVenues FolderVenue[]      @relation("FolderVenueAdder")
   webhookEndpoints  WebhookEndpoint[]
   phoneNumber       String?
   smsAlertsEnabled  Boolean            @default(false)
-=======
-  createdVenues      Venue[]            @relation("VenueCreator")
-  workStatus         WorkBuddyStatus?
-  hostedSessions     CoworkingSession[] @relation("SessionHost")
-  sessionRsvps       SessionRsvp[]
-  isAdmin            Boolean            @default(false)
-  flagsReported      FlaggedItem[]
-  adminAuditLogs     AdminAuditLog[]
-  ownedFolders       Folder[]           @relation("FolderOwner")
-  folderMemberships  FolderMember[]     @relation("FolderMembership")
-  addedFolderVenues  FolderVenue[]      @relation("FolderVenueAdder")
-  webhookEndpoints   WebhookEndpoint[]
->>>>>>> cb03d98 (feat: add coffee quality filter support)
 }
 
 model Venue {


### PR DESCRIPTION
## Description

`main` is currently broken for anyone who clones/installs it:

1. **`prisma/schema.prisma` had unresolved git conflict markers** committed directly into the `User` model, from a previous merge (`feat: add coffee quality filter support`, `cb03d98`). This makes `prisma generate` fail validation for every fresh install. Resolved by keeping all fields from both sides of the conflict — `phoneNumber` and `smsAlertsEnabled` were only present on one side and would otherwise have been silently dropped.
2. **`package-lock.json` was missing the `fake-indexeddb` entry** added in #343, which makes `npm ci` fail (used by CI and any strict install). Regenerated via `npm install`.

No functional/feature changes — just unblocking installs and CI for everyone.

## Testing

- `npm ci` now succeeds
- `npx prisma generate` now succeeds with zero validation errors
- `npx jest` — all suites pass except the pre-existing, unrelated React 19.2.7/19.2.3 version-mismatch failures already present on `main` (`VenueCard`, `skeleton`, `Map` tests)