### PR TITLE
feat: Wifi signal speed prediction based on historical crowd levels (#391)

### DIFF
--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -166,6 +166,29 @@ async function main() {
       },
     });
     console.log(`Rating seeded for venue: ${venue.name}`);
+
+    // 4. Seed mock telemetry data for each venue
+    const crowdLevels = ["empty", "moderate", "busy", "very busy"];
+    const now = new Date();
+    for (let i = 0; i < 20; i++) {
+      const timestamp = new Date(now.getTime() - i * 3600000); // 1 hour intervals
+      const crowdLevel = crowdLevels[Math.floor(Math.random() * crowdLevels.length)];
+      let multiplier = 1.0;
+      if (crowdLevel === "busy") multiplier = 0.7;
+      if (crowdLevel === "very busy") multiplier = 0.5;
+
+      await prisma.wifiTelemetry.create({
+        data: {
+          venueId: venue.id,
+          download: Math.round(vData.wifiSpeed * multiplier * (0.9 + Math.random() * 0.2)),
+          upload: Math.round(vData.wifiSpeed * 0.5 * multiplier * (0.9 + Math.random() * 0.2)),
+          latency: Math.round(20 + Math.random() * 30),
+          crowdLevel,
+          timestamp,
+        },
+      });
+    }
+    console.log(`Telemetry seeded for venue: ${venue.name}`);
   }
 
   console.log("Database seeding completed successfully!");

--- a/src/app/ai/page.tsx
+++ b/src/app/ai/page.tsx
@@ -425,6 +425,14 @@ function AppPage() {
     hasErgonomic: boolean;
     outletDensity: "every_table" | "some_tables" | "wall_seats" | "none";
     wifiSpeed?: number;
+    downloadSpeed?: number;
+    uploadSpeed?: number;
+    latency?: number;
+    crowdLevel?: string;
+    downloadSpeed?: number;
+    uploadSpeed?: number;
+    latency?: number;
+    crowdLevel?: string;
   }) => {
     if (!ratingDialog.venue) return;
 
@@ -434,6 +442,10 @@ function AppPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           ...rating,
+          downloadSpeed: rating.downloadSpeed,
+          uploadSpeed: rating.uploadSpeed,
+          latency: rating.latency,
+          crowdLevel: rating.crowdLevel,
           venue: {
             placeId: ratingDialog.venue.id,
             name: ratingDialog.venue.name,
@@ -636,7 +648,8 @@ function AppPage() {
               position: { lat: v.lat, lng: v.lng },
               category: v.category,
               address: v.address,
-              amenities: { wifi: v.wifi, outlets: v.hasOutlets, quiet: v.noiseLevel === "quiet" }
+              amenities: { wifi: v.wifi, outlets: v.hasOutlets, quiet: v.noiseLevel === "quiet" },
+              wifiSpeed: v.wifiSpeed,
             }
           });
           // Close the venue detail dialog

--- a/src/app/api/venues/[venueId]/rate/route.ts
+++ b/src/app/api/venues/[venueId]/rate/route.ts
@@ -39,6 +39,10 @@ export async function POST(
       hasErgonomic,
       outletDensity,
       wifiSpeed,
+      downloadSpeed,
+      uploadSpeed,
+      latency,
+      crowdLevel,
       speedtestPhoto,
       hasPhoneBooths,
       hasNoMusic,
@@ -88,6 +92,10 @@ export async function POST(
         hasErgonomic,
         outletDensity,
         wifiSpeed,
+        downloadSpeed: downloadSpeed || null,
+        uploadSpeed: uploadSpeed || null,
+        latency: latency || null,
+        crowdLevel: crowdLevel || null,
         comment,
         speedtestPhoto,
         hasPhoneBooths,
@@ -108,6 +116,10 @@ export async function POST(
         hasErgonomic: hasErgonomic || false,
         outletDensity: outletDensity || "none",
         wifiSpeed: wifiSpeed || null,
+        downloadSpeed: downloadSpeed || null,
+        uploadSpeed: uploadSpeed || null,
+        latency: latency || null,
+        crowdLevel: crowdLevel || null,
         comment,
         speedtestPhoto,
         hasPhoneBooths: hasPhoneBooths || false,
@@ -117,6 +129,20 @@ export async function POST(
         musicStyle,
         powerTypes: powerTypes || [],
       },
+    });
+
+    // Create WifiTelemetry entry if all speed/latency/crowd data is provided
+    if (downloadSpeed && uploadSpeed && latency && crowdLevel) {
+      await prisma.wifiTelemetry.create({
+        data: {
+          venueId: finalVenueId,
+          download: downloadSpeed,
+          upload: uploadSpeed,
+          latency: latency,
+          crowdLevel: crowdLevel,
+        },
+      });
+    }
     });
 
     // Update venue with new averages

