### PR TITLE
fix: make getRateLimitInfo support Upstash and cache limiters by limit

### DIFF
--- a/src/__tests__/lib/rateLimit.test.ts
+++ b/src/__tests__/lib/rateLimit.test.ts
@@ -1,51 +1,75 @@
-import { rateLimit, resetRateLimit } from '@/lib/rateLimit';
+import { rateLimit, getRateLimitInfo, resetRateLimit } from "@/lib/rateLimit";
 
-describe('Rate Limiting', () => {
+describe("Rate Limiting", () => {
   beforeEach(() => {
     resetRateLimit();
   });
 
-  it('should allow requests under the limit', async () => {
-    const ip = '192.168.1.1';
-    
+  it("should allow requests under the limit", async () => {
+    const ip = "192.168.1.1";
+
     for (let i = 0; i < 10; i++) {
       expect(await rateLimit(ip)).toBe(true);
     }
   });
 
-  it('should block requests over the limit', async () => {
-    const ip = '192.168.1.2';
-    
+  it("should block requests over the limit", async () => {
+    const ip = "192.168.1.2";
+
     // Make 10 requests (default limit)
     for (let i = 0; i < 10; i++) {
       await rateLimit(ip);
     }
-    
+
     // 11th request should be blocked
     expect(await rateLimit(ip)).toBe(false);
   });
 
-  it('should track different IPs separately', async () => {
-    const ip1 = '192.168.1.3';
-    const ip2 = '192.168.1.4';
-    
+  it("should track different IPs separately", async () => {
+    const ip1 = "192.168.1.3";
+    const ip2 = "192.168.1.4";
+
     // Exhaust limit for ip1
     for (let i = 0; i < 10; i++) {
       await rateLimit(ip1);
     }
-    
+
     // ip2 should still be allowed
     expect(await rateLimit(ip2)).toBe(true);
   });
 
-  it('should respect custom limits', async () => {
-    const ip = '192.168.1.5';
-    
+  it("should respect custom limits", async () => {
+    const ip = "192.168.1.5";
+
     // Custom limit of 5
     for (let i = 0; i < 5; i++) {
       expect(await rateLimit(ip, 5)).toBe(true);
     }
-    
+
     expect(await rateLimit(ip, 5)).toBe(false);
+  });
+
+  it("should return correct rate limit info", async () => {
+    const ip = "192.168.1.6";
+
+    let info = getRateLimitInfo(ip, 5);
+    expect(info).not.toBeNull();
+    expect(info?.count).toBe(0);
+    expect(info?.remaining).toBe(5);
+    expect(info?.isLimited).toBe(false);
+
+    await rateLimit(ip, 5);
+    info = getRateLimitInfo(ip, 5);
+    expect(info?.count).toBe(1);
+    expect(info?.remaining).toBe(4);
+    expect(info?.isLimited).toBe(false);
+
+    for (let i = 0; i < 4; i++) {
+      await rateLimit(ip, 5);
+    }
+    info = getRateLimitInfo(ip, 5);
+    expect(info?.count).toBe(5);
+    expect(info?.remaining).toBe(0);
+    expect(info?.isLimited).toBe(true);
   });
 });

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -6,9 +6,15 @@
  */
 
 // ─── Upstash (production) ────────────────────────────────────────────────────
-let upstashRatelimit: {
-  limit: (identifier: string) => Promise<{ success: boolean; remaining: number; reset: number }>;
-} | null = null;
+const upstashLimiters = new Map<number, any>();
+
+interface RateLimitInfo {
+  count: number;
+  remaining: number;
+  resetTime: number;
+  isLimited: boolean;
+}
+const rateLimitInfoStore = new Map<string, RateLimitInfo>();
 
 function getUpstashRatelimit(limitPerMinute: number) {
   if (
@@ -37,7 +43,7 @@ function getUpstashRatelimit(limitPerMinute: number) {
       prefix: "worksphere:ratelimit",
     }) as {
       limit: (
-        identifier: string
+        identifier: string,
       ) => Promise<{ success: boolean; remaining: number; reset: number }>;
     };
   } catch {
@@ -78,11 +84,16 @@ function memRateLimit(identifier: string, limit: number): boolean {
 
 function memGetInfo(
   identifier: string,
-  limit: number
+  limit: number,
 ): { count: number; remaining: number; resetTime: number; isLimited: boolean } {
   const entry = memStore.get(identifier);
   if (!entry || Date.now() > entry.resetTime) {
-    return { count: 0, remaining: limit, resetTime: Date.now() + WINDOW_MS, isLimited: false };
+    return {
+      count: 0,
+      remaining: limit,
+      resetTime: Date.now() + WINDOW_MS,
+      isLimited: false,
+    };
   }
   return {
     count: entry.count,
@@ -100,14 +111,33 @@ function memGetInfo(
  */
 export async function rateLimit(
   identifier: string,
-  limit = 10
+  limit = 10,
 ): Promise<boolean> {
-  const rl = upstashRatelimit ?? getUpstashRatelimit(limit);
+  let rl = upstashLimiters.get(limit);
+  if (!rl) {
+    rl = getUpstashRatelimit(limit);
+    if (rl) {
+      upstashLimiters.set(limit, rl);
+    }
+  }
 
   if (rl) {
-    upstashRatelimit = rl; // cache for subsequent calls
-    const { success } = await rl.limit(identifier);
+    const { success, remaining, reset } = await rl.limit(identifier);
+    rateLimitInfoStore.set(identifier, {
+      count: limit - remaining,
+      remaining,
+      resetTime: reset,
+      isLimited: !success,
+    });
     return success;
+  }
+
+  // Periodic cleanup of the Upstash info store to avoid unbound memory growth
+  if (rateLimitInfoStore.size > 10_000) {
+    const now = Date.now();
+    for (const [k, v] of rateLimitInfoStore) {
+      if (now > v.resetTime) rateLimitInfoStore.delete(k);
+    }
   }
 
   return memRateLimit(identifier, limit);
@@ -119,8 +149,17 @@ export async function rateLimit(
  */
 export function getRateLimitInfo(
   identifier: string,
-  limit = 10
-): { count: number; remaining: number; resetTime: number; isLimited: boolean } | null {
+  limit = 10,
+): {
+  count: number;
+  remaining: number;
+  resetTime: number;
+  isLimited: boolean;
+} | null {
+  const cached = rateLimitInfoStore.get(identifier);
+  if (cached) {
+    return cached;
+  }
   return memGetInfo(identifier, limit);
 }
 
@@ -128,7 +167,9 @@ export function getRateLimitInfo(
 export function resetRateLimit(identifier?: string): void {
   if (identifier) {
     memStore.delete(identifier);
+    rateLimitInfoStore.delete(identifier);
   } else {
     memStore.clear();
+    rateLimitInfoStore.clear();
   }
 }


### PR DESCRIPTION
### Description
This pull request addresses issue #497 by resolving two key issues in the rate limiting utility:
1. **Upstash ignore in getRateLimitInfo**: Hardcoding getRateLimitInfo to return `memGetInfo` is resolved. We now introduce a Request/Call-level `rateLimitInfoStore` that dynamically caches execution metadata from Upstash during the `rateLimit()` call, ensuring `getRateLimitInfo` returns accurate, live stats synchronously.
2. **Global cached limiter instance reuse**: Cached ratelimit instances are now mapped to their specific limit threshold in a key-value Map (`upstashLimiters`), preventing dynamic limits from being ignored when multiple routes configure different rate limit numbers.

Resolves #497

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rate-limit status tracking, including request count, remaining requests, reset time, and limited status.
  * Rate-limit information now stays accurate across different configured request limits.

* **Bug Fixes**
  * Resetting rate limits now clears all associated tracking information.

* **Tests**
  * Expanded coverage for rate-limit metadata and limit transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->