### PR TITLE
fix: reduce dark mode hydration flash on initial render

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,8 +19,13 @@
 }
 
 :root {
+
   --background: #ffffff;
+
   --foreground: #171717;
+
+  color-scheme: light dark;
+
 }
 
 @theme inline {
@@ -34,6 +39,18 @@
   --background: #0a0a0a;
   --foreground: #ededed;
 }
+
+html {
+  background: var(--background);
+  color: var(--foreground);
+}
+
+body { 
+  background: var(--background);
+  color: var(--foreground);
+  font-family: Arial, Helvetica, sans-serif;
+}
+
 body {
   background: var(--background);
   color: var(--foreground);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -75,6 +75,42 @@ export default async function RootLayout({
 
   const isDummyKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY === "pk_test_ZXhhbXBsZS5hY2NvdW50cy5kZXYk";
 
+  const content = (
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className="bg-white dark:bg-zinc-950"
+    >
+      <head>
+        <meta name="color-scheme" content="light dark" />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (() => {
+                try {
+                  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+                  if (prefersDark) {
+                    document.documentElement.classList.add('dark');
+                  } else {
+                    document.documentElement.classList.remove('dark');
+                  }
+                } catch {}
+              })();
+            `,
+          }}
+        />
+        <link rel="apple-touch-icon" href="/icons/icon-192x192.png" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="mobile-web-app-capable" content="yes" />
+      </head>
+      <body
+        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-white dark:bg-zinc-950 text-zinc-900 dark:text-zinc-50`}
+      >
+        <I18nProvider>
+          {children}
+        </I18nProvider>
+      </body>
+    </html>
   const innerContent = (
     <ThemeProvider>
       <I18nProvider>


### PR DESCRIPTION
## Description

This PR reduces the white flash that occurs during the initial page load when the application is opened in dark mode.

### Changes
- Added dark-compatible background and text classes to the root `<html>` and `<body>` elements.
- Added fallback root background styles in `globals.css`.
- Added `color-scheme: light dark` to improve the browser's initial rendering before hydration.
- Rebased the branch on the latest `main` and resolved merge conflicts.

These changes help keep the initial render visually consistent with the user's preferred color scheme while preserving the existing theme behavior.

## Related Issue

Fixes #399

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

N/A

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic light and dark theme support based on the device’s color-scheme preference.
  * Applied consistent background, text colors, and typography across the application.
  * Reduced visual theme switching during initial page load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->