### PR TITLE
fix: resolve unique key collisions on concurrent database RSVPs (#400)

### DIFF
--- a/src/app/api/social/sessions/[slug]/rsvp/route.ts
+++ b/src/app/api/social/sessions/[slug]/rsvp/route.ts
@@ -58,20 +58,37 @@ export async function POST(
     }
   }
 
-  const rsvp = await prisma.sessionRsvp.upsert({
-    where: {
-      sessionId_userId: {
+  try {
+    const rsvp = await prisma.sessionRsvp.upsert({
+      where: {
+        sessionId_userId: {
+          sessionId: session.id,
+          userId,
+        },
+      },
+      update: { status: status as "GOING" | "MAYBE" | "DECLINED" },
+      create: {
         sessionId: session.id,
         userId,
+        status: status as "GOING" | "MAYBE" | "DECLINED",
       },
-    },
-    update: { status: status as "GOING" | "MAYBE" | "DECLINED" },
-    create: {
-      sessionId: session.id,
-      userId,
-      status: status as "GOING" | "MAYBE" | "DECLINED",
-    },
-  });
+    });
 
-  return NextResponse.json(rsvp);
+    return NextResponse.json(rsvp);
+  } catch (error: any) {
+    // Handle concurrent insert collisions by falling back to update
+    if (error.code === "P2002") {
+      const rsvp = await prisma.sessionRsvp.update({
+        where: {
+          sessionId_userId: {
+            sessionId: session.id,
+            userId,
+          },
+        },
+        data: { status: status as "GOING" | "MAYBE" | "DECLINED" },
+      });
+      return NextResponse.json(rsvp);
+    }
+    throw error;
+  }
 }


### PR DESCRIPTION
### 📝 PR fix #400: Unique Key Collisions on Concurrent Database RSVPs

#### **🔍 Summary**
Resolves a database error (unique constraint violation code \P2002\) that occurs when two users RSVP to a session at the exact same millisecond. Since the standard upsert checks if a record exists and inserts if it does not, a race condition causes both to try and insert, triggering database driver constraint failures. This fix wraps the upsert in a try/catch, falling back to a direct update if a unique collision is encountered.

#### **🛠️ Technical Changes**
* **File Modified:** [src/app/api/social/sessions/[slug]/rsvp/route.ts](file:///t:/Code/PROJECTS/Open%20Source%20ECSOC/WorkSphere/src/app/api/social/sessions/%5Bslug%5D/rsvp/route.ts)
* **Concurrency Fix:** Wrapped \prisma.sessionRsvp.upsert\ in a \	ry/catch\ block.
* **Fallback Resolution:** On catching Prisma \P2002\ (unique constraint violation), execute \prisma.sessionRsvp.update\ to safely overwrite/update the record that was concurrently inserted.

#### **🧪 Verification Steps**
1. Send concurrent POST requests to \/api/social/sessions/[slug]/rsvp\ for the same user-session record.
2. Verify that both requests complete successfully (HTTP 200) and no 500 error logs or database driver constraint violations are thrown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RSVP reliability during simultaneous requests.
  * Prevented certain duplicate RSVP errors from being surfaced to users.
  * Ensured the latest RSVP status is returned after a recovered update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->