### PR TITLE
fix: correct async return type in rateLimit helper

### DIFF
--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -157,12 +157,12 @@ export async function rateLimit(
 export async function getRateLimitInfo(
   identifier: string,
   limit = 10,
-): {
+): Promise<{
   count: number;
   remaining: number;
   resetTime: number;
   isLimited: boolean;
-} | null {
+} | null> {
   return memGetInfo(identifier, limit);
 }
 


### PR DESCRIPTION
## Description

This PR fixes a TypeScript type mismatch in `src/lib/rateLimit.ts`.

The `getRateLimitInfo` function is declared as `async`, so its return type should be `Promise<T>`. The previous type annotation returned a non-Promise type, which caused the production build to fail during TypeScript compilation.

### Changes

- Updated the return type of `getRateLimitInfo` to `Promise<...>`.
- No runtime logic or rate-limiting behavior was changed.
- This is a type-only fix to align the function signature with its existing implementation.

## Related Issue

Fixes #641

> **Note:** If this PR is **not** linked to an existing GitHub issue, replace `Fixes #641` with `N/A` or remove this section. Don't invent an issue number.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

N/A (no UI changes)

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No