### PR TITLE
fix: load custom PDF fonts asynchronously to prevent event loop blocking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19366,6 +19366,81 @@
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
       }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
+      "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
+      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
+      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
+      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
+      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/src/__tests__/lib/pdfGenerator.test.ts
+++ b/src/__tests__/lib/pdfGenerator.test.ts
@@ -1,0 +1,65 @@
+import { generateReceiptPdf, generateTaxExportPdf } from "@/lib/pdfGenerator";
+import fs from "fs";
+
+jest.mock("fs", () => {
+  const actualFs = jest.requireActual("fs");
+  return {
+    ...actualFs,
+    promises: {
+      ...actualFs.promises,
+      readFile: jest.fn().mockImplementation((...args: any[]) => {
+        return actualFs.promises.readFile(...args);
+      }),
+    },
+  };
+});
+
+describe("PDF Generator", () => {
+  const mockBooking = {
+    id: 1,
+    confirmationId: "WS-12345",
+    date: "2026-07-15",
+    time: "19:00",
+    duration: 3,
+    projectBillingCode: "BILL-456",
+    customerEmail: "customer@example.com",
+    user: { firstName: "Jane", lastName: "Smith" },
+    venue: {
+      name: "Library Hub",
+      category: "library",
+      address: "456 Library Ave",
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("generateReceiptPdf", () => {
+    it("should generate a valid PDF asynchronously using custom fonts from disk", async () => {
+      const pdfBytes = await generateReceiptPdf(mockBooking);
+      expect(pdfBytes).toBeInstanceOf(Uint8Array);
+      expect(pdfBytes.length).toBeGreaterThan(0);
+      expect(fs.promises.readFile).toHaveBeenCalledTimes(2);
+    });
+
+    it("should fall back gracefully to Helvetica if custom fonts fail to load", async () => {
+      (fs.promises.readFile as jest.Mock).mockRejectedValue(
+        new Error("Font load error"),
+      );
+
+      const pdfBytes = await generateReceiptPdf(mockBooking);
+      expect(pdfBytes).toBeInstanceOf(Uint8Array);
+      expect(pdfBytes.length).toBeGreaterThan(0);
+      expect(fs.promises.readFile).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("generateTaxExportPdf", () => {
+    it("should generate a valid consolidated tax export PDF", async () => {
+      const pdfBytes = await generateTaxExportPdf([mockBooking]);
+      expect(pdfBytes).toBeInstanceOf(Uint8Array);
+      expect(pdfBytes.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/lib/pdfGenerator.ts
+++ b/src/lib/pdfGenerator.ts
@@ -294,8 +294,10 @@ export async function generateReceiptPdf(booking: any): Promise<Uint8Array> {
   let boldFont: any;
 
   try {
-    const regularFontBytes = fs.readFileSync(regularFontPath);
-    const boldFontBytes = fs.readFileSync(boldFontPath);
+    const [regularFontBytes, boldFontBytes] = await Promise.all([
+      fs.promises.readFile(regularFontPath),
+      fs.promises.readFile(boldFontPath),
+    ]);
     font = await pdfDoc.embedFont(regularFontBytes);
     boldFont = await pdfDoc.embedFont(boldFontBytes);
   } catch {


### PR DESCRIPTION
Fixes https://github.com/SatyamPandey-07/WorkSphere/issues/500

### Description
This PR refactors the PDF receipt generator module to load custom fonts asynchronously using `fs.promises.readFile` inside `Promise.all` instead of the synchronous `fs.readFileSync` method, preventing event loop blocking under moderate to high concurrent load.

### Changes
- Refactored `generateReceiptPdf` to read font files asynchronously with `fs.promises.readFile` and `Promise.all`.
- Added comprehensive unit tests in `src/__tests__/lib/pdfGenerator.test.ts` to test both the successful font loading scenario and the graceful fallback to Helvetica when disk reads fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved receipt PDF generation by loading fonts asynchronously.
  * Receipt PDFs now continue to generate successfully when custom font files cannot be loaded.

* **Tests**
  * Added coverage for receipt and tax export PDF generation, including font-loading failures and file access behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->