### PR TITLE
fix: resolve unrestricted file upload vulnerability in local fallback handler

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,24 +1,48 @@
-import '@testing-library/jest-dom';
-import { TextEncoder, TextDecoder } from 'util';
-import { webcrypto } from 'crypto';
-
+import "@testing-library/jest-dom";
+import { TextEncoder, TextDecoder } from "util";
+import { webcrypto } from "crypto";
 // jsdom doesn't provide these globals; Node's implementations are drop-in
 // replacements and let us test Edge-runtime-style code (e.g. src/lib/csrf.ts)
 // under the standard jsdom test environment.
-if (typeof global.TextEncoder === 'undefined') {
+if (typeof global.TextEncoder === "undefined") {
   global.TextEncoder = TextEncoder;
   global.TextDecoder = TextDecoder;
 }
-if (typeof global.crypto === 'undefined' || !global.crypto.subtle) {
-  Object.defineProperty(global, 'crypto', {
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const {
+  Request: UndiciRequest,
+  Response: UndiciResponse,
+  Headers: UndiciHeaders,
+  FormData: UndiciFormData,
+  File: UndiciFile,
+} = require("undici");
+
+if (typeof global.Request === "undefined") {
+  global.Request = UndiciRequest;
+}
+if (typeof global.Response === "undefined") {
+  global.Response = UndiciResponse;
+}
+if (typeof global.Headers === "undefined") {
+  global.Headers = UndiciHeaders;
+}
+if (typeof global.FormData === "undefined") {
+  global.FormData = UndiciFormData;
+}
+if (typeof global.File === "undefined") {
+  global.File = UndiciFile;
+}
+if (typeof global.crypto === "undefined" || !global.crypto.subtle) {
+  Object.defineProperty(global, "crypto", {
     value: webcrypto,
     configurable: true,
   });
 }
-if (typeof global.structuredClone === 'undefined') {
+if (typeof global.structuredClone === "undefined") {
   global.structuredClone = (val) => JSON.parse(JSON.stringify(val));
 }
-import 'fake-indexeddb/auto';
+import "fake-indexeddb/auto";
 
 // Mock Leaflet global variable L
 global.L = {
@@ -48,7 +72,7 @@ global.L = {
 };
 
 // Mock next/navigation
-jest.mock('next/navigation', () => ({
+jest.mock("next/navigation", () => ({
   useRouter: () => ({
     push: jest.fn(),
     replace: jest.fn(),
@@ -57,18 +81,18 @@ jest.mock('next/navigation', () => ({
   useSearchParams: () => ({
     get: jest.fn(),
   }),
-  usePathname: () => '',
+  usePathname: () => "",
 }));
 
 // Mock Clerk
-jest.mock('@clerk/nextjs', () => ({
+jest.mock("@clerk/nextjs", () => ({
   useUser: () => ({
-    user: { id: 'test-user', imageUrl: 'https://example.com/avatar.png' },
+    user: { id: "test-user", imageUrl: "https://example.com/avatar.png" },
     isSignedIn: true,
     isLoaded: true,
   }),
   useAuth: () => ({
-    userId: 'test-user',
+    userId: "test-user",
     isSignedIn: true,
   }),
   SignInButton: ({ children }) => children,
@@ -83,5 +107,5 @@ global.fetch = jest.fn(() =>
   Promise.resolve({
     ok: true,
     json: () => Promise.resolve({}),
-  })
+  }),
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -912,39 +912,6 @@
         "@electric-sql/pglite": "0.4.1"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
@@ -19365,6 +19332,81 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
+      "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
+      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
+      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
+      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
+      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     }
   }

--- a/src/__tests__/api/upload.test.ts
+++ b/src/__tests__/api/upload.test.ts
@@ -1,0 +1,184 @@
+import { POST } from "@/app/api/upload/route";
+import { auth } from "@clerk/nextjs/server";
+import fs from "fs";
+
+// Mock Clerk auth
+jest.mock("@clerk/nextjs/server", () => ({
+  auth: jest.fn(),
+}));
+
+// Mock fs promises
+jest.mock("fs", () => ({
+  ...jest.requireActual("fs"),
+  existsSync: jest.fn(),
+  promises: {
+    mkdir: jest.fn().mockResolvedValue(undefined),
+    writeFile: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// Mock Cloudinary
+jest.mock("cloudinary", () => ({
+  v2: {
+    config: jest.fn(),
+    uploader: {
+      upload_stream: jest.fn(),
+    },
+  },
+}));
+
+describe("Upload API", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("should return 401 if user is unauthorized", async () => {
+    (auth as unknown as jest.Mock).mockResolvedValue({ userId: null });
+
+    const request = {
+      formData: jest.fn(),
+    } as unknown as Request;
+
+    const response = await POST(request);
+    expect(response.status).toBe(401);
+    const data = await response.json();
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("should return 400 if no file is provided", async () => {
+    (auth as unknown as jest.Mock).mockResolvedValue({
+      userId: "test-user-123",
+    });
+
+    const mockFormData = {
+      get: jest.fn().mockReturnValue(null),
+    };
+
+    const request = {
+      formData: jest.fn().mockResolvedValue(mockFormData),
+    } as unknown as Request;
+
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBe("No file provided");
+  });
+
+  it("should return 400 if file size exceeds 5MB limit", async () => {
+    (auth as unknown as jest.Mock).mockResolvedValue({
+      userId: "test-user-123",
+    });
+
+    const mockFile = {
+      name: "large_image.png",
+      type: "image/png",
+      size: 6 * 1024 * 1024, // 6MB
+      arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(0)),
+    };
+
+    const mockFormData = {
+      get: jest.fn().mockReturnValue(mockFile),
+    };
+
+    const request = {
+      formData: jest.fn().mockResolvedValue(mockFormData),
+    } as unknown as Request;
+
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toContain("size exceeds 5MB limit");
+  });
+
+  it("should return 400 if MIME type is invalid", async () => {
+    (auth as unknown as jest.Mock).mockResolvedValue({
+      userId: "test-user-123",
+    });
+
+    const mockFile = {
+      name: "malicious.html",
+      type: "text/html",
+      size: 1024,
+      arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(0)),
+    };
+
+    const mockFormData = {
+      get: jest.fn().mockReturnValue(mockFile),
+    };
+
+    const request = {
+      formData: jest.fn().mockResolvedValue(mockFormData),
+    } as unknown as Request;
+
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toContain("Invalid file type");
+  });
+
+  it("should return 400 if file extension is invalid", async () => {
+    (auth as unknown as jest.Mock).mockResolvedValue({
+      userId: "test-user-123",
+    });
+
+    const mockFile = {
+      name: "malicious.exe",
+      type: "image/png", // Spoofed MIME type
+      size: 1024,
+      arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(0)),
+    };
+
+    const mockFormData = {
+      get: jest.fn().mockReturnValue(mockFile),
+    };
+
+    const request = {
+      formData: jest.fn().mockResolvedValue(mockFormData),
+    } as unknown as Request;
+
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toContain("Invalid file extension");
+  });
+
+  it("should successfully upload and save locally if Cloudinary config is missing", async () => {
+    (auth as unknown as jest.Mock).mockResolvedValue({
+      userId: "test-user-123",
+    });
+    process.env.CLOUDINARY_CLOUD_NAME = "dummy";
+
+    const fileContent = new TextEncoder().encode("fake image content");
+    const mockFile = {
+      name: "valid_image.png",
+      type: "image/png",
+      size: 1024,
+      arrayBuffer: jest.fn().mockResolvedValue(fileContent.buffer),
+    };
+
+    const mockFormData = {
+      get: jest.fn().mockReturnValue(mockFile),
+    };
+
+    const request = {
+      formData: jest.fn().mockResolvedValue(mockFormData),
+    } as unknown as Request;
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.url).toContain("/uploads/");
+    expect(data.url).toContain("valid_image.png");
+
+    expect(fs.promises.mkdir).toHaveBeenCalled();
+    expect(fs.promises.writeFile).toHaveBeenCalled();
+  });
+});

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,8 +1,8 @@
-import { NextResponse } from 'next/server';
-import { v2 as cloudinary } from 'cloudinary';
-import { auth } from '@clerk/nextjs/server';
-import fs from 'fs';
-import path from 'path';
+import { NextResponse } from "next/server";
+import { v2 as cloudinary } from "cloudinary";
+import { auth } from "@clerk/nextjs/server";
+import fs from "fs";
+import path from "path";
 
 cloudinary.config({
   cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
@@ -14,48 +14,94 @@ export async function POST(request: Request) {
   try {
     const { userId } = await auth();
     if (!userId) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     const formData = await request.formData();
-    const file = formData.get('file') as File;
+    const file = formData.get("file") as File;
 
     if (!file) {
-      return NextResponse.json({ error: 'No file provided' }, { status: 400 });
+      return NextResponse.json({ error: "No file provided" }, { status: 400 });
+    }
+
+    // Validate file size (max 5MB)
+    const MAX_FILE_SIZE = 5 * 1024 * 1024;
+    if (file.size > MAX_FILE_SIZE) {
+      return NextResponse.json(
+        { error: "File size exceeds 5MB limit" },
+        { status: 400 },
+      );
+    }
+
+    // Validate MIME type
+    const allowedMimeTypes = [
+      "image/png",
+      "image/jpeg",
+      "image/jpg",
+      "image/gif",
+      "image/webp",
+    ];
+    if (!allowedMimeTypes.includes(file.type)) {
+      return NextResponse.json(
+        {
+          error:
+            "Invalid file type. Only PNG, JPEG, GIF, and WEBP images are allowed.",
+        },
+        { status: 400 },
+      );
+    }
+
+    // Validate file extension
+    const fileExt = path.extname(file.name).toLowerCase();
+    const allowedExtensions = [".png", ".jpeg", ".jpg", ".gif", ".webp"];
+    if (!allowedExtensions.includes(fileExt)) {
+      return NextResponse.json(
+        { error: "Invalid file extension." },
+        { status: 400 },
+      );
     }
 
     const bytes = await file.arrayBuffer();
     const buffer = Buffer.from(bytes);
 
     // Fallback to local storage if Cloudinary config is missing
-    if (!process.env.CLOUDINARY_CLOUD_NAME || process.env.CLOUDINARY_CLOUD_NAME === "dummy") {
-      const uploadDir = path.join(process.cwd(), 'public', 'uploads');
-      
-      if (!fs.existsSync(uploadDir)) {
-        fs.mkdirSync(uploadDir, { recursive: true });
+    if (
+      !process.env.CLOUDINARY_CLOUD_NAME ||
+      process.env.CLOUDINARY_CLOUD_NAME === "dummy"
+    ) {
+      if (process.env.VERCEL || process.env.AWS_LAMBDA_FUNCTION_NAME) {
+        console.warn(
+          "Warning: Using local storage fallback in a serverless environment. Uploaded files will not persist.",
+        );
       }
 
-      const fileName = `${Date.now()}-${file.name.replace(/[^a-zA-Z0-9.-]/g, '_')}`;
+      const uploadDir = path.join(process.cwd(), "public", "uploads");
+
+      await fs.promises.mkdir(uploadDir, { recursive: true });
+
+      const fileName = `${Date.now()}-${file.name.replace(/[^a-zA-Z0-9.-]/g, "_")}`;
       const filePath = path.join(uploadDir, fileName);
-      fs.writeFileSync(filePath, buffer);
+      await fs.promises.writeFile(filePath, buffer);
 
       return NextResponse.json({ url: `/uploads/${fileName}` });
     }
 
     // Upload to Cloudinary using buffer stream
     const result: any = await new Promise((resolve, reject) => {
-      cloudinary.uploader.upload_stream(
-        { folder: 'worksphere_venues' },
-        (error: any, result: any) => {
-          if (error) reject(error);
-          else resolve(result);
-        }
-      ).end(buffer);
+      cloudinary.uploader
+        .upload_stream(
+          { folder: "worksphere_venues" },
+          (error: any, result: any) => {
+            if (error) reject(error);
+            else resolve(result);
+          },
+        )
+        .end(buffer);
     });
 
     return NextResponse.json({ url: result.secure_url });
   } catch (error) {
-    console.error('Upload error:', error);
-    return NextResponse.json({ error: 'Upload failed' }, { status: 500 });
+    console.error("Upload error:", error);
+    return NextResponse.json({ error: "Upload failed" }, { status: 500 });
   }
 }


### PR DESCRIPTION
Fixes https://github.com/SatyamPandey-07/WorkSphere/issues/502

### Description
This PR fixes the security vulnerability regarding unrestricted file uploads when using the local fallback storage handler in the `/api/upload` endpoint.

### Changes
- Added file size limit validation (max 5MB) on upload.
- Added MIME type and file extension checking to restrict uploads to safe, common image formats (`PNG`, `JPEG`, `GIF`, `WEBP`).
- Replaced synchronous filesystem calls (`fs.mkdirSync`, `fs.writeFileSync`) with asynchronous `fs.promises` equivalent calls (`fs.promises.mkdir`, `fs.promises.writeFile`).
- Added warnings when local fallback is used in serverless environments (detected via `VERCEL` or `AWS_LAMBDA_FUNCTION_NAME`).
- Added comprehensive unit tests in `src/__tests__/api/upload.test.ts` to test these validations and scenarios.
- Polyfilled standard Web API globals in `jest.setup.js` using `undici` to allow testing App Router handlers directly in JSDOM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-side validation for uploaded files, including size, MIME type, and filename extension checks.
  * Added a local-storage fallback for uploads when cloud storage is unavailable.

* **Bug Fixes**
  * Improved upload error handling with clearer responses for invalid or missing files.

* **Tests**
  * Added coverage for authentication, validation failures, successful uploads, and local file storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->