### PR TITLE
fix: persist database telemetry for serverless environments

### DIFF
--- a/src/__tests__/lib/dbTelemetry.test.ts
+++ b/src/__tests__/lib/dbTelemetry.test.ts
@@ -140,8 +140,14 @@ describe("Database Telemetry", () => {
 
       const stats = await dbTelemetry.getDbLatencyStats();
 
-      expect(mockHgetall).toHaveBeenCalledWith("worksphere:telemetry:global");
-      expect(mockSmembers).toHaveBeenCalledWith("worksphere:telemetry:models");
+      expect(mockHgetall).toHaveBeenCalledWith(
+        "worksphere:telemetry:global",
+        expect.any(Object),
+      );
+      expect(mockSmembers).toHaveBeenCalledWith(
+        "worksphere:telemetry:models",
+        expect.any(Object),
+      );
       expect(mockLrange).toHaveBeenCalledWith(
         "worksphere:telemetry:samples:Product",
         0,
@@ -156,6 +162,34 @@ describe("Database Telemetry", () => {
         model: "Product",
         avgMs: 200,
         p95Ms: 300,
+        sampleCount: 2,
+      });
+    });
+
+    it("should fetch db stats from Redis when it yields pre-deserialized objects (production behavior)", async () => {
+      mockHgetall.mockResolvedValue({
+        totalQueryCount: "5",
+        slowQueryCount: "1",
+      });
+      mockSmembers.mockResolvedValue(["Product"]);
+      // Return objects directly (automatic deserialization behavior)
+      mockExec.mockResolvedValue([
+        [
+          { durationMs: 120, timestamp: Date.now() },
+          { durationMs: 220, timestamp: Date.now() },
+        ],
+      ]);
+
+      const stats = await dbTelemetry.getDbLatencyStats();
+
+      expect(stats.totalQueryCount).toBe(5);
+      expect(stats.slowQueryCount).toBe(1);
+      expect(stats.avgMs).toBe(170);
+      expect(stats.p95Ms).toBe(220);
+      expect(stats.byModel).toContainEqual({
+        model: "Product",
+        avgMs: 170,
+        p95Ms: 220,
         sampleCount: 2,
       });
     });

--- a/src/__tests__/lib/dbTelemetry.test.ts
+++ b/src/__tests__/lib/dbTelemetry.test.ts
@@ -1,0 +1,163 @@
+// Create shared mock functions/objects that are accessible outside/inside Jest mock
+const mockHincrby = jest.fn();
+const mockSadd = jest.fn();
+const mockLpush = jest.fn();
+const mockLtrim = jest.fn();
+const mockLrange = jest.fn();
+const mockExec = jest.fn();
+const mockHgetall = jest.fn();
+const mockSmembers = jest.fn();
+
+const mockPipeline = {
+  hincrby: mockHincrby,
+  sadd: mockSadd,
+  lpush: mockLpush,
+  ltrim: mockLtrim,
+  lrange: mockLrange,
+  exec: mockExec,
+};
+
+const mockRedisInstance = {
+  pipeline: jest.fn().mockReturnValue(mockPipeline),
+  hgetall: mockHgetall,
+  smembers: mockSmembers,
+};
+
+// Return chainable mock pipeline methods
+mockHincrby.mockReturnValue(mockPipeline);
+mockSadd.mockReturnValue(mockPipeline);
+mockLpush.mockReturnValue(mockPipeline);
+mockLtrim.mockReturnValue(mockPipeline);
+mockLrange.mockReturnValue(mockPipeline);
+mockExec.mockResolvedValue([]);
+
+jest.mock("@upstash/redis", () => {
+  return {
+    Redis: jest.fn().mockImplementation(() => mockRedisInstance),
+  };
+});
+
+describe("Database Telemetry", () => {
+  const originalEnv = process.env;
+  let dbTelemetry: typeof import("@/lib/dbTelemetry");
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+
+    // Reset mock implementation/resolved values to default
+    mockHincrby.mockReturnValue(mockPipeline);
+    mockSadd.mockReturnValue(mockPipeline);
+    mockLpush.mockReturnValue(mockPipeline);
+    mockLtrim.mockReturnValue(mockPipeline);
+    mockLrange.mockReturnValue(mockPipeline);
+    mockExec.mockResolvedValue([]);
+    mockHgetall.mockReset();
+    mockSmembers.mockReset();
+
+    // Reset module registry so each test gets a fresh cachedRedis and counters in dbTelemetry
+    jest.resetModules();
+    dbTelemetry = await import("@/lib/dbTelemetry");
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe("In-Memory Fallback", () => {
+    beforeEach(() => {
+      delete process.env.UPSTASH_REDIS_REST_URL;
+      delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    });
+
+    it("should record query durations and calculate stats", async () => {
+      dbTelemetry.recordQueryDuration("User", 150);
+      dbTelemetry.recordQueryDuration("User", 250); // slow query
+
+      const stats = await dbTelemetry.getDbLatencyStats();
+      expect(stats.totalQueryCount).toBe(2);
+      expect(stats.slowQueryCount).toBe(1);
+      expect(stats.slowQueryThresholdMs).toBe(200);
+
+      const userModel = stats.byModel.find((m) => m.model === "User");
+      expect(userModel).toBeDefined();
+      expect(userModel?.avgMs).toBe(200); // (150 + 250) / 2
+      expect(userModel?.sampleCount).toBe(2);
+    });
+  });
+
+  describe("Redis Integration", () => {
+    beforeEach(() => {
+      process.env.UPSTASH_REDIS_REST_URL = "https://mock-redis.upstash.io";
+      process.env.UPSTASH_REDIS_REST_TOKEN = "mock-token";
+    });
+
+    it("should write queries to Redis using a pipeline", async () => {
+      dbTelemetry.recordQueryDuration("Product", 300);
+
+      // Give async microtasks a tick to run
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(mockRedisInstance.pipeline).toHaveBeenCalled();
+      expect(mockHincrby).toHaveBeenCalledWith(
+        "worksphere:telemetry:global",
+        "totalQueryCount",
+        1,
+      );
+      expect(mockHincrby).toHaveBeenCalledWith(
+        "worksphere:telemetry:global",
+        "slowQueryCount",
+        1,
+      );
+      expect(mockSadd).toHaveBeenCalledWith(
+        "worksphere:telemetry:models",
+        "Product",
+      );
+      expect(mockLpush).toHaveBeenCalledWith(
+        "worksphere:telemetry:samples:Product",
+        expect.any(String),
+      );
+      expect(mockLtrim).toHaveBeenCalledWith(
+        "worksphere:telemetry:samples:Product",
+        0,
+        199,
+      );
+      expect(mockExec).toHaveBeenCalled();
+    });
+
+    it("should fetch db stats from Redis", async () => {
+      mockHgetall.mockResolvedValue({
+        totalQueryCount: "10",
+        slowQueryCount: "2",
+      });
+      mockSmembers.mockResolvedValue(["Product"]);
+      mockExec.mockResolvedValue([
+        [
+          JSON.stringify({ durationMs: 100, timestamp: Date.now() }),
+          JSON.stringify({ durationMs: 300, timestamp: Date.now() }),
+        ],
+      ]);
+
+      const stats = await dbTelemetry.getDbLatencyStats();
+
+      expect(mockHgetall).toHaveBeenCalledWith("worksphere:telemetry:global");
+      expect(mockSmembers).toHaveBeenCalledWith("worksphere:telemetry:models");
+      expect(mockLrange).toHaveBeenCalledWith(
+        "worksphere:telemetry:samples:Product",
+        0,
+        -1,
+      );
+
+      expect(stats.totalQueryCount).toBe(10);
+      expect(stats.slowQueryCount).toBe(2);
+      expect(stats.avgMs).toBe(200);
+      expect(stats.p95Ms).toBe(300);
+      expect(stats.byModel).toContainEqual({
+        model: "Product",
+        avgMs: 200,
+        p95Ms: 300,
+        sampleCount: 2,
+      });
+    });
+  });
+});

--- a/src/lib/adminSystemMetrics.ts
+++ b/src/lib/adminSystemMetrics.ts
@@ -16,7 +16,9 @@ type AnalyticsEvent = {
 
 function average(values: number[]) {
   if (values.length === 0) return 0;
-  return Math.round(values.reduce((sum, value) => sum + value, 0) / values.length);
+  return Math.round(
+    values.reduce((sum, value) => sum + value, 0) / values.length,
+  );
 }
 
 function percentile(sortedValues: number[], p: number) {
@@ -37,7 +39,7 @@ export async function getAdminSystemMetrics(range: RangeKey) {
       where: { createdAt: { gte: startDate } },
       select: { createdAt: true },
     }),
-    Promise.resolve(getDbLatencyStats()),
+    getDbLatencyStats(),
   ]);
 
   const recentEvents = (telemetry.recentEvents as AnalyticsEvent[]).filter(

--- a/src/lib/dbTelemetry.ts
+++ b/src/lib/dbTelemetry.ts
@@ -1,11 +1,16 @@
+import { Redis } from "@upstash/redis";
+
 /**
  * Lightweight DB query latency telemetry.
  *
  * We deliberately do NOT log every query into the main analytics event
  * stream (src/lib/analytics.ts) — that would flood Redis/memory with one
- * event per Prisma call. Instead we keep a small in-memory rolling window
- * of recent query durations (per model) and expose aggregate stats
- * (avg / p95 / slow-query count) for the admin dashboard.
+ * event per Prisma call. Instead we keep a small rolling window of recent
+ * query durations (per model) and expose aggregate stats (avg / p95 / slow-query count)
+ * for the admin dashboard.
+ *
+ * Production: Upstash Redis provides durable distributed counters/events.
+ * Development: an in-memory fallback keeps local analytics functional without Redis.
  */
 
 const MAX_SAMPLES_PER_MODEL = 200;
@@ -13,23 +18,74 @@ const SLOW_QUERY_THRESHOLD_MS = 200;
 
 type QuerySample = { durationMs: number; timestamp: number };
 
+// ─── In-memory fallback (development / no Redis) ─────────────────────────────
 const samplesByModel = new Map<string, QuerySample[]>();
 let slowQueryCount = 0;
 let totalQueryCount = 0;
 
+// ─── Redis Setup ─────────────────────────────────────────────────────────────
+let cachedRedis: Redis | null = null;
+
+function getRedis(): Redis | null {
+  if (cachedRedis) return cachedRedis;
+
+  if (
+    !process.env.UPSTASH_REDIS_REST_URL ||
+    !process.env.UPSTASH_REDIS_REST_TOKEN
+  ) {
+    return null;
+  }
+
+  try {
+    cachedRedis = new Redis({
+      url: process.env.UPSTASH_REDIS_REST_URL,
+      token: process.env.UPSTASH_REDIS_REST_TOKEN,
+    });
+  } catch (error) {
+    console.error("[dbTelemetry] Redis initialization failed:", error);
+  }
+
+  return cachedRedis;
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
 export function recordQueryDuration(model: string, durationMs: number) {
+  // Always update local in-memory values as fallback/best-effort
   totalQueryCount += 1;
   if (durationMs >= SLOW_QUERY_THRESHOLD_MS) slowQueryCount += 1;
 
   const key = model || "unknown";
   const samples = samplesByModel.get(key) ?? [];
-  samples.push({ durationMs, timestamp: Date.now() });
+  const sample = { durationMs, timestamp: Date.now() };
+  samples.push(sample);
 
   if (samples.length > MAX_SAMPLES_PER_MODEL) {
     samples.shift();
   }
 
   samplesByModel.set(key, samples);
+
+  // Write to Upstash Redis asynchronously if configured
+  const redis = getRedis();
+  if (redis) {
+    const pipeline = redis.pipeline();
+    const globalKey = "worksphere:telemetry:global";
+    const modelsKey = "worksphere:telemetry:models";
+    const samplesKey = `worksphere:telemetry:samples:${key}`;
+
+    pipeline.hincrby(globalKey, "totalQueryCount", 1);
+    if (durationMs >= SLOW_QUERY_THRESHOLD_MS) {
+      pipeline.hincrby(globalKey, "slowQueryCount", 1);
+    }
+    pipeline.sadd(modelsKey, key);
+    pipeline.lpush(samplesKey, JSON.stringify(sample));
+    pipeline.ltrim(samplesKey, 0, MAX_SAMPLES_PER_MODEL - 1);
+
+    pipeline.exec().catch((error) => {
+      console.error("[dbTelemetry] Redis write failed:", error);
+    });
+  }
 }
 
 function percentile(sorted: number[], p: number) {
@@ -41,7 +97,7 @@ function percentile(sorted: number[], p: number) {
   return sorted[index];
 }
 
-export function getDbLatencyStats() {
+function getDbLatencyStatsSync() {
   const allDurations: number[] = [];
   const byModel: Array<{
     model: string;
@@ -76,4 +132,100 @@ export function getDbLatencyStats() {
     p95Ms: Math.round(percentile(allDurations, 95)),
     byModel: byModel.sort((a, b) => b.avgMs - a.avgMs),
   };
+}
+
+export async function getDbLatencyStats() {
+  const redis = getRedis();
+
+  if (redis) {
+    try {
+      const globalKey = "worksphere:telemetry:global";
+      const modelsKey = "worksphere:telemetry:models";
+
+      const [globalStats, models] = await Promise.all([
+        redis.hgetall(globalKey) as Promise<Record<
+          string,
+          string | number
+        > | null>,
+        redis.smembers(modelsKey) as Promise<string[]>,
+      ]);
+
+      const redisTotalQueryCount = globalStats
+        ? Number(globalStats.totalQueryCount || 0)
+        : 0;
+      const redisSlowQueryCount = globalStats
+        ? Number(globalStats.slowQueryCount || 0)
+        : 0;
+
+      const byModel: Array<{
+        model: string;
+        avgMs: number;
+        p95Ms: number;
+        sampleCount: number;
+      }> = [];
+      const allDurations: number[] = [];
+
+      if (models && models.length > 0) {
+        const pipeline = redis.pipeline();
+        for (const model of models) {
+          pipeline.lrange(`worksphere:telemetry:samples:${model}`, 0, -1);
+        }
+        const samplesListsRaw = await pipeline.exec();
+
+        for (let i = 0; i < models.length; i++) {
+          const model = models[i];
+          const rawSamples = samplesListsRaw[i] as string[];
+          if (!rawSamples || rawSamples.length === 0) continue;
+
+          const durations = rawSamples
+            .map((s) => {
+              try {
+                const parsed = JSON.parse(s);
+                return typeof parsed?.durationMs === "number"
+                  ? parsed.durationMs
+                  : null;
+              } catch {
+                return null;
+              }
+            })
+            .filter((d): d is number => d !== null)
+            .sort((a, b) => a - b);
+
+          if (durations.length === 0) continue;
+
+          allDurations.push(...durations);
+
+          byModel.push({
+            model,
+            avgMs: Math.round(
+              durations.reduce((sum, d) => sum + d, 0) / durations.length,
+            ),
+            p95Ms: Math.round(percentile(durations, 95)),
+            sampleCount: durations.length,
+          });
+        }
+      }
+
+      allDurations.sort((a, b) => a - b);
+
+      return {
+        totalQueryCount: redisTotalQueryCount,
+        slowQueryCount: redisSlowQueryCount,
+        slowQueryThresholdMs: SLOW_QUERY_THRESHOLD_MS,
+        avgMs: Math.round(
+          allDurations.reduce((sum, d) => sum + d, 0) /
+            (allDurations.length || 1),
+        ),
+        p95Ms: Math.round(percentile(allDurations, 95)),
+        byModel: byModel.sort((a, b) => b.avgMs - a.avgMs),
+      };
+    } catch (error) {
+      console.error(
+        "[dbTelemetry] Redis read failed, falling back to in-memory:",
+        error,
+      );
+    }
+  }
+
+  return getDbLatencyStatsSync();
 }

--- a/src/lib/dbTelemetry.ts
+++ b/src/lib/dbTelemetry.ts
@@ -25,6 +25,17 @@ let totalQueryCount = 0;
 
 // ─── Redis Setup ─────────────────────────────────────────────────────────────
 let cachedRedis: Redis | null = null;
+let nextServerAfter: typeof import("next/server").after | null = null;
+
+if (typeof window === "undefined") {
+  import("next/server")
+    .then(({ after }) => {
+      nextServerAfter = after;
+    })
+    .catch(() => {
+      // Ignored: outside of Next.js server environment
+    });
+}
 
 function getRedis(): Redis | null {
   if (cachedRedis) return cachedRedis;
@@ -40,6 +51,7 @@ function getRedis(): Redis | null {
     cachedRedis = new Redis({
       url: process.env.UPSTASH_REDIS_REST_URL,
       token: process.env.UPSTASH_REDIS_REST_TOKEN,
+      retry: false, // Disable automatic retries for telemetry writes
     });
   } catch (error) {
     console.error("[dbTelemetry] Redis initialization failed:", error);
@@ -82,9 +94,20 @@ export function recordQueryDuration(model: string, durationMs: number) {
     pipeline.lpush(samplesKey, JSON.stringify(sample));
     pipeline.ltrim(samplesKey, 0, MAX_SAMPLES_PER_MODEL - 1);
 
-    pipeline.exec().catch((error) => {
-      console.error("[dbTelemetry] Redis write failed:", error);
-    });
+    const promise = pipeline
+      .exec({ signal: AbortSignal.timeout(2000) })
+      .catch((error) => {
+        console.error("[dbTelemetry] Redis write failed:", error);
+      });
+
+    // Request lifecycle integration for Next.js 15+ serverless environments
+    if (nextServerAfter) {
+      try {
+        nextServerAfter(() => promise);
+      } catch {
+        // Ignored: outside of request context
+      }
+    }
   }
 }
 
@@ -142,12 +165,16 @@ export async function getDbLatencyStats() {
       const globalKey = "worksphere:telemetry:global";
       const modelsKey = "worksphere:telemetry:models";
 
+      const timeoutSignal = AbortSignal.timeout(1500);
+
       const [globalStats, models] = await Promise.all([
-        redis.hgetall(globalKey) as Promise<Record<
+        redis.hgetall(globalKey, { signal: timeoutSignal }) as Promise<Record<
           string,
           string | number
         > | null>,
-        redis.smembers(modelsKey) as Promise<string[]>,
+        redis.smembers(modelsKey, { signal: timeoutSignal }) as Promise<
+          string[]
+        >,
       ]);
 
       const redisTotalQueryCount = globalStats
@@ -170,17 +197,17 @@ export async function getDbLatencyStats() {
         for (const model of models) {
           pipeline.lrange(`worksphere:telemetry:samples:${model}`, 0, -1);
         }
-        const samplesListsRaw = await pipeline.exec();
+        const samplesListsRaw = await pipeline.exec({ signal: timeoutSignal });
 
         for (let i = 0; i < models.length; i++) {
           const model = models[i];
-          const rawSamples = samplesListsRaw[i] as string[];
+          const rawSamples = samplesListsRaw[i] as any[];
           if (!rawSamples || rawSamples.length === 0) continue;
 
           const durations = rawSamples
             .map((s) => {
               try {
-                const parsed = JSON.parse(s);
+                const parsed = typeof s === "string" ? JSON.parse(s) : s;
                 return typeof parsed?.durationMs === "number"
                   ? parsed.durationMs
                   : null;


### PR DESCRIPTION
## Description

This PR fixes serverless state loss in the database telemetry system by replacing process-local telemetry with a Redis-backed implementation while preserving an in-memory fallback for local development.

### Changes
- Added centralized Redis-backed telemetry storage using the existing Upstash Redis infrastructure.
- Preserved the in-memory fallback when Redis is not configured (development/local environments).
- Updated the admin system metrics service to support asynchronous telemetry retrieval.
- Added comprehensive unit tests covering both Redis-backed and in-memory telemetry implementations.

## Related Issue

Fixes #490

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings in the modified code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

Not applicable (backend/infrastructure change).

## Breaking Changes

- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Redis-backed database latency telemetry with query recording and retrieval of aggregate + per-model stats (average and 95th-percentile).
  * Telemetry includes total queries, slow-query counts, sample counts, and uses stored per-model samples to compute distributions.

* **Reliability**
  * Preserves an in-memory fallback when Redis is unavailable or misconfigured, including graceful handling of Redis read failures.

* **Tests**
  * Added a comprehensive test suite covering both in-memory and Redis behaviors, including multiple Redis response shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->