### PR TITLE
[Feature]: Automate good-ui, good-backend, and good-pr labeling on PR creation

### DIFF
--- a/.github/workflows/auto-comment.yml
+++ b/.github/workflows/auto-comment.yml
@@ -2,29 +2,30 @@ name: Auto Thank on Merge
 
 on:
   pull_request_target:
-    types: [closed]
-
-permissions:
-  issues: write
-  pull-requests: write
+    types: [opened, synchronize, closed]
 
 jobs:
-  thank-contributor:
+  # Job 1: Label the PR when it is opened or updated (before merge)
+  label-pr:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
+    if: github.event.action != 'closed'
+    permissions:
+      issues: write
+      pull-requests: read
     steps:
-      - name: Thank Contributor
+      - name: Auto-label PR
         uses: actions/github-script@v9
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
             const pr = context.payload.pull_request;
             
-            // 1. Fetch files changed in this PR
-            const { data: files } = await github.rest.pulls.listFiles({
+            // Fetch files changed in this PR using pagination
+            const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: prNumber
+              pull_number: prNumber,
+              per_page: 100
             });
             
             let hasUI = false;
@@ -52,29 +53,84 @@ jobs:
             }
 
             const labelsToAdd = [];
-            const bonusDetails = [];
             
             if (hasUI && (pr.additions > 15 || fileCount > 2)) {
               labelsToAdd.push('good-ui');
-              bonusDetails.push('🎨 **good-ui** (+25 XP) - for frontend/UI improvements');
             }
             if (hasBackend && (pr.additions > 20 || fileCount > 2)) {
               labelsToAdd.push('good-backend');
-              bonusDetails.push('⚙️ **good-backend** (+50 XP) - for backend/API or DB improvements');
             }
             if (hasTests || (pr.body && pr.body.length > 100 && pr.additions > 10)) {
               labelsToAdd.push('good-pr');
-              bonusDetails.push('📝 **good-pr** (+15 XP) - for high-quality contributions with testing or details');
             }
             
             if (labelsToAdd.length > 0) {
-              console.log(`Auto-assigning bonus labels on merge for PR #${prNumber}: ${labelsToAdd.join(', ')}`);
+              console.log(`Auto-assigning bonus labels on PR open for PR #${prNumber}: ${labelsToAdd.join(', ')}`);
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: prNumber,
                 labels: labelsToAdd
               });
+            }
+
+  # Job 2: Thank contributor and summarize XP when merged
+  thank-contributor:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Thank Contributor
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const pr = context.payload.pull_request;
+            
+            // Fetch files changed in this PR using pagination
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              per_page: 100
+            });
+            
+            let hasUI = false;
+            let hasBackend = false;
+            let hasTests = false;
+            let fileCount = files.length;
+            
+            for (const file of files) {
+              const filename = file.filename;
+              if (filename.includes('__tests__/') || filename.endsWith('.test.ts') || filename.endsWith('.test.tsx')) {
+                hasTests = true;
+              } else if (
+                filename.startsWith('src/components/') || 
+                (filename.startsWith('src/app/') && !filename.includes('/api/') && (filename.endsWith('.tsx') || filename.endsWith('.css')))
+              ) {
+                hasUI = true;
+              } else if (
+                filename.startsWith('src/app/api/') || 
+                filename.startsWith('prisma/') || 
+                filename.startsWith('src/lib/') || 
+                filename === 'src/middleware.ts'
+              ) {
+                hasBackend = true;
+              }
+            }
+
+            const bonusDetails = [];
+            
+            if (hasUI && (pr.additions > 15 || fileCount > 2)) {
+              bonusDetails.push('🎨 **good-ui** (+25 XP) - for frontend/UI improvements');
+            }
+            if (hasBackend && (pr.additions > 20 || fileCount > 2)) {
+              bonusDetails.push('⚙️ **good-backend** (+50 XP) - for backend/API or DB improvements');
+            }
+            if (hasTests || (pr.body && pr.body.length > 100 && pr.additions > 10)) {
+              bonusDetails.push('📝 **good-pr** (+15 XP) - for high-quality contributions with testing or details');
             }
 
             let bonusSection = '';


### PR DESCRIPTION
- closes #484

### Description
Currently, our automated contribution analysis only runs when a Pull Request is successfully merged. While this correctly rewards XP upon completion, it leaves PRs unlabeled during the active review and testing phases. 

We need to update our automation workflow so that the quality/category labels (`good-ui`, `good-backend`, and `good-pr`) are applied to the PR as soon as it is raised or updated, while keeping the congratulations and XP comment trigger restricted to the actual merge event.

### Objectives
- [ ] Modify `.github/workflows/auto-comment.yml` to trigger on PR creation and updates (`pull_request_target` on `opened` and `synchronize`).
- [ ] Split the workflow into two distinct jobs:
  1. **`label-pr`**: Analyzes the modified files and applies the appropriate quality tags (`good-ui`, `good-backend`, `good-pr`) immediately.
  2. **`thank-contributor`**: Triggers exclusively when the PR is merged to post the congratulations comment and XP summary.
- [ ] Ensure that the classification criteria (lines of code added, file paths, and test directories) remain identical.

### Expected Behavior
1. When a contributor raises a new PR, the bot evaluates the paths/additions and applies the `good-ui`, `good-backend`, or `good-pr` labels within seconds.
2. If the contributor adds more code to the PR, the labels update accordingly.
3. Once a maintainer merges the PR, the bot posts the thank you comment summarizing the final XP rewards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic pull request labeling based on detected changes.
  * Added a dedicated thank-you message for merged pull requests, including a bonus section with details.
* **Improvements**
  * Updated pull request automation to trigger on creation, updates, and merge/close events.
  * Refined merge-time behavior to re-evaluate changed files and post a richer congratulations comment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->