### PR TITLE
fix: resolve real-time event source freezing during battery saving mode #210

### DIFF
--- a/src/app/api/venues/[venueId]/live-stream/route.ts
+++ b/src/app/api/venues/[venueId]/live-stream/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+
+export async function GET(request: Request, { params }: { params: { venueId: string } }) {
+  const responseStream = new TransformStream();
+  const writer = responseStream.writable.getWriter();
+  const encoder = new TextEncoder();
+
+  // 1. Emit an instant validation payload framework connection chunk
+  writer.write(encoder.encode(`data: ${JSON.stringify({ type: 'heartbeat', status: 'initialized' })}\n\n`));
+
+  // 2. Set up an interval loop to dispatch thin keep-alive packets every 15 seconds
+  // This gives the client two chances to catch a ping before passing the 30-second watchdog limit.
+  const heartbeatInterval = setInterval(() => {
+    try {
+      writer.write(encoder.encode(`data: ${JSON.stringify({ type: 'heartbeat' })}\n\n`));
+    } catch (err) {
+      clearInterval(heartbeatInterval);
+    }
+  }, 15000);
+
+  // Clean up the interval background process thread if the connection drops or is closed
+  request.signal.addEventListener('abort', () => {
+    clearInterval(heartbeatInterval);
+    writer.close();
+  });
+
+  return new NextResponse(responseStream.readable, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      'Connection': 'keep-alive',
+    },
+  });
+}

--- a/src/hooks/useRealtimeCapacity.ts
+++ b/src/hooks/useRealtimeCapacity.ts
@@ -1,0 +1,88 @@
+import { useState, useEffect, useRef } from 'react';
+
+export function useRealtimeCapacity(venueId: string) {
+  const [capacity, setCapacity] = useState<number>(0);
+  const [status, setStatus] = useState<'connecting' | 'connected' | 'frozen'>('connecting');
+  
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const heartbeatTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const connectRealtime = () => {
+    // Clean up any stale trailing connections before spinning up a new one
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+    }
+
+    setStatus('connecting');
+    // Initialize the SSE stream endpoint loop
+    const es = new EventSource(`/api/venues/${venueId}/live-stream`);
+    eventSourceRef.current = es;
+
+    // Start monitoring heartbeats immediately on connection opening
+    resetHeartbeatWatchdog();
+
+    es.onmessage = (event) => {
+      // Reset our 30-second watchdog timer every single time we receive a message or ping
+      resetHeartbeatWatchdog();
+      
+      try {
+        const data = JSON.parse(event.data);
+        if (data.type === 'heartbeat') {
+          // It's just a keep-alive ping from the server, keep status connected
+          setStatus('connected');
+          return;
+        }
+        
+        if (data.capacity !== undefined) {
+          setCapacity(data.capacity);
+          setStatus('connected');
+        }
+      } catch (err) {
+        console.error('Error parsing live stream payload matrix:', err);
+      }
+    };
+
+    es.onerror = () => {
+      console.warn('SSE socket dropped or intercepted by OS power throttling. Scheduling reconnect...');
+      setStatus('frozen');
+      es.close();
+      // Wait 5 seconds before attempting a clean retry to avoid spinning out the client loop
+      setTimeout(connectRealtime, 5000);
+    };
+  };
+
+  const resetHeartbeatWatchdog = () => {
+    if (heartbeatTimeoutRef.current) {
+      clearTimeout(heartbeatTimeoutRef.current);
+    }
+
+    // WATCHDOG TIMER: If 30 seconds pass without a single message/heartbeat from the server,
+    // the connection is frozen due to low power mode throttling. Force a reconnect cycle.
+    heartbeatTimeoutRef.current = setTimeout(() => {
+      console.warn(`No heartbeat intercepted for 30s. Connection marked frozen. Forcing reconnect protocol...`);
+      setStatus('frozen');
+      connectRealtime();
+    }, 30000);
+  };
+
+  useEffect(() => {
+    connectRealtime();
+
+    // Reconnect instantly when the app comes back into focus (e.g., screen unlocked)
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        connectRealtime();
+      }
+    };
+
+    window.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      if (eventSourceRef.current) eventSourceRef.current.close();
+      if (heartbeatTimeoutRef.current) clearTimeout(heartbeatTimeoutRef.current);
+      window.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [venueId]);
+
+  return { capacity, status };
+}


### PR DESCRIPTION
## Description
This PR fixes a critical mobile usability issue where mobile operating systems operating in Low Power / Battery Saving Mode silently throttle or freeze Server-Sent Events (SSE) streaming connections without triggering standard socket error listeners.

### Structural Updates
1. **Client-Side Heartbeat Watchdog:** Implemented a 30-second `setTimeout` connection tracker loop inside the custom consumer hook (`useRealtimeCapacity.ts`). If no event traffic is processed before the timer runs out, the socket is assumed frozen and actively cycles into a clean reconnection phase.
2. **Server-Side Keep-Alive Packets:** Configured a safe 15-second recursive ping dispatch thread inside the route endpoint stream array to continuously feed data down connection buffers.
3. **Visibility Interceptor:** Hooked into the browser `visibilitychange` lifecycle to instantly re-prime event pipelines the split-second a user unfolds or unlocks their screen layout.

## Related Issue
Fixes #210

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


## Breaking Changes
- [ ] Yes 
- [x] No