### PR TITLE
feat: collaborative workspace folders guest invitation links with 48 h…

### DIFF
--- a/src/app/api/folders/[id]/invites/route.ts
+++ b/src/app/api/folders/[id]/invites/route.ts
@@ -7,7 +7,7 @@ import crypto from "crypto";
 // POST /api/folders/[id]/invites - Generate or regenerate invite token
 export async function POST(
   req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
     const { userId } = await auth();
@@ -22,10 +22,14 @@ export async function POST(
       return NextResponse.json({ error: "Folder not found" }, { status: 404 });
     }
     if (!hasAccess || (role !== "OWNER" && role !== "EDITOR")) {
-      return NextResponse.json({ error: "Forbidden. Only owner or editor can generate invites." }, { status: 403 });
+      return NextResponse.json(
+        { error: "Forbidden. Only owner or editor can generate invites." },
+        { status: 403 },
+      );
     }
 
-    const inviteToken = crypto.randomBytes(16).toString("hex");
+    const timestamp = Date.now();
+    const inviteToken = `${crypto.randomBytes(16).toString("hex")}_${timestamp}`;
 
     const updatedFolder = await prisma.folder.update({
       where: { id },
@@ -37,7 +41,7 @@ export async function POST(
     console.error(`POST /api/folders/invites error:`, error);
     return NextResponse.json(
       { error: "Failed to generate invite token" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/src/app/api/folders/join/route.ts
+++ b/src/app/api/folders/join/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { prisma } from "@/lib/prisma";
 import { z } from "zod";
+import { ensureUserExists } from "@/lib/auth";
 
 const joinSchema = z.object({
   token: z.string(),
@@ -15,11 +16,17 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
+    // Ensure the guest user exists in the local database to avoid foreign key violations
+    await ensureUserExists(userId);
+
     const body = await req.json();
     const validation = joinSchema.safeParse(body);
-    
+
     if (!validation.success) {
-      return NextResponse.json({ error: "Invalid token format" }, { status: 400 });
+      return NextResponse.json(
+        { error: "Invalid token format" },
+        { status: 400 },
+      );
     }
 
     const { token } = validation.data;
@@ -30,13 +37,30 @@ export async function POST(req: NextRequest) {
     });
 
     if (!folder) {
-      return NextResponse.json({ error: "Invalid or expired invite token" }, { status: 404 });
+      return NextResponse.json(
+        { error: "Invalid or expired invite token" },
+        { status: 404 },
+      );
+    }
+
+    // Check validity timestamp (48 hours validity)
+    const parts = token.split("_");
+    const timestamp = Number(parts[parts.length - 1]);
+    const fortyEightHours = 48 * 60 * 60 * 1000;
+    if (isNaN(timestamp) || Date.now() - timestamp > fortyEightHours) {
+      return NextResponse.json(
+        { error: "Invalid or expired invite token" },
+        { status: 410 },
+      );
     }
 
     // Check if already a member
-    const existingMember = folder.members.find(m => m.userId === userId);
+    const existingMember = folder.members.find((m) => m.userId === userId);
     if (existingMember) {
-       return NextResponse.json({ message: "Already a member", folderId: folder.id }, { status: 200 });
+      return NextResponse.json(
+        { message: "Already a member", folderId: folder.id },
+        { status: 200 },
+      );
     }
 
     // Add user as member
@@ -45,15 +69,18 @@ export async function POST(req: NextRequest) {
         folderId: folder.id,
         userId: userId,
         role: "MEMBER",
-      }
+      },
     });
 
-    return NextResponse.json({ success: true, folderId: folder.id }, { status: 200 });
+    return NextResponse.json(
+      { success: true, folderId: folder.id },
+      { status: 200 },
+    );
   } catch (error) {
     console.error("POST /api/folders/join error:", error);
     return NextResponse.json(
       { error: "Failed to join folder" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }


### PR DESCRIPTION
## 🔍 Summary
Enables workspace folder owners to generate dynamic invitation links (valid for 48 hours) to let other users join the folder as members instantly. This PR implements secure invite tokens embedded with creation timestamps for expiration checking and fixes joining failures for newly registered guest users who do not yet have a record in the local database.

## 🛠️ Technical Changes
Timestamped Token Generation: Modified 

src/app/api/folders/[id]/invites/route.ts
 to append the current timestamp to the generated token (randomHex_timestamp).
Validity Checking: Updated the join route 

src/app/api/folders/join/route.ts
 to parse the timestamp and reject invitation tokens older than 48 hours with an HTTP 410 Gone status.
Guest Registration Protection: Added ensureUserExists(userId) from @/lib/auth right after the auth check in the join route, preventing database foreign key constraint failures when newly signed-up guests join.


## 🧪 Verification Steps
Generate an invite link for a folder from the collections detail page.
Sign in as a different user (or newly created test user) and visit /collections/join?token=XYZ with the token.
Verify the user is successfully linked, registered in the local DB, and added as a folder member.
Manually modify a token timestamp to simulate a token older than 48 hours, try to join, and verify it is rejected as expired

closes #421  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invitation tokens now expire after 48 hours.
  * Joining with an expired invitation displays a distinct expiration response.
  * New users are automatically set up before joining a folder.

* **Bug Fixes**
  * Improved access-denied messaging when creating invitations.
  * Invalid invitation tokens now return a clearer not-found response.
  * Preserved existing handling for users who are already members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->