### PR TITLE
fix: resolve OSRM router crashes when internet speed is restricted #206

### DIFF
--- a/src/hooks/useMapDirections.ts
+++ b/src/hooks/useMapDirections.ts
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+import { fetchOSRMRoute } from '@/lib/osrmService';
+
+export function useMapDirections() {
+  const [routeData, setRouteData] = useState<any>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const calculateRoute = async (start: { lat: number; lng: number }, end: { lat: number; lng: number }) => {
+    setIsLoading(true);
+    setErrorMessage(null);
+
+    try {
+      const data = await fetchOSRMRoute(start, end);
+      setRouteData(data);
+    } catch (error: any) {
+      console.warn('Routing system intercepted a connection block:', error.message);
+      // Surface the clean text alert cleanly to the UI state overlay
+      setErrorMessage(error.message || 'An unexpected routing error occurred.');
+      setRouteData(null);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { routeData, errorMessage, isLoading, calculateRoute };
+}

--- a/src/lib/osrmService.ts
+++ b/src/lib/osrmService.ts
@@ -1,0 +1,39 @@
+interface RouteCoordinates {
+  lat: number;
+  lng: number;
+}
+
+/**
+ * Fetches routing vectors from the OSRM engine with a strict timeout execution boundary.
+ */
+export async function fetchOSRMRoute(start: RouteCoordinates, end: RouteCoordinates) {
+  // 1. Initialize the AbortController tracking interface
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 5000); // Strict 5-second boundary
+
+  const url = `https://router.project-osrm.org/route/v1/driving/${start.lng},${start.lat};${end.lng},${end.lat}?overview=full&geometries=geojson`;
+
+  try {
+    const response = await fetch(url, { 
+      signal: controller.signal,
+      headers: { 'Accept': 'application/json' }
+    });
+
+    clearTimeout(timeoutId); // Clear timeout instantly upon successful resolution
+
+    if (!response.ok) {
+      throw new Error(`OSRM engine returned invalid status payload: ${response.status}`);
+    }
+
+    return await response.json();
+  } catch (error: any) {
+    clearTimeout(timeoutId);
+
+    // 2. Explicitly catch the Abort Error thrown by the controller signal
+    if (error.name === 'AbortError') {
+      throw new Error('Network latency timeout. Unable to connect to routing servers.');
+    }
+
+    throw error;
+  }
+}


### PR DESCRIPTION
## Description
This PR resolves a critical client-side UI freeze/crash that occurs when requests to the external OSRM routing engine hang indefinitely due to high network latency or thorttled connections (e.g., Slow 3G settings).

An `AbortController` mechanism has been introduced to establish a strict 5-second connection execution limit. When this window is exceeded, the pipeline safely drops the trailing request and sets a localized UI error message state rather than throwing unhandled fatal exceptions.

## Related Issue
Fixes #206

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


## Breaking Changes
- [ ] Yes 
- [x] No