### PR TITLE
docs: add Clerk user webhooks payload sync schema documentation (clos…

### DIFF
--- a/docs/CLERK_SYNC_SCHEMA.md
+++ b/docs/CLERK_SYNC_SCHEMA.md
@@ -20,8 +20,8 @@ When a webhook is received, the payload data must be extracted and mapped to our
 
 | Clerk Payload Field                | Clerk Type       | Prisma Model Variable | Prisma Type       | Description                                   |
 | :--------------------------------- | :--------------- | :-------------------- | :---------------- | :-------------------------------------------- |
-| `id`                               | `String`         | `clerkId`             | `String (Unique)` | The primary identifier for the user in Clerk. |
-| `email_addresses[0].email_address` | `Array[Object]`  | `email`               | `String (Unique)` | The primary email address of the user.        |
+| `id`                               | `String`         | `id`                  | `String (Unique)` | The primary identifier for the user in Clerk. |
+| `email_addresses[0].email_address` | `Array[Object]`  | `email`               | `String?`         | The primary email address of the user.        |
 | `first_name`                       | `String \| null` | `firstName`           | `String?`         | The user's first name.                        |
 | `last_name`                        | `String \| null` | `lastName`            | `String?`         | The user's last name.                         |
 | `image_url`                        | `String`         | `imageUrl`            | `String?`         | URL to the user's avatar/profile picture.     |
@@ -30,7 +30,7 @@ When a webhook is received, the payload data must be extracted and mapped to our
 
 ## 3. Payload Extraction Example
 
-When processing the incoming webhook, use the following pattern to extract the required variables safely, as some fields (like names) may be null depending on the user's sign-up method.
+When processing the incoming webhook, use the following pattern to extract the required variables safely, as some fields (like names) may be null depending on the user's sign-up method. Ensure you use optional chaining to prevent crashes on empty arrays.
 
 ```typescript
 // Inside the webhook handler
@@ -43,20 +43,30 @@ const evt = wh.verify(body, {
 if (evt.type === "user.created" || evt.type === "user.updated") {
   const { id, email_addresses, first_name, last_name, image_url } = evt.data;
 
-  // Extract the primary email reliably
-  const primaryEmail = email_addresses.find(
-    (email) => email.id === evt.data.primary_email_address_id,
-  )?.email_address;
+  // Extract the primary email reliably with safe fallbacks
+  const primaryEmail =
+    email_addresses?.find(
+      (email) => email.id === evt.data.primary_email_address_id,
+    )?.email_address ||
+    email_addresses?.[0]?.email_address ||
+    null;
 
   const prismaData = {
-    clerkId: id,
-    email: primaryEmail || email_addresses[0].email_address,
-    firstName: first_name || "",
-    lastName: last_name || "",
-    imageUrl: image_url || "",
+    email: primaryEmail,
+    firstName: first_name || null,
+    lastName: last_name || null,
+    imageUrl: image_url || null,
   };
 
-  // Proceed with prisma.user.upsert(prismaData)
+  // Perform an idempotent upsert to handle out-of-order webhooks
+  await prisma.user.upsert({
+    where: { id: id },
+    update: prismaData,
+    create: {
+      id: id,
+      ...prismaData,
+    },
+  });
 }
 ```
 
@@ -64,5 +74,5 @@ if (evt.type === "user.created" || evt.type === "user.updated") {
 
 ## 4. Security Requirements
 
-- **Svix Verification:** All incoming webhooks MUST be verified using the `svix` package and the `CLERK_WEBHOOK_SECRET` environment variable to ensure the payload originated from Clerk.
-- **Idempotent Operations:** Always use `prisma.user.upsert` rather than `create` to prevent unique constraint errors if a webhook is delivered multiple times or out of order.
+- **Svix Verification:** All incoming webhooks MUST be verified using the `svix` package and the `WEBHOOK_SECRET` environment variable to ensure the payload originated from Clerk.
+- **Idempotent Operations:** Always use `prisma.user.upsert` with a `where`, `update`, and `create` block rather than `create` directly to prevent unique constraint errors if a webhook is delivered multiple times or out of order.

--- a/docs/CLERK_SYNC_SCHEMA.md
+++ b/docs/CLERK_SYNC_SCHEMA.md
@@ -1,0 +1,68 @@
+# Clerk User Webhooks Payload Sync Schema Documentation
+
+This document outlines the schema mapping between the JSON payload sent by Clerk Webhooks (specifically `user.created` and `user.updated` events) and the WorkSphere database User model defined in Prisma.
+
+---
+
+## 1. Webhook Event Types
+
+WorkSphere listens for the following Clerk webhook events to keep the local database synchronized:
+
+- `user.created`: Triggered when a new user signs up.
+- `user.updated`: Triggered when a user changes their profile details (e.g., name, email, profile picture).
+- `user.deleted`: Triggered when a user deletes their account.
+
+---
+
+## 2. Schema Mapping Reference
+
+When a webhook is received, the payload data must be extracted and mapped to our Prisma `User` model. Below is the mapping standard for the data object.
+
+| Clerk Payload Field                | Clerk Type       | Prisma Model Variable | Prisma Type       | Description                                   |
+| :--------------------------------- | :--------------- | :-------------------- | :---------------- | :-------------------------------------------- |
+| `id`                               | `String`         | `clerkId`             | `String (Unique)` | The primary identifier for the user in Clerk. |
+| `email_addresses[0].email_address` | `Array[Object]`  | `email`               | `String (Unique)` | The primary email address of the user.        |
+| `first_name`                       | `String \| null` | `firstName`           | `String?`         | The user's first name.                        |
+| `last_name`                        | `String \| null` | `lastName`            | `String?`         | The user's last name.                         |
+| `image_url`                        | `String`         | `imageUrl`            | `String?`         | URL to the user's avatar/profile picture.     |
+
+---
+
+## 3. Payload Extraction Example
+
+When processing the incoming webhook, use the following pattern to extract the required variables safely, as some fields (like names) may be null depending on the user's sign-up method.
+
+```typescript
+// Inside the webhook handler
+const evt = wh.verify(body, {
+  "svix-id": svix_id,
+  "svix-timestamp": svix_timestamp,
+  "svix-signature": svix_signature,
+}) as WebhookEvent;
+
+if (evt.type === "user.created" || evt.type === "user.updated") {
+  const { id, email_addresses, first_name, last_name, image_url } = evt.data;
+
+  // Extract the primary email reliably
+  const primaryEmail = email_addresses.find(
+    (email) => email.id === evt.data.primary_email_address_id,
+  )?.email_address;
+
+  const prismaData = {
+    clerkId: id,
+    email: primaryEmail || email_addresses[0].email_address,
+    firstName: first_name || "",
+    lastName: last_name || "",
+    imageUrl: image_url || "",
+  };
+
+  // Proceed with prisma.user.upsert(prismaData)
+}
+```
+
+---
+
+## 4. Security Requirements
+
+- **Svix Verification:** All incoming webhooks MUST be verified using the `svix` package and the `CLERK_WEBHOOK_SECRET` environment variable to ensure the payload originated from Clerk.
+- **Idempotent Operations:** Always use `prisma.user.upsert` rather than `create` to prevent unique constraint errors if a webhook is delivered multiple times or out of order.


### PR DESCRIPTION
## Description

This PR introduces the `docs/CLERK_SYNC_SCHEMA.md` file to document the synchronization schema between Clerk user webhooks and our Prisma database model.

### Changes Made
* Created `CLERK_SYNC_SCHEMA.md`.
* Documented the required webhook event types (`user.created`, `user.updated`, `user.deleted`).
* Added a detailed mapping table comparing Clerk payload fields to Prisma model variables.
* Provided a TypeScript extraction example for safe data handling and null checking.
* Added security requirements for Svix signature verification and idempotent database operations.

## Related Issue

Closes #577

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a reference document detailing how Clerk `user.created` and `user.updated` webhook payload fields map to WorkSphere user records.
  * Includes examples for primary email selection, normalization of optional fields, required webhook verification, and idempotent synchronization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->