### PR TITLE
[Refactor]: Add periodic cleanup interval to LRUCache

### DIFF
--- a/src/__tests__/lib/cache.test.ts
+++ b/src/__tests__/lib/cache.test.ts
@@ -1,0 +1,44 @@
+import { LRUCache } from "../../lib/cache";
+
+describe("LRUCache Memory Leak Fix", () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it("should proactively remove expired items via the background interval", () => {
+    const ttlMs = 500;
+    const capacity = 100;
+
+    // Create the cache instance
+    const cache = new LRUCache<string>(capacity, ttlMs);
+
+    // 1. Insert an item
+    cache.set("test-key", "test-value");
+
+    // 2. Verify it's accessible immediately
+    expect(cache.get("test-key")).toBe("test-value");
+
+    // Re-insert to reset the TTL
+    cache.set("test-key", "test-value");
+
+    // 3. Fast-forward time past the TTL and the cleanup interval.
+    // The constructor sets the interval to Math.max(1000, Math.min(ttlMs, 60000))
+    // So for 500ms TTL, the interval runs every 1000ms.
+    jest.advanceTimersByTime(1100);
+
+    // 4. Access the raw underlying Map to verify it was evicted automatically.
+    const internalMap = (cache as any).cache as Map<string, any>;
+
+    // With our proactive interval fix, it should be false!
+    expect(internalMap.has("test-key")).toBe(false);
+
+    // Clean up interval to keep test runners happy
+    if (cache.dispose) {
+      cache.dispose();
+    }
+  });
+});

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -3,6 +3,7 @@ export interface Cache<T> {
   set(key: string, value: T): void;
   invalidate(key: string): void;
   clear(): void;
+  dispose?(): void;
 }
 
 interface CacheItem<T> {
@@ -14,6 +15,7 @@ export class LRUCache<T> implements Cache<T> {
   private capacity: number;
   private ttlMs: number;
   private cache: Map<string, CacheItem<T>>;
+  private cleanupInterval: ReturnType<typeof setInterval>;
 
   /**
    * @param capacity Maximum number of items the cache can hold
@@ -26,6 +28,28 @@ export class LRUCache<T> implements Cache<T> {
     this.capacity = capacity;
     this.ttlMs = ttlMs;
     this.cache = new Map();
+
+    const intervalTime = Math.min(ttlMs, 60000); // Check at most every 60 seconds
+    this.cleanupInterval = setInterval(
+      () => this.cleanup(),
+      Math.max(1000, intervalTime),
+    );
+
+    if (
+      this.cleanupInterval &&
+      typeof (this.cleanupInterval as any).unref === "function"
+    ) {
+      (this.cleanupInterval as any).unref();
+    }
+  }
+
+  private cleanup(): void {
+    const now = Date.now();
+    for (const [key, item] of this.cache.entries()) {
+      if (now > item.expiresAt) {
+        this.cache.delete(key);
+      }
+    }
   }
 
   get(key: string): T | undefined {
@@ -69,6 +93,11 @@ export class LRUCache<T> implements Cache<T> {
   }
 
   clear(): void {
+    this.cache.clear();
+  }
+
+  dispose(): void {
+    clearInterval(this.cleanupInterval);
     this.cache.clear();
   }
 }


### PR DESCRIPTION
- closes #489

### Summary
This PR addresses an unbounded memory leak in the `LRUCache` caused by expired items remaining in memory indefinitely under the previous lazy eviction strategy.

### Changes
- Implemented a proactive background cleanup task using `setInterval` to periodically evict expired cache entries.
- Configured the interval to run dynamically based on the cache's TTL (up to a maximum of 60 seconds) for optimal performance.
- Added `unref()` to the cleanup timer to prevent blocking the Node.js event loop during application teardown.
- Added a `dispose()` method to explicitly clear the cache and release the interval when the cache is no longer needed.

### Impact
These changes ensure memory is reclaimed promptly, preventing long-running instances from experiencing memory bloat and unexpected OOM crashes, while preserving optimal O(1) performance for standard read/write operations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache reliability by automatically removing expired entries in the background, helping prevent stale data from accumulating.

* **Enhancements**
  * Added lifecycle support to stop cache cleanup and release associated resources when no longer needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->