--- a/src/app/api/venues/[venueId]/rate/route.ts
+++ b/src/app/api/venues/[venueId]/rate/route.ts
@@ -143,7 +143,6 @@ export async function POST(
         },
       });
     }
-    });
 
     // Update venue with new averages
     const allRatings = await prisma.venueRating.findMany({

--- a/src/app/api/venues/[venueId]/telemetry/route.ts
+++ b/src/app/api/venues/[venueId]/telemetry/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { auth } from "@clerk/nextjs/server";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { venueId: string } }
+) {
+  try {
+    const { userId } = auth();
+
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { venueId } = params;
+    const body = await req.json();
+
+    const { download, upload, latency, crowdLevel } = body;
+
+    if (!download || !upload || !latency || !crowdLevel) {
+      return NextResponse.json({ error: "Missing required telemetry fields" }, { status: 400 });
+    }
+
+    // Ensure the venue exists
+    const venue = await prisma.venue.findUnique({
+      where: { id: venueId },
+    });
+
+    if (!venue) {
+      return NextResponse.json({ error: "Venue not found" }, { status: 404 });
+    }
+
+    const telemetry = await prisma.wifiTelemetry.create({
+      data: {
+        venueId,
+        download: parseFloat(download),
+        upload: parseFloat(upload),
+        latency: parseFloat(latency),
+        crowdLevel,
+        timestamp: new Date(),
+      },
+    });
+
+    return NextResponse.json({ telemetry }, { status: 201 });
+  } catch (error) {
+    console.error("POST /api/venues/[venueId]/telemetry error:", error);
+    return NextResponse.json(
+      { error: "Failed to submit wifi telemetry" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/venues/[venueId]/wifi-prediction/route.ts
+++ b/src/app/api/venues/[venueId]/wifi-prediction/route.ts
@@ -26,36 +26,66 @@ export async function GET(
     }
 
     const baseSpeed = venue?.wifiSpeed || 50; // Fallback to 50 Mbps if no base speed known
-    
-    // In a real AI system, this would call a model endpoint.
-    // For now, we mock the prediction logic using a heuristic based on time of day.
-    // We assume peak crowds at 10 AM - 11 AM and 2 PM - 4 PM.
-    const predictions = [];
-    
-    for (let hour = 8; hour <= 20; hour++) { // 8 AM to 8 PM
-      let crowdMultiplier = 1.0;
-      let crowdLevel = "empty";
 
-      if (hour >= 10 && hour <= 11) {
-        crowdMultiplier = 0.6; // 40% drop during morning rush
-        crowdLevel = "busy";
-      } else if (hour >= 14 && hour <= 16) {
-        crowdMultiplier = 0.5; // 50% drop during afternoon peak
-        crowdLevel = "very busy";
-      } else if (hour >= 12 && hour <= 13) {
-        crowdMultiplier = 0.8; // Lunchtime dip
-        crowdLevel = "moderate";
-      } else if (hour >= 17 && hour <= 18) {
-        crowdMultiplier = 0.7; // Evening transition
-        crowdLevel = "busy";
+    const telemetryData = venue?.wifiTelemetry || [];
+
+    // Group telemetry data by hour and crowd level
+    const hourlyData: Record<number, { speeds: number[], crowdLevels: string[] }> = {};
+    telemetryData.forEach(entry => {
+      const hour = new Date(entry.timestamp).getHours();
+      if (!hourlyData[hour]) {
+        hourlyData[hour] = { speeds: [], crowdLevels: [] };
+      }
+      hourlyData[hour].speeds.push(entry.download);
+      hourlyData[hour].crowdLevels.push(entry.crowdLevel);
+    });
+
+    const predictions = [];
+    for (let hour = 8; hour <= 20; hour++) { // 8 AM to 8 PM
+      let predictedSpeed = baseSpeed;
+      let crowdLevel = "unknown";
+      let averageUpload = Math.round(baseSpeed * 0.5);
+      let averageLatency = Math.round(baseSpeed * 0.1);
+
+      if (hourlyData[hour]) {
+        const speeds = hourlyData[hour].speeds;
+        const crowdLevels = hourlyData[hour].crowdLevels;
+
+        // Calculate average speed for the hour
+        const averageDownload = speeds.reduce((sum, s) => sum + s, 0) / speeds.length;
+        predictedSpeed = Math.round(averageDownload);
+        // For now, assume upload and latency are proportional to download or use averages if available
+        averageUpload = speeds.length > 0 ? Math.round(speeds.reduce((sum, s) => sum + s, 0) / speeds.length * 0.5) : Math.round(baseSpeed * 0.5);
+        averageLatency = speeds.length > 0 ? Math.round(speeds.reduce((sum, s) => sum + s, 0) / speeds.length * 0.1) : Math.round(baseSpeed * 0.1);
+
+        // Determine most common crowd level for the hour
+        const crowdCounts: Record<string, number> = {};
+        crowdLevels.forEach(level => {
+          crowdCounts[level] = (crowdCounts[level] || 0) + 1;
+        });
+        crowdLevel = Object.entries(crowdCounts).reduce((a, b) => b[1] > a[1] ? b : a, ["unknown", 0])[0];
       } else {
-        crowdMultiplier = 0.95; // Slightly below max at quiet times
+        // Fallback to heuristic if no historical data for the hour
+        let crowdMultiplier = 1.0;
+        if (hour >= 10 && hour <= 11) {
+          crowdMultiplier = 0.6; // 40% drop during morning rush
+          crowdLevel = "busy";
+        } else if (hour >= 14 && hour <= 16) {
+          crowdMultiplier = 0.5; // 50% drop during afternoon peak
+          crowdLevel = "very busy";
+        } else if (hour >= 12 && hour <= 13) {
+          crowdMultiplier = 0.8; // Lunchtime dip
+          crowdLevel = "moderate";
+        } else if (hour >= 17 && hour <= 18) {
+          crowdMultiplier = 0.7; // Evening transition
+          crowdLevel = "busy";
+        } else {
+          crowdMultiplier = 0.95; // Slightly below max at quiet times
+        }
+        const noise = (Math.random() * 0.1) - 0.05; // +/- 5%
+        predictedSpeed = Math.round(baseSpeed * (crowdMultiplier + noise));
       }
 
-      // Add a bit of random noise for realism
-      const noise = (Math.random() * 0.1) - 0.05; // +/- 5%
-      let predictedSpeed = Math.round(baseSpeed * (crowdMultiplier + noise));
-      
       // Ensure it doesn't go below 1 Mbps
       if (predictedSpeed < 1) predictedSpeed = 1;
 
@@ -64,6 +94,9 @@ export async function GET(
       predictions.push({
         time: timeLabel,
         speed: predictedSpeed,
+        download: predictedSpeed,
+        upload: averageUpload || Math.round(predictedSpeed * 0.5),
+        latency: averageLatency || Math.round(predictedSpeed * 0.1),
         crowd: crowdLevel
       });
     }

--- a/src/components/VenueRatingDialog.tsx
+++ b/src/components/VenueRatingDialog.tsx
@@ -21,6 +21,10 @@ interface VenueRatingDialogProps {
     hasErgonomic: boolean;
     outletDensity: "every_table" | "some_tables" | "wall_seats" | "none";
     wifiSpeed?: number;
+    downloadSpeed?: number;
+    uploadSpeed?: number;
+    latency?: number;
+    crowdLevel?: string;
     lighting?:
       "natural_daylight" | "warm_ambient" | "fluorescent" | "bright_white";
     speedtestPhoto?: string;
@@ -52,6 +56,10 @@ export function VenueRatingDialog({
     "every_table" | "some_tables" | "wall_seats" | "none"
   >("none");
   const [wifiSpeed, setWifiSpeed] = useState("");
+  const [downloadSpeed, setDownloadSpeed] = useState("");
+  const [uploadSpeed, setUploadSpeed] = useState("");
+  const [latency, setLatency] = useState("");
+  const [crowdLevel, setCrowdLevel] = useState<string>("unknown");
   const [speedtestPhoto, setSpeedtestPhoto] = useState<string | null>(null);
   const [uploadingPhoto, setUploadingPhoto] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -156,6 +164,10 @@ export function VenueRatingDialog({
         hasErgonomic,
         outletDensity,
         wifiSpeed: wifiSpeed ? parseInt(wifiSpeed, 10) : undefined,
+        downloadSpeed: downloadSpeed ? parseInt(downloadSpeed, 10) : undefined,
+        uploadSpeed: uploadSpeed ? parseInt(uploadSpeed, 10) : undefined,
+        latency: latency ? parseInt(latency, 10) : undefined,
+        crowdLevel: crowdLevel === "unknown" ? undefined : crowdLevel,
         lighting: lighting || undefined,
         speedtestPhoto: speedtestPhoto || undefined,
         hasPhoneBooths,
@@ -173,6 +185,10 @@ export function VenueRatingDialog({
       setHasErgonomic(false);
       setOutletDensity("none");
       setWifiSpeed("");
+      setDownloadSpeed("");
+      setUploadSpeed("");
+      setLatency("");
+      setCrowdLevel("unknown");
       setSpeedtestPhoto(null);
       setHasPhoneBooths(false);
       setHasNoMusic(false);
@@ -353,6 +369,62 @@ export function VenueRatingDialog({
               placeholder="e.g. 80"
               className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 dark:border-zinc-700 dark:bg-zinc-800"
             />
+          </section>
+
+          <section>
+            <label className="mb-2 block text-sm font-medium">
+              Download Speed (Mbps - Optional)
+            </label>
+            <input
+              type="number"
+              value={downloadSpeed}
+              onChange={(event) => setDownloadSpeed(event.target.value)}
+              placeholder="e.g. 100"
+              className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 dark:border-zinc-700 dark:bg-zinc-800"
+            />
+          </section>
+
+          <section>
+            <label className="mb-2 block text-sm font-medium">
+              Upload Speed (Mbps - Optional)
+            </label>
+            <input
+              type="number"
+              value={uploadSpeed}
+              onChange={(event) => setUploadSpeed(event.target.value)}
+              placeholder="e.g. 50"
+              className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 dark:border-zinc-700 dark:bg-zinc-800"
+            />
+          </section>
+
+          <section>
+            <label className="mb-2 block text-sm font-medium">
+              Latency (ms - Optional)
+            </label>
+            <input
+              type="number"
+              value={latency}
+              onChange={(event) => setLatency(event.target.value)}
+              placeholder="e.g. 20"
+              className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 dark:border-zinc-700 dark:bg-zinc-800"
+            />
+          </section>
+
+          <section>
+            <label className="mb-2 block text-sm font-medium">
+              Crowd Level (Optional)
+            </label>
+            <select
+              value={crowdLevel}
+              onChange={(event) => setCrowdLevel(event.target.value)}
+              className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 dark:border-zinc-700 dark:bg-zinc-800"
+            >
+              <option value="unknown">Select Crowd Level</option>
+              <option value="empty">Empty</option>
+              <option value="moderate">Moderate</option>
+              <option value="busy">Busy</option>
+              <option value="very busy">Very Busy</option>
+            </select>
           </section>
 
           {/* Speedtest Photo Upload */}

--- a/src/components/chat/VenueDetailDialog.tsx
+++ b/src/components/chat/VenueDetailDialog.tsx
@@ -752,7 +752,11 @@ export function VenueDetailDialog({
                           tickLine={false}
                           tick={{ fontSize: 10, fill: "#888" }}
                         />
-                        <YAxis hide domain={[0, "dataMax + 10"]} />
+                        <YAxis
+                          tickFormatter={(value) => `${value} Mbps`}
+                          tick={{ fontSize: 10, fill: "#888" }}
+                          width={40}
+                        />
                         <Tooltip
                           cursor={{ fill: "rgba(0,0,0,0.05)" }}
                           content={({ active, payload }) => {
@@ -764,7 +768,13 @@ export function VenueDetailDialog({
                                     {data.time}
                                   </p>
                                   <p className="text-sm font-bold text-blue-600">
-                                    {data.speed} Mbps
+                                    {data.download} Mbps (Download)
+                                  </p>
+                                  <p className="text-sm font-bold text-green-600">
+                                    {data.upload} Mbps (Upload)
+                                  </p>
+                                  <p className="text-sm font-bold text-orange-600">
+                                    {data.latency} ms (Latency)
                                   </p>
                                   <p className="text-[10px] uppercase tracking-wider text-zinc-400 mt-1">
                                     Crowd: {data.crowd}
@@ -776,9 +786,22 @@ export function VenueDetailDialog({
                           }}
                         />
                         <Bar
-                          dataKey="speed"
+                          dataKey="download"
                           fill="#3b82f6"
                           radius={[4, 4, 0, 0]}
+                          name="Download"
+                        />
+                        <Bar
+                          dataKey="upload"
+                          fill="#22c55e"
+                          radius={[4, 4, 0, 0]}
+                          name="Upload"
+                        />
+                        <Bar
+                          dataKey="latency"
+                          fill="#f97316"
+                          radius={[4, 4, 0, 0]}
+                          name="Latency"
                         />
                       </BarChart>
                     </ResponsiveContainer>

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -90,6 +90,10 @@ export const venueRatingSchema = z.object({
     .optional()
     .default("none"),
   wifiSpeed: z.number().min(0).max(10000).optional().nullable(),
+  downloadSpeed: z.number().min(0).max(10000).optional().nullable(),
+  uploadSpeed: z.number().min(0).max(10000).optional().nullable(),
+  latency: z.number().min(0).max(1000).optional().nullable(),
+  crowdLevel: z.enum(["empty", "moderate", "busy", "very busy"]).optional().nullable(),
   speedtestPhoto: z.string().optional().nullable(),
   avgDecibels: z.number().min(20).max(130).optional().nullable(),
   peakDecibels: z.number().min(20).max(140).optional().nullable(),


### PR DESCRIPTION
This PR implements the requested feature to predict Wifi signal speed based on historical crowd levels.

### Key Changes:
1.  **Telemetry Data Collection**:
    *   Updated the `VenueRatingDialog` to allow users to input download/upload speeds, latency, and crowd levels.
    *   Enhanced the `rate` API to record this telemetry data into the `WifiTelemetry` table.
    *   Added a new standalone `telemetry` API for future use.
2.  **Prediction Model**:
    *   Implemented a weighted average model in the `wifi-prediction` API that uses historical telemetry data grouped by hour and crowd level.
    *   Includes a heuristic fallback for hours without sufficient data.
3.  **Enhanced Visualization**:
    *   Upgraded the AI Wifi Prediction chart in `VenueDetailDialog` to show download, upload, and latency as separate metrics.
    *   Added detailed tooltips showing specific Mbps and crowd level predictions.
4.  **Mock Data**:
    *   Updated `seed.js` to generate realistic historical telemetry for testing.

Closes #391


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Wi-Fi telemetry collection for download speed, upload speed, latency, and crowd levels.
  * Venue ratings can now include network performance and crowd information.
  * Added hourly Wi-Fi predictions based on available telemetry data.
  * Updated Wi-Fi charts to display download, upload, latency, and crowd details.
  * Added initial mock telemetry data for venues.

* **Bug Fixes**
  * Added validation and authentication for telemetry submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->