### PR TITLE
fix(prisma): add cascade delete for user-owned relations

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -102,7 +102,7 @@ model Venue {
 model VenueRating {
   id                String   @id @default(cuid())
   userId            String
-  user              User     @relation(fields: [userId], references: [id])
+  user              User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   venueId           String
   venue             Venue    @relation(fields: [venueId], references: [id])
   wifiQuality       Int // 1-5
@@ -141,7 +141,7 @@ model VenueRating {
 model Favorite {
   id        String   @id @default(cuid())
   userId    String
-  user      User     @relation(fields: [userId], references: [id])
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   venueId   String
   venue     Venue    @relation(fields: [venueId], references: [id])
   createdAt DateTime @default(now())
@@ -153,7 +153,7 @@ model Favorite {
 model Conversation {
   id        String    @id @default(cuid())
   userId    String
-  user      User      @relation(fields: [userId], references: [id])
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   title     String?   @default("Work Space Search")
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
@@ -177,7 +177,7 @@ model Message {
 model Booking {
   id              String        @id @default(cuid())
   userId          String
-  user            User          @relation(fields: [userId], references: [id])
+  user            User          @relation(fields: [userId], references: [id], onDelete: Cascade)
   venueId         String
   venue           Venue         @relation(fields: [venueId], references: [id])
   date            String
@@ -234,7 +234,7 @@ enum BookingStatus {
 model UserMemory {
   id        String                       @id @default(cuid())
   userId    String
-  user      User                         @relation(fields: [userId], references: [id])
+  user      User                         @relation(fields: [userId], references: [id], onDelete: Cascade)
   content   String
   embedding Unsupported("vector(1024)")?
   createdAt DateTime                     @default(now())


### PR DESCRIPTION
## Description

This PR fixes the foreign key constraint issue that prevents user account deletion when dependent records exist.

The missing `onDelete: Cascade` referential action has been added to the following user-owned Prisma relations:

* `VenueRating`
* `Favorite`
* `Conversation`
* `Booking`
* `UserMemory`

With these changes, deleting a `User` will automatically remove the associated child records, preventing Prisma `P2003` foreign key constraint errors during account deletion and maintaining referential integrity.

## Related Issue

Fixes #513

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules

## Notes

* Verified the Prisma schema using `npx prisma validate`.
* Audited the schema to ensure there are no remaining `userId` relations missing `onDelete: Cascade`.
* A Prisma migration could not be generated locally because the repository does not include a configured `.env.local`/`DATABASE_URL` required to run `prisma migrate dev`.

## Screenshots / Screen Recordings (if applicable)

Not applicable. This PR only updates the Prisma schema.

## Breaking Changes

* [ ] Yes (please describe below)
* [x] No
