### PR TITLE
Fix/indexeddb connection leak 491

### DIFF
--- a/src/lib/offlineStore.ts
+++ b/src/lib/offlineStore.ts
@@ -44,7 +44,10 @@ if (typeof window !== "undefined") {
 
 function getDB(): Promise<IDBDatabase> {
   // Guard: IndexedDB is not available in SSR / Node environments.
-  if (typeof window === "undefined") {
+  // Checking `indexedDB` directly (rather than `window`) ensures that
+  // contexts such as Service Workers — which expose indexedDB without a
+  // window object — are not incorrectly rejected.
+  if (typeof indexedDB === "undefined") {
     return Promise.reject(
       new Error("IndexedDB is not available on server-side"),
     );

--- a/src/lib/offlineStore.ts
+++ b/src/lib/offlineStore.ts
@@ -24,8 +24,12 @@ export interface OfflineAction {
 let dbInstance: IDBDatabase | null = null;
 let dbPromise: Promise<IDBDatabase> | null = null;
 
-// Register the beforeunload cleanup exactly once per module load.
-// { once: true } prevents duplicate listeners on HMR reloads.
+// Register the beforeunload cleanup at module load time.
+// { once: true } auto-removes the listener after it fires, preventing it from
+// running on subsequent navigations in long-lived SPAs.  HMR reloads
+// re-execute this block and register a new listener each time, but the
+// operations (db.close() and null assignments) are idempotent so duplicate
+// registrations are harmless.
 if (typeof window !== "undefined") {
   window.addEventListener(
     "beforeunload",
@@ -84,6 +88,7 @@ function getDB(): Promise<IDBDatabase> {
       };
 
       dbInstance = db;
+      dbPromise = null; // opening is complete; dbInstance is now the sole authority
       resolve(db);
     };
 

--- a/src/lib/offlineStore.ts
+++ b/src/lib/offlineStore.ts
@@ -8,13 +8,59 @@ export interface OfflineAction {
   timestamp: number;
 }
 
+// ---------------------------------------------------------------------------
+// Singleton connection state
+//
+// dbInstance  — the live IDBDatabase once the DB is open
+// dbPromise   — the in-flight Promise while the DB is opening
+//
+// Rules:
+//   • Only ONE indexedDB.open() call is ever in-flight at a time.
+//   • Concurrent callers all await the same dbPromise.
+//   • A failed open clears both variables so the next caller retries cleanly.
+//   • A versionchange event closes the stale connection and clears the cache.
+//   • beforeunload closes the connection gracefully (registered once).
+// ---------------------------------------------------------------------------
+let dbInstance: IDBDatabase | null = null;
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+// Register the beforeunload cleanup exactly once per module load.
+// { once: true } prevents duplicate listeners on HMR reloads.
+if (typeof window !== "undefined") {
+  window.addEventListener(
+    "beforeunload",
+    () => {
+      dbInstance?.close();
+      dbInstance = null;
+      dbPromise = null;
+    },
+    { once: true },
+  );
+}
+
 function getDB(): Promise<IDBDatabase> {
-  return new Promise((resolve, reject) => {
-    if (typeof window === "undefined") {
-      reject(new Error("IndexedDB is not available on server-side"));
-      return;
-    }
+  // Guard: IndexedDB is not available in SSR / Node environments.
+  if (typeof window === "undefined") {
+    return Promise.reject(
+      new Error("IndexedDB is not available on server-side"),
+    );
+  }
+
+  // Fast path — return the already-open connection immediately.
+  if (dbInstance !== null) {
+    return Promise.resolve(dbInstance);
+  }
+
+  // In-flight path — a previous caller already issued indexedDB.open();
+  // share that same Promise instead of opening a second connection.
+  if (dbPromise !== null) {
+    return dbPromise;
+  }
+
+  // Slow path — first caller: open the database and cache the Promise.
+  dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
     const request = indexedDB.open(DB_NAME, 1);
+
     request.onupgradeneeded = (event) => {
       const db = (event.target as IDBOpenDBRequest).result;
       if (!db.objectStoreNames.contains(STORE_NAME)) {
@@ -24,13 +70,32 @@ function getDB(): Promise<IDBDatabase> {
         });
       }
     };
+
     request.onsuccess = () => {
-      resolve(request.result);
+      const db = request.result;
+
+      // Handle external schema upgrades (e.g. another tab calling a higher
+      // DB version).  Close the stale connection and clear the singleton so
+      // the next getDB() call re-opens with the new version.
+      db.onversionchange = () => {
+        db.close();
+        dbInstance = null;
+        dbPromise = null;
+      };
+
+      dbInstance = db;
+      resolve(db);
     };
+
     request.onerror = () => {
+      // Clear both variables so the next getDB() call starts fresh.
+      dbInstance = null;
+      dbPromise = null;
       reject(request.error);
     };
   });
+
+  return dbPromise;
 }
 
 /**


### PR DESCRIPTION
## Description

This PR fixes the IndexedDB connection leak in `src/lib/offlineStore.ts` by implementing a singleton database connection lifecycle.

### Changes
- Reused a single `IDBDatabase` instance across the application.
- Prevented concurrent `indexedDB.open()` calls by sharing an in-flight Promise.
- Cleared the cached Promise after a successful connection.
- Handled `versionchange` events by closing stale connections and resetting cached state.
- Added cleanup on `beforeunload` to close the cached connection.
- Updated lifecycle comments for better technical accuracy.

## Related Issue

Fixes #491

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

N/A (No UI changes)

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline data reliability by reusing a single IndexedDB connection.
  * Prevented multiple simultaneous database-open operations.
  * Added safer recovery when database open fails, so retries start fresh.
  * Handled database schema/version changes by closing stale connections and reopening when needed.
  * Ensured the database connection is properly closed when leaving the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->