### PR TITLE
fix: prevent PDF receipt crash on locale-specific date formatting

### DIFF
--- a/src/app/api/bookings/[bookingId]/download/route.ts
+++ b/src/app/api/bookings/[bookingId]/download/route.ts
@@ -96,6 +96,7 @@ export async function GET(
       : "";
 
     // Helper to draw text with absolute safety against encoding crashes
+
     const drawSafeText = (text: string, options: PDFPageDrawTextOptions) => {
       try {
         page.drawText(text, options);
@@ -113,6 +114,33 @@ export async function GET(
             fallbackErr,
           );
         }
+      }
+    };
+
+    const formatBookingDate = (rawDate: unknown): string => {
+      try {
+        if (rawDate === null || rawDate === undefined || rawDate === "") {
+          return "N/A";
+        }
+
+        const dateObj =
+          rawDate instanceof Date ? rawDate : new Date(rawDate as string);
+
+        if (isNaN(dateObj.getTime())) {
+          return String(rawDate);
+        }
+
+        return new Intl.DateTimeFormat("en-GB", {
+          day: "2-digit",
+          month: "2-digit",
+          year: "numeric",
+        }).format(dateObj);
+      } catch (err) {
+        console.warn(
+          "[PDF date format warning]: Failed to format booking date, using raw fallback",
+          err,
+        );
+        return String(rawDate ?? "N/A");
       }
     };
 
@@ -178,12 +206,15 @@ export async function GET(
       font,
     });
     yPosition -= 18;
-    drawSafeText(`SCHEDULE: ${booking.date} @ ${booking.time}`, {
-      x: 50,
-      y: yPosition,
-      size: 10,
-      font,
-    });
+    drawSafeText(
+      `SCHEDULE: ${formatBookingDate(booking.date)} @ ${booking.time}`,
+      {
+        x: 50,
+        y: yPosition,
+        size: 10,
+        font,
+      },
+    );
     yPosition -= 18;
     drawSafeText(`BILLING CODE: ${booking.projectBillingCode || "N/A"}`, {
       x: 50,


### PR DESCRIPTION
Hey! So this fixes the bug where downloading a PDF receipt would crash (500 error) if your locale was set to something like German or French.

What was happening:
The SCHEDULE line in the receipt was just dropping booking.date straight into the PDF text without checking what format it was actually in. If the date came through as a locale-formatted string (like a German date format) instead of a normal parseable one, it would blow up when the app tried to handle it and the whole PDF generation would fail.

What I did:
Added a small helper function called formatBookingDate() that:
- Checks if the date is null/undefined/empty and just returns "N/A" instead of crashing
- Tries to parse it into a proper Date object
- If it can't be parsed (invalid date), it just falls back to showing the raw value instead of throwing an error
- If it can be parsed, it formats it consistently using a fixed format (dd/mm/yyyy style) so it doesn't matter what locale the user has selected — it won't randomly break

Wrapped the whole thing in a try/catch too, just to be extra safe, same pattern the file already uses for drawSafeText.

Files changed:
Only route.ts (the booking PDF download route) — no other files touched.

Testing:
Tried it with different date formats to make sure it doesn't crash anymore and still shows a sensible date on the receipt.

Fixes #397 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved booking receipt date formatting.
  * Receipts now handle missing, invalid, or unexpected booking dates more reliably while preserving the existing time display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->