### PR TITLE
fix: prevent ConstraintError on double-click by removing explicit IDB…

### DIFF
--- a/src/__tests__/lib/offlineStore.test.ts
+++ b/src/__tests__/lib/offlineStore.test.ts
@@ -1,0 +1,76 @@
+import "fake-indexeddb/auto";
+
+/**
+ * Tests for src/lib/offlineStore.ts
+ *
+ * Covers Issue #395: double-clicking the offline favourite button caused a
+ * ConstraintError because queueOfflineFavorite supplied an explicit `id`
+ * computed from Date.now(), which collided when two calls arrived within the
+ * same millisecond.  The fix removes the explicit id so IndexedDB's own
+ * autoIncrement generator assigns unique keys.
+ */
+
+import {
+  queueOfflineFavorite,
+  getQueuedFavorites,
+  dequeueOfflineAction,
+} from "../../lib/offlineStore";
+
+describe("offlineStore – queueOfflineFavorite", () => {
+  it("queues a single action with the correct shape", async () => {
+    await queueOfflineFavorite("venue-1", "ADD");
+
+    const queued = await getQueuedFavorites();
+    const entry = queued.find((a) => a.venueId === "venue-1");
+
+    expect(entry).toBeDefined();
+    expect(entry!.action).toBe("ADD");
+    expect(typeof entry!.timestamp).toBe("number");
+    // id must be present and be a number (assigned by autoIncrement)
+    expect(typeof entry!.id).toBe("number");
+  });
+
+  it("does NOT throw a ConstraintError when called twice in rapid succession (double-click)", async () => {
+    // Fire both calls concurrently without awaiting the first — this mirrors
+    // what happens when a user double-clicks the Check In / Favourite button.
+    await expect(
+      Promise.all([
+        queueOfflineFavorite("venue-double", "ADD"),
+        queueOfflineFavorite("venue-double", "ADD"),
+      ]),
+    ).resolves.not.toThrow();
+
+    const queued = await getQueuedFavorites();
+    const entries = queued.filter((a) => a.venueId === "venue-double");
+
+    // Both inserts must have succeeded — two distinct records in the store.
+    expect(entries).toHaveLength(2);
+
+    // Each record must have a unique autoIncrement id.
+    const ids = entries.map((e) => e.id);
+    expect(new Set(ids).size).toBe(2);
+  });
+
+  it("queues a REMOVE action correctly", async () => {
+    await queueOfflineFavorite("venue-remove", "REMOVE");
+
+    const queued = await getQueuedFavorites();
+    const entry = queued.find((a) => a.venueId === "venue-remove");
+
+    expect(entry).toBeDefined();
+    expect(entry!.action).toBe("REMOVE");
+  });
+
+  it("dequeueOfflineAction removes the correct entry by id", async () => {
+    await queueOfflineFavorite("venue-dequeue", "ADD");
+
+    const before = await getQueuedFavorites();
+    const target = before.find((a) => a.venueId === "venue-dequeue");
+    expect(target).toBeDefined();
+
+    await dequeueOfflineAction(target!.id!);
+
+    const after = await getQueuedFavorites();
+    expect(after.find((a) => a.id === target!.id)).toBeUndefined();
+  });
+});

--- a/src/lib/offlineStore.ts
+++ b/src/lib/offlineStore.ts
@@ -107,7 +107,14 @@ function getDB(): Promise<IDBDatabase> {
 }
 
 /**
- * Pushes a target action into the client IndexedDB transaction queue
+ * Pushes a target action into the client IndexedDB transaction queue.
+ *
+ * Key assignment is deliberately left to IndexedDB's built-in autoIncrement
+ * generator — do NOT supply an explicit `id` field.  A hand-crafted key based
+ * on Date.now() collides when two clicks arrive within the same millisecond
+ * (double-click), producing a ConstraintError on the second store.add() call.
+ * The autoIncrement counter is serialised by the IndexedDB engine and is
+ * guaranteed to be unique across concurrent transactions. (Issue #395)
  */
 export async function queueOfflineFavorite(
   venueId: string,
@@ -118,9 +125,8 @@ export async function queueOfflineFavorite(
     return new Promise((resolve, reject) => {
       const tx = db.transaction(STORE_NAME, "readwrite");
       const store = tx.objectStore(STORE_NAME);
-      const uniqueId = Date.now() * 1000 + Math.floor(Math.random() * 1000);
+      // No `id` field — let the autoIncrement keyPath assign a collision-free key.
       store.add({
-        id: uniqueId,
         venueId,
         action,
         timestamp: Date.now(),


### PR DESCRIPTION
## Description

This PR fixes a race condition that could cause an IndexedDB `ConstraintError` when users rapidly performed offline check-ins.

### Changes

- Removed manual IndexedDB key generation for queued offline records
- Used IndexedDB's built-in `autoIncrement` key generation
- Added tests covering concurrent offline queue insertions
- Preserved the existing offline sync behavior and public APIs

## Related Issue

Fixes #395

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

N/A (Bug fix only)

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline favorite queuing to prevent failures when multiple actions are added in rapid succession.
  * Ensured queued favorite actions receive unique identifiers automatically.
  * Added coverage for adding, removing, and dequeuing offline favorite actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->