### PR TITLE
fix: prevent map pin cluster marker overlap during zoom animations on iOS Safari (#396)

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -428,6 +428,10 @@ const Map = ({
       <style
         dangerouslySetInnerHTML={{
           __html: `
+        /* Webkit/iOS Safari hardware acceleration fixes to prevent overlapping/jitter during zoom animations */
+        .leaflet-marker-icon, .leaflet-pane {
+          will-change: transform;
+        }
         .custom-user-marker {
           /* This container itself doesn't need styles */
         }


### PR DESCRIPTION
### 📝 PR fix #396: Map Pin Cluster Overlap During Zoom Animations on iOS Safari

#### **🔍 Summary**
Resolves a rendering issue where zoom transitions on Leaflet map markers on iOS Safari cause marker cluster bounds to calculate incorrectly or lag behind animation frames, resulting in overlapping UI layouts during pinch-zoom. This fix applies WebKit hardware acceleration to the map panes and marker icons, prompting Safari to promote them to separate compositor layers.

#### **🛠️ Technical Changes**
* **File Modified:** [src/components/Map.tsx](file:///t:/Code/PROJECTS/Open%20Source%20ECSOC/WorkSphere/src/components/Map.tsx)
* **CSS Optimization:** Added \will-change: transform\ to \.leaflet-marker-icon\ and \.leaflet-pane\ within the inline \<style>\ block to ensure hardware acceleration is active without overriding Leaflet's dynamic coordinate translation properties.

#### **🧪 Verification Steps**
1. Open the Leaflet map on iPhone Safari or simulating Safari iOS.
2. Pinch-zoom or double-tap to zoom into a high-density cluster of venue pins.
3. Observe smooth zoom transitions with no layout synchronization delays or overlapping markers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map marker and layer stability during zoom animations on WebKit and iOS devices.
  * Reduced visual overlap and jitter when interacting with the map.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->