### PR TITLE
fix(ui): resolve tailwind color configuration mismatches on dark theme scrollbars (fixes #281)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,6 +42,8 @@ body {
 /* Smooth scrolling */
 html {
   scroll-behavior: smooth;
+  scrollbar-color: var(--color-zinc-300) transparent;
+  scrollbar-width: thin;
 }
 
 /* Gradient animation */
@@ -123,21 +125,25 @@ html {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #d1d5db;
+  background: var(--color-zinc-300);
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #9ca3af;
+  background: var(--color-zinc-400);
 }
 
 @media (prefers-color-scheme: dark) {
+  html {
+    scrollbar-color: var(--color-zinc-700) transparent;
+  }
+
   ::-webkit-scrollbar-thumb {
-    background: #374151;
+    background: var(--color-zinc-700);
   }
 
   ::-webkit-scrollbar-thumb:hover {
-    background: #4b5563;
+    background: var(--color-zinc-600);
   }
 }
 


### PR DESCRIPTION
## Description

This PR addresses the scrollbar color mismatch when the dark theme is active, particularly fixing issues with white scrollbars against dark backgrounds on WebKit browsers and providing proper scrollbar rendering on Firefox.

### Work Done
Defined explicit Firefox scrollbar properties and modified WebKit scrollbar pseudo-elements to use the Zinc color palette variables provided by Tailwind in dark mode.

### Files Modified
- `src/app/globals.css`: Added `scrollbar-color` and `scrollbar-width` to `html`, and updated `::-webkit-scrollbar-thumb` colors for light and dark themes.

### Output / Summary
Scrollbars now seamlessly match the active theme across both Firefox and Chrome/Safari, creating a polished UI experience without jarring bright white scrollbars in dark mode.

## Related Issue

Fixes #281

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

N/A

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No
