### PR TITLE
perf: define database indexes on chronological models to prevent sequential table scans (closes #516)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -132,6 +132,7 @@ model VenueRating {
 
   @@unique([userId, venueId])
   @@index([venueId])
+  @@index([createdAt])
 }
 
 model Favorite {
@@ -194,6 +195,7 @@ model Booking {
   @@index([userId])
   @@index([venueId])
   @@index([seatId])
+  @@index([createdAt])
 }
 
 model BookingGuest {
@@ -372,6 +374,8 @@ model WifiTelemetry {
   timestamp  DateTime @default(now())
 
   @@index([venueId])
+  @@index([timestamp])
+  @@index([venueId, timestamp])
 }
 
 enum FlagType {
@@ -409,6 +413,8 @@ model AdminAuditLog {
   entityId   String
   details    String?
   createdAt  DateTime @default(now())
+
+  @@index([createdAt])
 }
 
 model Folder {
@@ -499,6 +505,8 @@ model WebhookDeliveryLog {
   createdAt  DateTime        @default(now())
 
   @@index([endpointId])
+  @@index([createdAt])
+  @@index([endpointId, createdAt])
 }
 
 model FolderUpvote {


### PR DESCRIPTION
Closes #516

This PR defines database indexes on frequently queried chronological/time-series columns (`timestamp` and `createdAt`) in the Prisma schema. These indexes optimize database query patterns, preventing sequential scans (`Seq Scan`) across growing datasets.

### Key Changes
1. **`WifiTelemetry` Model**:
   - Added `@@index([timestamp])` to speed up global time-series sweeps.
   - Added `@@index([venueId, timestamp])` composite index to optimize hourly speed/prediction lookups.
2. **`WebhookDeliveryLog` Model**:
   - Added `@@index([createdAt])` for chronological sweeps.
   - Added `@@index([endpointId, createdAt])` composite index to optimize delivery logs filtering by endpoints.
3. **`AdminAuditLog` Model**:
   - Added `@@index([createdAt])` to optimize admin audit log queries.
4. **`Booking` Model**:
   - Added `@@index([createdAt])` to speed up date-range analytics filtering.
5. **`VenueRating` Model**:
   - Added `@@index([createdAt])` to accelerate historical reviews and rating averages timeline analytics.

