### PR TITLE
fix: debounce Leaflet map resize handling

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -166,6 +166,30 @@ function HeatmapOverlay({ points, visible }: { points: any[]; visible: boolean }
 
   return null;
 }
+function ResizeWatcher({ delay = 150 }: { delay?: number }) {
+  const map = useMap();
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+
+    const handleResize = () => {
+      clearTimeout(timer);
+
+      timer = setTimeout(() => {
+        map.invalidateSize();
+      }, delay);
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      clearTimeout(timer);
+      window.removeEventListener("resize", handleResize);
+    };
+  }, [map, delay]);
+
+  return null;
+}
 
 const Map = ({
   location,
@@ -475,6 +499,7 @@ const Map = ({
         <MapController mapView={mapView} />
         <AutoCenter markers={markers} userLocation={center} />
         <ZoomWatcher onZoomSettled={handleZoomSettled} />
+        <ResizeWatcher />
 
         {customIcon && (
           <Marker position={center} icon={customIcon}>


### PR DESCRIPTION
## Description

This PR improves Leaflet map behavior during browser window resize events by introducing a debounced resize handler.

### Changes Made

- Added a `ResizeWatcher` component to monitor browser resize events.
- Debounced resize handling to avoid excessive map updates during rapid window resizing.
- Called `map.invalidateSize()` after resizing to ensure the Leaflet map recalculates its dimensions correctly.
- Integrated the resize watcher into the existing map lifecycle without affecting current functionality.

## Related Issue

Fixes #276

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

N/A – Internal Leaflet resize handling improvement with no visual UI changes.

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No