### PR TITLE
fix: resolve signup resend OTP CSRF validation failure on session expiration (closes #393)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3118,7 +3118,7 @@
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
       "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.61.1"
@@ -8759,6 +8759,27 @@
         "tailwindcss": "4.3.2"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -8824,6 +8845,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -9130,7 +9159,6 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -9140,7 +9168,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -9150,7 +9178,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
@@ -11632,6 +11659,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "17.4.2",
@@ -16399,6 +16434,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -17605,7 +17651,7 @@
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
       "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.61.1"
@@ -17624,7 +17670,7 @@
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
       "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -17772,6 +17818,44 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/printable-characters": {
       "version": "1.0.42",
@@ -20001,7 +20085,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/src/__tests__/lib/useCsrfToken.test.tsx
+++ b/src/__tests__/lib/useCsrfToken.test.tsx
@@ -1,0 +1,80 @@
+import { useCsrfToken } from "@/hooks/useCsrfToken";
+import { renderHook } from "@testing-library/react";
+
+// Mock i18next
+jest.mock("i18next", () => ({
+  on: jest.fn(),
+  off: jest.fn(),
+}));
+
+describe("useCsrfToken fetch interceptor auto-retry", () => {
+  let originalFetch: typeof window.fetch;
+
+  beforeAll(() => {
+    originalFetch = window.fetch;
+  });
+
+  afterAll(() => {
+    window.fetch = originalFetch;
+  });
+
+  it("automatically refreshes CSRF token and retries a failed mutating request", async () => {
+    let csrfTokenCallCount = 0;
+    let mainCallCount = 0;
+
+    window.fetch = jest.fn().mockImplementation(async (input: any, init: any) => {
+      const url = typeof input === "string" ? input : input.url;
+
+      if (url.includes("/api/auth/csrf-token")) {
+        csrfTokenCallCount++;
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ csrfToken: `new-csrf-token-${csrfTokenCallCount}` }),
+        };
+      }
+
+      if (url.includes("/api/test-mutation")) {
+        mainCallCount++;
+        if (mainCallCount === 1) {
+          // First attempt fails with 403 CSRF validation error
+          return {
+            ok: false,
+            status: 403,
+            clone: function () {
+              return this;
+            },
+            json: async () => ({ error: "CSRF validation failed." }),
+          };
+        } else {
+          // Second attempt (retry) succeeds
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              success: true,
+              receivedToken: init.headers.get("x-csrf-token"),
+            }),
+          };
+        }
+      }
+
+      return { ok: true, status: 200 };
+    }) as any;
+
+    // Render hook to register fetch interceptor
+    renderHook(() => useCsrfToken());
+
+    // Trigger initial mutation request
+    const response = await fetch("/api/test-mutation", {
+      method: "POST",
+      body: JSON.stringify({ data: "test" }),
+    });
+
+    const data = await response.json();
+    expect(data.success).toBe(true);
+    expect(data.receivedToken).toBe("new-csrf-token-2");
+    expect(csrfTokenCallCount).toBe(2); // Initial load + 403 refresh load
+    expect(mainCallCount).toBe(2); // Initial attempt + retry attempt
+  });
+});

--- a/src/hooks/useCsrfToken.ts
+++ b/src/hooks/useCsrfToken.ts
@@ -36,16 +36,36 @@ function installCsrfFetchInterceptor() {
 
   const originalFetch = window.fetch.bind(window);
 
-  window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+  window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === "string" || input instanceof URL ? input.toString() : input.url;
-    const method = (init?.method || (input instanceof Request ? input.method : "GET")).toUpperCase();
+    const isInputRequest = typeof Request !== "undefined" && input instanceof Request;
+    const method = (init?.method || (isInputRequest ? input.method : "GET")).toUpperCase();
     const isMutating = ["POST", "PUT", "PATCH", "DELETE"].includes(method);
     const isSameOriginApi = url.startsWith("/api") || url.startsWith(`${window.location.origin}/api`);
 
-    if (isMutating && isSameOriginApi && currentCsrfToken) {
-      const headers = new Headers(init?.headers ?? (input instanceof Request ? input.headers : undefined));
-      headers.set(CSRF_HEADER_NAME, currentCsrfToken);
-      return originalFetch(input, { ...init, headers });
+    if (isMutating && isSameOriginApi) {
+      const headers = new Headers(init?.headers ?? (isInputRequest ? input.headers : undefined));
+      if (currentCsrfToken) {
+        headers.set(CSRF_HEADER_NAME, currentCsrfToken);
+      }
+      const response = await originalFetch(input, { ...init, headers });
+      if (response.status === 403) {
+        const clone = response.clone();
+        try {
+          const body = await clone.json();
+          if (body && body.error && body.error.toLowerCase().includes("csrf")) {
+            const freshToken = await fetchFreshToken();
+            if (freshToken) {
+              const retryHeaders = new Headers(init?.headers ?? (isInputRequest ? input.headers : undefined));
+              retryHeaders.set(CSRF_HEADER_NAME, freshToken);
+              return originalFetch(input, { ...init, headers: retryHeaders });
+            }
+          }
+        } catch {
+          // Response was not JSON or did not have CSRF error
+        }
+      }
+      return response;
     }
 
     return originalFetch(input, init);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -14,6 +14,10 @@ const isPublicRoute = createRouteMatcher([
   "/sign-up(.*)",
   "/api/webhook(.*)",
   "/api/auth/csrf-token",
+  "/api/auth/resend-otp",
+  "/api/auth/verify-otp",
+  "/api/auth/forgot-password",
+  "/api/auth/reset-password",
   "/privacy(.*)",
   "/terms(.*)",
 ]);


### PR DESCRIPTION
Fixes #393.

### Summary of Changes:
1. **Clerk Public Routes Matcher**: Whitelisted `/api/auth/resend-otp`, `/api/auth/verify-otp`, `/api/auth/forgot-password`, and `/api/auth/reset-password` inside `middleware.ts` to prevent Clerk middleware from rejecting them during unauthenticated user scenarios (e.g. signup OTP validation & password resets).
2. **Auto-refresh and Retry Interceptor**: Upgraded `installCsrfFetchInterceptor` in `useCsrfToken.ts` to catch `403 Forbidden` CSRF validation errors, query a fresh token from `/api/auth/csrf-token`, and automatically retry the original mutating request with the updated token.
3. **Tests**: Wrote a Jest unit test suite in `useCsrfToken.test.tsx` verifying this auto-retry interceptor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSRF protection handling for same-origin requests.
  * Automatically refreshes expired CSRF tokens and retries affected requests, reducing failed form submissions.
  * Updated authentication flows so OTP verification, OTP resending, password recovery, and password reset can proceed without unnecessary authentication blocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->