### PR TITLE
fix: use nextjs after() to process PDF in background (#518)

### DIFF
--- a/src/app/api/bookings/confirm/route.ts
+++ b/src/app/api/bookings/confirm/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextResponse, after } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { prisma } from "@/lib/prisma";
 import { ensureUserExists } from "@/lib/auth";
@@ -8,6 +8,7 @@ import "@/core/subscribers/discord";
 import "@/core/subscribers/whatsapp";
 import "@/core/subscribers/guests";
 import "@/core/subscribers/telegram";
+
 export async function POST(req: Request) {
   try {
     const { userId } = await auth();
@@ -92,19 +93,27 @@ export async function POST(req: Request) {
     // --- END OF FIX ---
 
     // 2. Emit Booking Confirmed Event to handle Side-Effects (PDF, Email, Analytics)
-    await eventBus.emit("booking:confirmed", {
-      bookingId: booking.id,
-      confirmationId,
-      venue: {
-        id: dbVenue.id,
-        name: venue.name || "Unknown Venue",
-        category: venue.category || "other",
-        address: venue.address || undefined,
-      },
-      customerEmail: customerEmail || "pandeysatyam1802@gmail.com",
-      date,
-      time,
+    // --- ASYNC PDF FIX IMPLEMENTATION (#518) ---
+    after(async () => {
+      try {
+        await eventBus.emit("booking:confirmed", {
+          bookingId: booking.id,
+          confirmationId,
+          venue: {
+            id: dbVenue.id,
+            name: venue.name || "Unknown Venue",
+            category: venue.category || "other",
+            address: venue.address || undefined,
+          },
+          customerEmail: customerEmail || "pandeysatyam1802@gmail.com",
+          date,
+          time,
+        });
+      } catch (backgroundError) {
+        console.error("[Background Event Bus Error]:", backgroundError);
+      }
     });
+    // --- END OF ASYNC PDF FIX ---
 
     return NextResponse.json({
       success: true,


### PR DESCRIPTION
This PR addresses the state desynchronization issue where slow PDF generation was causing 504 Gateway Timeouts on serverless deployments.

**What was changed:**
* Imported the `after()` function from `next/server`.
* Wrapped the `eventBus.emit("booking:confirmed", ...)` call inside `after()` in `src/app/api/booking/confirm/route.ts`. 

By moving the event bus trigger (which handles the heavy PDF receipt generation) into a background execution context, the critical database transaction can finish and return an immediate `HTTP 200 Success` response to the client. This prevents the serverless function from timing out.

## Related Issue

<!--
Please link to the issue here using the standard keywords.
Example: Fixes #123 or Closes #123
-->
Fixes #518

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

<!-- Add visual evidence if this PR changes UI/UX. -->
No screenshots needed (backend architectural fix).

## Breaking Changes

- [ ] Yes (please describe below)

- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Booking confirmations now complete without waiting for follow-up processing.
  * Background processing errors are logged without interrupting successful confirmation responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->