### PR TITLE
feat: add multi-category venue filters to collection folders (#385)

### DIFF
--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -32,6 +32,11 @@ export default function FolderDetailsPage({
   const [generatingInvite, setGeneratingInvite] = useState(false);
   const [updatingPublic, setUpdatingPublic] = useState(false);
   const [exporting, setExporting] = useState(false);
+  const [filters, setFilters] = useState({
+    hasOutlets: false,
+    wifiQualityMin: false,
+    quietOnly: false,
+  });
 
   const handleExportBilling = async () => {
     try {
@@ -179,6 +184,13 @@ export default function FolderDetailsPage({
       </div>
     );
 
+  const filteredVenues = folder.venues.filter((fv: any) => {
+    if (filters.hasOutlets && !fv.venue.hasOutlets) return false;
+    if (filters.wifiQualityMin && fv.venue.wifiQuality < 4) return false;
+    if (filters.quietOnly && fv.venue.noiseLevel !== "quiet") return false;
+    return true;
+  });
+
   return (
     <div className="min-h-screen bg-zinc-50 dark:bg-zinc-950 p-4 sm:p-6 lg:p-8 pt-8">
       <div className="max-w-5xl mx-auto">
@@ -207,7 +219,7 @@ export default function FolderDetailsPage({
           <div className="md:col-span-2 space-y-4">
             <h2 className="text-lg font-semibold text-zinc-900 dark:text-white flex items-center gap-2">
               <MapPin className="w-5 h-5 text-blue-500" /> Saved Venues (
-              {folder.venues.length})
+              {filteredVenues.length})
             </h2>
 
             {folder.venues.length === 0 ? (
@@ -220,9 +232,19 @@ export default function FolderDetailsPage({
                   Add venues to this collection from the map.
                 </p>
               </div>
+            ) : filteredVenues.length === 0 ? (
+              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-12 text-center shadow-sm">
+                <MapPin className="w-12 h-12 text-zinc-300 dark:text-zinc-700 mx-auto mb-3" />
+                <h3 className="text-lg font-medium text-zinc-900 dark:text-white mb-1">
+                  No venues match your filters
+                </h3>
+                <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                  Try unchecking a filter to see more results.
+                </p>
+              </div>
             ) : (
               <div className="grid gap-4">
-                {folder.venues.map((fv: any) => (
+                {filteredVenues.map((fv: any) => (
                   <div
                     key={fv.id}
                     className="flex gap-4 p-4 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-2xl shadow-sm relative group"
@@ -268,6 +290,54 @@ export default function FolderDetailsPage({
           </div>
 
           <div className="md:col-span-1 space-y-6">
+            {/* Filter Venues Section */}
+            <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-6 shadow-sm">
+              <h2 className="text-lg font-semibold text-zinc-900 dark:text-white flex items-center gap-2 mb-4">
+                Filter Venues
+              </h2>
+              <div className="space-y-3 text-sm">
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={filters.hasOutlets}
+                    onChange={(e) =>
+                      setFilters((f) => ({
+                        ...f,
+                        hasOutlets: e.target.checked,
+                      }))
+                    }
+                    className="rounded"
+                  />
+                  Has Outlets
+                </label>
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={filters.wifiQualityMin}
+                    onChange={(e) =>
+                      setFilters((f) => ({
+                        ...f,
+                        wifiQualityMin: e.target.checked,
+                      }))
+                    }
+                    className="rounded"
+                  />
+                  Good WiFi (4+)
+                </label>
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={filters.quietOnly}
+                    onChange={(e) =>
+                      setFilters((f) => ({ ...f, quietOnly: e.target.checked }))
+                    }
+                    className="rounded"
+                  />
+                  Quiet Only
+                </label>
+              </div>
+            </div>
+
             {/* Billing Export Section */}
             {userRole !== "VIEWER" && (
               <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-6 shadow-sm">


### PR DESCRIPTION
## Description
Adds multi-category venue filtering to the collection folder sidebar at /collections/[id].

Changes:
- New "Filter Venues" checkbox card in the sidebar (Has Outlets, Good WiFi 4+, Quiet Only)
- Client-side filteredVenues computed via .filter() on the existing folder.venues data — no backend changes needed, since the API already returns full venue amenity data
- Filters combine as AND (all checked conditions must match)
- Separate empty-state message for "no venues match filters" vs "no venues saved at all"

Verification:
- npm run lint, npx tsc --noEmit, npm test (161/161 passing), and npm run build all pass clean
- Verified the sidebar renders correctly with real authentication

## Related Issue
Fixes #385

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added venue filtering by available outlets, minimum WiFi quality, and quietness.
  * Added a “Filter Venues” section with easy-to-use checkboxes.
  * Updated the saved venue count to reflect active filters.
  * Added clear messages for empty saved venues and when no venues match the selected filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->