### PR TITLE
docs: add multi-agent chatbot token optimization directives (closes #…

### DIFF
--- a/docs/CHATBOT_TOKEN_OPTIMIZATION.md
+++ b/docs/CHATBOT_TOKEN_OPTIMIZATION.md
@@ -1,0 +1,42 @@
+# Multi-Agent Chatbot Token Optimization Directives
+
+This document outlines the strict directives for managing and optimizing token consumption when interacting with the Groq LLM API in the WorkSphere multi-agent chatbot system.
+
+---
+
+## 1. Prompt Context Reduction Rules
+
+Sending the entire conversation history to the LLM for every request leads to massive token waste and API rate limits. Implement the following rules for context reduction:
+
+- **Rolling Window Context:** Only send the last 5 to 7 conversational turns (user/assistant pairs) to the LLM.
+- **Dynamic Summarization:** Once the conversation exceeds 10 turns, trigger a background agent to generate a concise summary of the older context. Append this summary to the system prompt and clear the older messages.
+- **State-Based Pruning:** Remove system acknowledgments, filler words, or UI-specific JSON responses from the context array before sending it back to the API.
+
+---
+
+## 2. Message Length Constraints
+
+To prevent malicious token draining and maintain fast inference speeds on Groq, enforce the following constraints at the application level:
+
+- **User Input Limit:** Restrict user message inputs to a maximum of 500 characters. Implement UI-level validation to block oversized inputs.
+- **System Prompt Limit:** System prompts must not exceed 800 tokens. If an agent requires more context, split the agent's responsibilities into two separate specialized agents.
+- **Output Max Tokens:** Always enforce a strict `max_tokens` parameter (e.g., 300 to 500) on the API request to prevent runaway generation.
+
+---
+
+## 3. System Prompt Structuring
+
+Clean and efficient system prompts directly impact token usage and response accuracy.
+
+- **Zero-Fluff Directives:** Eliminate conversational filler in system prompts. Use concise commands instead of polite requests.
+- **Format Specifications:** Explicitly define the output format using tight JSON schemas or Markdown structures to prevent the LLM from generating unnecessary explanatory text.
+- **Role Definition:** Clearly state the agent's exact role in the first sentence to heavily weight its attention mechanism, reducing the need for repeated instructions throughout the prompt.
+
+---
+
+## 4. Prompt Caching Strategy
+
+While Groq processes tokens extremely fast, re-sending static data is inefficient.
+
+- **Static System Prompts:** Store static system prompts in environment variables or a constant configuration file to avoid regenerating them dynamically on every request.
+- **Redis Caching:** Cache identical user queries. Before sending a query to the Groq API, hash the prompt and check if an exact match exists in the Redis cache. If it exists and is less than 24 hours old, return the cached response instead of hitting the API.

--- a/docs/CHATBOT_TOKEN_OPTIMIZATION.md
+++ b/docs/CHATBOT_TOKEN_OPTIMIZATION.md
@@ -8,8 +8,8 @@ This document outlines the strict directives for managing and optimizing token c
 
 Sending the entire conversation history to the LLM for every request leads to massive token waste and API rate limits. Implement the following rules for context reduction:
 
-- **Rolling Window Context:** Only send the last 5 to 7 conversational turns (user/assistant pairs) to the LLM.
-- **Dynamic Summarization:** Once the conversation exceeds 10 turns, trigger a background agent to generate a concise summary of the older context. Append this summary to the system prompt and clear the older messages.
+- **Token-Budget Based Pruning:** Do not rely solely on turn counts (e.g., the last 5 messages). Instead, define a strict input-token budget—including the system prompt, tools, summary, and current request—and prune the older history until it fits.
+- **Dynamic Summarization:** Once the context approaches the token budget, trigger a background agent to generate a concise summary of the older context. Keep this dynamic summary separate from the static system prompt prefix to ensure Groq's automatic prefix caching functions correctly.
 - **State-Based Pruning:** Remove system acknowledgments, filler words, or UI-specific JSON responses from the context array before sending it back to the API.
 
 ---
@@ -18,9 +18,9 @@ Sending the entire conversation history to the LLM for every request leads to ma
 
 To prevent malicious token draining and maintain fast inference speeds on Groq, enforce the following constraints at the application level:
 
-- **User Input Limit:** Restrict user message inputs to a maximum of 500 characters. Implement UI-level validation to block oversized inputs.
+- **User Input Limit:** Enforce token-aware input limits strictly on the server-side before invoking Groq. UI-level character validation is bypassable and insufficient for token management.
 - **System Prompt Limit:** System prompts must not exceed 800 tokens. If an agent requires more context, split the agent's responsibilities into two separate specialized agents.
-- **Output Max Tokens:** Always enforce a strict `max_tokens` parameter (e.g., 300 to 500) on the API request to prevent runaway generation.
+- **Output Max Tokens:** Always enforce a strict `max_completion_tokens` parameter on the API request. Set this budget dynamically based on the specific model and the agent's task to prevent runaway generation.
 
 ---
 
@@ -29,7 +29,7 @@ To prevent malicious token draining and maintain fast inference speeds on Groq, 
 Clean and efficient system prompts directly impact token usage and response accuracy.
 
 - **Zero-Fluff Directives:** Eliminate conversational filler in system prompts. Use concise commands instead of polite requests.
-- **Format Specifications:** Explicitly define the output format using tight JSON schemas or Markdown structures to prevent the LLM from generating unnecessary explanatory text.
+- **Format Specifications:** The response format must exactly match the consuming agent's requirements. For the orchestrator contract, require strict schema-constrained JSON and explicitly prohibit Markdown to prevent downstream `JSON.parse()` errors.
 - **Role Definition:** Clearly state the agent's exact role in the first sentence to heavily weight its attention mechanism, reducing the need for repeated instructions throughout the prompt.
 
 ---
@@ -38,5 +38,5 @@ Clean and efficient system prompts directly impact token usage and response accu
 
 While Groq processes tokens extremely fast, re-sending static data is inefficient.
 
-- **Static System Prompts:** Store static system prompts in environment variables or a constant configuration file to avoid regenerating them dynamically on every request.
-- **Redis Caching:** Cache identical user queries. Before sending a query to the Groq API, hash the prompt and check if an exact match exists in the Redis cache. If it exists and is less than 24 hours old, return the cached response instead of hitting the API.
+- **Static System Prompts:** Store static system prompts in environment variables or a constant configuration file. Keep stable instructions at the very beginning of the prompt so Groq can automatically cache the exact prefix.
+- **Redis Caching:** Cache identical user queries securely. To prevent returning stale data or breaching tenant boundaries, scope Redis cache keys to the complete authorized request. This must include the tenant/user scope, model, system-prompt version, context state, and locale. Only return a cache hit after completing all authorization checks.


### PR DESCRIPTION
## Description

This PR adds the `docs/CHATBOT_TOKEN_OPTIMIZATION.md` file to establish standards for Groq LLM API token consumption in our multi-agent system.

### Changes Made
* Created `CHATBOT_TOKEN_OPTIMIZATION.md`.
* Added rules for prompt context reduction and dynamic summarization.
* Outlined hard constraints for message lengths and output limits.
* Provided best practices for structuring clean, zero-fluff system prompts.
* Added directives for implementing prompt caching via Redis.

## Related Issue

Closes #578

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for optimizing chatbot token usage, including context/history pruning based on token budgets, stricter generation constraints (system prompt and completion caps), enforcing exact machine-readable response formatting, and server-side input size limits.
  * Documented prompt caching strategy for faster, safer repeat requests, with cache keys scoped to model, locale, and authorized request context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->