### PR TITLE
fix: add legacy Firefox fallback for Tailwind opacity utilities

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -235,4 +235,57 @@ html {
   .border-emerald-400\/20 {
     border-color: rgba(52, 211, 153, 0.2);
   }
+  /* Legacy Firefox fallback for additional Tailwind opacity utilities */
+
+  .bg-zinc-950\/95 {
+    background-color: rgba(9, 9, 11, 0.95);
+  }
+
+  .bg-zinc-900\/50 {
+    background-color: rgba(24, 24, 27, 0.5);
+  }
+
+  .bg-zinc-800\/20 {
+    background-color: rgba(39, 39, 42, 0.2);
+  }
+
+  .bg-zinc-800\/10 {
+    background-color: rgba(39, 39, 42, 0.1);
+  }
+
+  .bg-zinc-50\/50 {
+    background-color: rgba(250, 250, 250, 0.5);
+  }
+
+  .bg-blue-900\/10 {
+    background-color: rgba(30, 58, 138, 0.1);
+  }
+
+  .bg-blue-900\/30 {
+    background-color: rgba(30, 58, 138, 0.3);
+  }
+
+  .bg-black\/90 {
+    background-color: rgba(0, 0, 0, 0.9);
+  }
+
+  .bg-black\/60 {
+    background-color: rgba(0, 0, 0, 0.6);
+  }
+
+  .bg-black\/40 {
+    background-color: rgba(0, 0, 0, 0.4);
+  }
+
+  .border-amber-500\/20 {
+    border-color: rgba(245, 158, 11, 0.2);
+  }
+
+  .border-blue-500\/20 {
+    border-color: rgba(59, 130, 246, 0.2);
+  }
+
+  .border-blue-900\/30 {
+    border-color: rgba(30, 58, 138, 0.3);
+  }
 }


### PR DESCRIPTION
## Description

This PR extends the existing CSS fallback for browsers that do not fully support Tailwind v4's `color-mix()` generated opacity utilities.

It adds explicit `rgba()` fallbacks for additional background and border utility classes used by the Venue Detail dialog and related UI components. These fallbacks help preserve the intended translucent backgrounds and borders on older Firefox versions where `color-mix()` may not render correctly.

## Related Issue

Fixes #327

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

N/A (CSS fallback for browser compatibility)

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visual consistency in older Firefox versions by adding fallback styling for additional background and border opacity utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->