### PR TITLE
feat: add sticky top scroll progress indicator

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { ClerkProvider } from "@clerk/nextjs";
 import "./globals.css";
 import I18nProvider from "../components/I18nProvider";
 import { ThemeProvider } from "../components/ThemeProvider";
+import { ScrollProgress } from "../components/ui/ScrollProgress";
 
 import { headers } from "next/headers";
 
@@ -118,6 +119,7 @@ export default async function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
         suppressHydrationWarning
       >
+        <ScrollProgress />
         {bodyContent}
       </body>
     </html>

--- a/src/components/ui/ScrollProgress.tsx
+++ b/src/components/ui/ScrollProgress.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useScrollProgress } from "@/hooks/useScrollProgress";
+
+export function ScrollProgress() {
+  const progress = useScrollProgress();
+
+  return (
+    <div
+      className="fixed top-0 left-0 right-auto h-1 bg-gradient-to-r from-blue-600 to-purple-600 z-50 pointer-events-none transition-all duration-75"
+      style={{ width: `${progress}%` }}
+      aria-hidden="true"
+    />
+  );
+}

--- a/src/hooks/useScrollProgress.ts
+++ b/src/hooks/useScrollProgress.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+export function useScrollProgress() {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    let frameId: number;
+
+    const handleScroll = () => {
+      if (frameId) {
+        cancelAnimationFrame(frameId);
+      }
+
+      frameId = requestAnimationFrame(() => {
+        const scrollY = window.scrollY;
+        const maxScrollableHeight =
+          document.documentElement.scrollHeight - window.innerHeight;
+
+        if (maxScrollableHeight <= 0) {
+          setProgress(0);
+          return;
+        }
+
+        let calculatedProgress = (scrollY / maxScrollableHeight) * 100;
+
+        if (Number.isNaN(calculatedProgress)) {
+          setProgress(0);
+          return;
+        }
+
+        // Clamp between 0 and 100
+        calculatedProgress = Math.max(0, Math.min(100, calculatedProgress));
+
+        setProgress(calculatedProgress);
+      });
+    };
+
+    // Calculate once on mount
+    handleScroll();
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      if (frameId) {
+        cancelAnimationFrame(frameId);
+      }
+    };
+  }, []);
+
+  return progress;
+}


### PR DESCRIPTION
## Description

Adds a global sticky scroll progress indicator that visually shows the user's page scroll depth.

### Changes made
- Added a reusable `useScrollProgress` hook to calculate scroll progress.
- Added a reusable `ScrollProgress` component.
- Mounted the progress bar globally in the root layout.
- Used `requestAnimationFrame` with passive scroll listeners for smooth performance.
- Added proper cleanup for event listeners and animation frames.
- Ensured the implementation is SSR-safe.

## Related Issue

Fixes #606

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

> **Note:** `npm run build` currently fails due to a pre-existing upstream TypeScript error in `src/lib/rateLimit.ts`, which is unrelated to this PR.

## Screenshots / Screen Recordings (if applicable)

UI change only. Screenshots can be added if requested during review.

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual progress bar at the top of the page that indicates the user’s reading position while scrolling.
  * Progress updates smoothly as users move through page content and resets appropriately on pages without scrollable content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->