### PR TITLE
docs: add Next.js hydration best practices (#460)

### DIFF
--- a/docs/HYDRATION_BEST_PRACTICES.md
+++ b/docs/HYDRATION_BEST_PRACTICES.md
@@ -13,6 +13,8 @@ Themes usually rely on `window.localStorage` or the user's system preferences, w
 **The Fix:** Use a `mounted` state with a `useEffect` hook to ensure theme-dependent UI only renders after the component has mounted on the client.
 
 ```tsx
+"use client";
+
 import { useState, useEffect } from "react";
 import { useTheme } from "next-themes";
 
@@ -39,11 +41,13 @@ export default function ThemeToggle() {
 
 ## 2. Local Clock Components & Window State
 
-Components that display the current local time or rely on `window` dimensions (like `window.innerWidth`) will always mismatch because the server's time/environment is different from the user's browser.
+Components that display the current local time or rely on `window` dimensions (like `window.innerWidth`) often mismatch because the server's environment is different from the user's browser.
 
-**The Fix:** Use Next.js dynamic imports and disable SSR for these specific components.
+**The Fix:** Use Next.js dynamic imports and disable SSR for these specific components. _Note: Disabling SSR trades away server-rendered HTML for that specific component._
 
 ```tsx
+"use client";
+
 import dynamic from "next/dynamic";
 
 // The server will skip rendering this component entirely
@@ -61,20 +65,24 @@ export default function Dashboard() {
 }
 ```
 
-## 3. Layout Wrapper Template (`SafeHydrate`)
+## 3. Client-Only Gate (`ClientOnly`)
 
-If you have a larger section of your app that relies heavily on client-side state (like browser APIs), you can use a layout wrapper template to suppress hydration errors safely.
+If you have a larger section of your app that relies heavily on client-side state (like browser APIs), you can use a client-only gate wrapper. Since this pattern renders `null` (or a stable fallback) during SSR, it safely bypasses hydration issues without needing the `suppressHydrationWarning` attribute.
 
-Create a generic `<SafeHydrate>` wrapper component:
+Create a generic `<ClientOnly>` wrapper component:
 
 ```tsx
-// components/SafeHydrate.tsx
+"use client";
+
+// components/ClientOnly.tsx
 import { useEffect, useState } from "react";
 
-export default function SafeHydrate({
+export default function ClientOnly({
   children,
+  fallback = null,
 }: {
   children: React.ReactNode;
+  fallback?: React.ReactNode;
 }) {
   const [isClient, setIsClient] = useState(false);
 
@@ -82,20 +90,22 @@ export default function SafeHydrate({
     setIsClient(true);
   }, []);
 
-  return <div suppressHydrationWarning>{isClient ? children : null}</div>;
+  return <>{isClient ? children : fallback}</>;
 }
 ```
 
 **Usage in a Layout or Page:**
 
 ```tsx
-import SafeHydrate from "@/components/SafeHydrate";
+"use client";
+
+import ClientOnly from '@/components/ClientOnly';
 
 export default function ClientHeavyPage() {
   return (
-    <SafeHydrate>
-      <ClientOnlyDashboard />
-    </SafeHydrate>
+    <ClientOnly fallback="{<div">Loading...</div>}>
+      <ClientOnlyDashboard/>
+    </ClientOnly>
   );
 }
 ```

--- a/docs/HYDRATION_BEST_PRACTICES.md
+++ b/docs/HYDRATION_BEST_PRACTICES.md
@@ -1,0 +1,101 @@
+# Next.js Server-Client Hydration Best Practices
+
+Hydration mismatches happen when the initial HTML rendered on the server does not exactly match the HTML rendered on the client during the first load. In Next.js, this typically throws a hydration error and can break your UI.
+
+This document outlines the guidelines to prevent hydration mismatches across the WorkSphere frontend.
+
+---
+
+## 1. Handling Theme Triggers (Dark/Light Mode)
+
+Themes usually rely on `window.localStorage` or the user's system preferences, which the server cannot access during Server-Side Rendering (SSR).
+
+**The Fix:** Use a `mounted` state with a `useEffect` hook to ensure theme-dependent UI only renders after the component has mounted on the client.
+
+```tsx
+import { useState, useEffect } from "react";
+import { useTheme } from "next-themes";
+
+export default function ThemeToggle() {
+  const [mounted, setMounted] = useState(false);
+  const { theme, setTheme } = useTheme();
+
+  // useEffect only runs on the client
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return null; // or a loading skeleton
+  }
+
+  return (
+    <button onClick={() => setTheme(theme === "dark" ? "light" : "dark")}>
+      Toggle Theme
+    </button>
+  );
+}
+```
+
+## 2. Local Clock Components & Window State
+
+Components that display the current local time or rely on `window` dimensions (like `window.innerWidth`) will always mismatch because the server's time/environment is different from the user's browser.
+
+**The Fix:** Use Next.js dynamic imports and disable SSR for these specific components.
+
+```tsx
+import dynamic from "next/dynamic";
+
+// The server will skip rendering this component entirely
+const LocalClock = dynamic(() => import("../components/LocalClock"), {
+  ssr: false,
+});
+
+export default function Dashboard() {
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <LocalClock />
+    </div>
+  );
+}
+```
+
+## 3. Layout Wrapper Template (`SafeHydrate`)
+
+If you have a larger section of your app that relies heavily on client-side state (like browser APIs), you can use a layout wrapper template to suppress hydration errors safely.
+
+Create a generic `<SafeHydrate>` wrapper component:
+
+```tsx
+// components/SafeHydrate.tsx
+import { useEffect, useState } from "react";
+
+export default function SafeHydrate({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  return <div suppressHydrationWarning>{isClient ? children : null}</div>;
+}
+```
+
+**Usage in a Layout or Page:**
+
+```tsx
+import SafeHydrate from "@/components/SafeHydrate";
+
+export default function ClientHeavyPage() {
+  return (
+    <SafeHydrate>
+      <ClientOnlyDashboard />
+    </SafeHydrate>
+  );
+}
+```


### PR DESCRIPTION
### Description
This PR introduces the documentation for Next.js server-client hydration best practices to prevent mismatches across the WorkSphere frontend.

**What was added in `HYDRATION_BEST_PRACTICES.md`:**
* **Theme Triggers:** Guidelines for handling Dark/Light mode using a `mounted` state and `useEffect`.
* **Local Clock & Window State:** Best practices for using Next.js dynamic imports (`ssr: false`) for components relying on browser APIs.
* **Layout Wrapper:** A reusable `<SafeHydrate>` wrapper template to safely suppress hydration warnings for client-heavy components.

### Related Issue
Closes #460

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for preventing server/client hydration mismatches in the frontend.
  * Documented patterns for theme-dependent, browser-dependent, and time-dependent content.
  * Included examples using client-only rendering, dynamic imports, and reusable fallback components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->