### PR TITLE
fix: stop touch gesture propagation on map overlay panel to prevent accidental panning (closes #451)

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useUser } from "@clerk/nextjs";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   MapContainer,
   TileLayer,
@@ -201,6 +201,45 @@ const Map = ({
 }) => {
   const clerkUser = useUser();
   const { latitude, longitude } = location;
+  const routingPanelRef = useRef<HTMLDivElement>(null);
+
+  // Prevent touch/mouse/scroll event propagation on overlays from bubbling to Leaflet Map
+  useEffect(() => {
+    const el = routingPanelRef.current;
+    if (!el) return;
+
+    if (L && L.DomEvent) {
+      L.DomEvent.disableClickPropagation(el);
+      L.DomEvent.disableScrollPropagation(el);
+    }
+
+    // Stop touch and pointer events from propagating to prevent map dragging/panning
+    const stopPropagation = (e: Event) => {
+      e.stopPropagation();
+    };
+
+    const events = [
+      "touchstart",
+      "touchmove",
+      "touchend",
+      "pointerdown",
+      "pointermove",
+      "pointerup",
+      "mousedown",
+      "mousemove",
+      "mouseup",
+    ];
+
+    events.forEach((event) => {
+      el.addEventListener(event, stopPropagation, { passive: true });
+    });
+
+    return () => {
+      events.forEach((event) => {
+        el.removeEventListener(event, stopPropagation);
+      });
+    };
+  }, []);
 
   // Settled zoom level (debounced via ZoomWatcher), used to keep spiderfied
   // marker offsets at a consistent on-screen pixel separation regardless of
@@ -707,7 +746,10 @@ const Map = ({
           );
         })}
         {/* MULTI-STOP ROUTING OPTIMIZER CONTROL INTERFACE OVERLAY */}
-        <div className="absolute bottom-6 left-6 z-[1000] w-80 rounded-xl border border-zinc-800 bg-zinc-950/90 p-4 text-white shadow-2xl backdrop-blur-md">
+        <div
+          ref={routingPanelRef}
+          className="absolute bottom-6 left-6 z-[1000] w-80 rounded-xl border border-zinc-800 bg-zinc-950/90 p-4 text-white shadow-2xl backdrop-blur-md"
+        >
           <div className="mb-3 flex items-center justify-between border-b border-zinc-800 pb-2">
             <h3 className="font-semibold text-sm tracking-wide text-zinc-200">
               📍 ROUTING OPTIMIZER


### PR DESCRIPTION
## Description

This PR resolves the touch gesture conflicts on the map overlay panel inside the mobile viewport simulation.

Swiping or scrolling vertically on the workday timeline queue cards inside the Multi-Stop Routing Optimizer overlay panel (located inside the interactive Leaflet map container) was incorrectly bubbling touch and pointer events to the map container, triggering accidental map dragging and coordinate shifting.

We resolve this by adding explicit event listeners on the routing panel wrapper element (routingPanelRef inside 

Map.tsx
) to stop event propagation for all touch (touchstart, touchmove, touchend), pointer (pointerdown, pointermove, pointerup), and mouse (mousedown, mousemove, mouseup) events, fully isolating swipe/scroll interactions within the overlay panel container.


## Related Issue

Closes #451

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

## Breaking Changes

- [ ] Yes (please describe below)
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interaction with the routing optimizer overlay by preventing map gestures and clicks from triggering beneath it.
  * Enabled more reliable scrolling, tapping, and pointer interactions within the routing panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->