### PR TITLE
fix(ui): resolve nextjs server client hydration warnings on responsive sidebar layout (fixes #279)

### DIFF
--- a/src/hooks/usePWA.tsx
+++ b/src/hooks/usePWA.tsx
@@ -12,22 +12,14 @@ interface BeforeInstallPromptEvent extends Event {
  * Hook to register service worker and manage PWA state
  */
 export function useServiceWorker() {
-  const [isInstalled] = useState(() => {
-    // Initialize state from window on first render (SSR safe)
-    if (typeof window !== 'undefined') {
-      return window.matchMedia('(display-mode: standalone)').matches;
-    }
-    return false;
-  });
-  const [isOnline, setIsOnline] = useState(() => {
-    if (typeof window !== 'undefined') {
-      return navigator.onLine;
-    }
-    return true;
-  });
+  const [isInstalled, setIsInstalled] = useState(false);
+  const [isOnline, setIsOnline] = useState(true);
   const [registration, setRegistration] = useState<ServiceWorkerRegistration | null>(null);
 
   useEffect(() => {
+    setIsInstalled(window.matchMedia('(display-mode: standalone)').matches);
+    setIsOnline(navigator.onLine);
+
     // Register service worker
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker


### PR DESCRIPTION
## Description

This PR resolves the NextJS hydration warnings that occur during the initial page load. The issue was caused by initializing state with `window` and `navigator` properties, leading to a mismatch between server-rendered and client-rendered HTML. 

### Work Done
Refactored the `useServiceWorker` hook to use safe defaults for initial state and perform browser API checks within a `useEffect` block.

### Files Modified
- `src/hooks/usePWA.tsx`: Updated `isInstalled` and `isOnline` state initialization logic.

### Output / Summary
The application now renders without hydration mismatch errors, ensuring a stable progressive web app initialization process that correctly evaluates standalone mode and online status post-mount.

## Related Issue

Fixes #279

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

N/A

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No
