### PR TITLE
fix: move in-memory rate limiter cleanup off request path

### DIFF
--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -64,15 +64,41 @@ interface RateLimitInfo {
 }
 const rateLimitInfoStore = new Map<string, RateLimitInfo>();
 
-function memRateLimit(identifier: string, limit: number): boolean {
+// Run cleanup in the background instead of on the request path.
+const CLEANUP_INTERVAL_MS = 60_000;
+
+function cleanupExpiredEntries() {
   const now = Date.now();
 
-  // Periodic cleanup — keep memory from growing unbounded
-  if (memStore.size > 10_000) {
-    for (const [k, v] of memStore) {
-      if (now > v.resetTime) memStore.delete(k);
+  for (const [key, value] of memStore) {
+    if (now > value.resetTime) {
+      memStore.delete(key);
     }
   }
+
+  for (const [key, value] of rateLimitInfoStore) {
+    if (now > value.resetTime) {
+      rateLimitInfoStore.delete(key);
+    }
+  }
+}
+
+// Start a single background cleanup task.
+const globalCleanup = globalThis as typeof globalThis & {
+  __rateLimitCleanupTimer?: NodeJS.Timeout;
+};
+
+if (!globalCleanup.__rateLimitCleanupTimer) {
+  globalCleanup.__rateLimitCleanupTimer = setInterval(
+    cleanupExpiredEntries,
+    CLEANUP_INTERVAL_MS,
+  );
+
+  globalCleanup.__rateLimitCleanupTimer.unref?.();
+}
+
+function memRateLimit(identifier: string, limit: number): boolean {
+  const now = Date.now();
 
   const entry = memStore.get(identifier);
 
@@ -137,14 +163,6 @@ export async function rateLimit(
       isLimited: !success,
     });
     return success;
-  }
-
-  // Periodic cleanup of the Upstash info store to avoid unbound memory growth
-  if (rateLimitInfoStore.size > 10_000) {
-    const now = Date.now();
-    for (const [k, v] of rateLimitInfoStore) {
-      if (now > v.resetTime) rateLimitInfoStore.delete(k);
-    }
   }
 
   return memRateLimit(identifier, limit);


### PR DESCRIPTION
## Description

This PR fixes a performance and security issue in the in-memory rate limiter fallback by removing synchronous cleanup from the request path.

### Changes made

- Introduced a background cleanup task that runs every **60 seconds**.
- Moved expired-entry cleanup into a dedicated `cleanupExpiredEntries()` function.
- Removed the **O(N)** cleanup loop from `memRateLimit()`.
- Removed synchronous cleanup of `rateLimitInfoStore` from `rateLimit()`.
- Added a singleton cleanup timer using `globalThis` to ensure only one cleanup interval is created.

### Why this change is needed

Previously, once the in-memory store exceeded the cleanup threshold, every incoming request could trigger a full map scan. Under sustained traffic, this caused repeated **O(N)** iterations on the Node.js event loop, leading to increased CPU usage and potential denial-of-service (DoS) conditions.

By moving cleanup to a scheduled background task, request processing remains lightweight and avoids blocking the event loop with expensive cleanup work.

## Related Issue

Fixes #487

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes *(The local test suite could not be executed because Jest fails during initialization due to a missing `fake-indexeddb/auto` dependency, which is unrelated to this change.)*
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

Not applicable. This change does not affect the UI.

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rate-limit data cleanup by running it automatically in the background.
  * Expired rate-limit records are now removed consistently from both memory and cached data.
  * Reduced unnecessary cleanup work during individual requests, improving request handling efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->