### PR TITLE
[Feature]: allow keyboard navigation in venue listings

### DIFF
--- a/src/__tests__/components/VenueListings.test.tsx
+++ b/src/__tests__/components/VenueListings.test.tsx
@@ -96,4 +96,29 @@ describe("VenueListings Component", () => {
     expect(screen.getAllByText("WiFi").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Power").length).toBeGreaterThan(0);
   });
+
+  it("navigates venues using arrow keys and selects with enter", async () => {
+    await renderVenueListings();
+
+    const cards = screen
+      .getAllByRole("generic")
+      .filter((el) => el.hasAttribute("data-index"));
+    expect(cards.length).toBe(mockVenues.length);
+
+    // Focus the first item
+    cards[0].focus();
+    expect(cards[0]).toHaveFocus();
+
+    // Simulate arrow down
+    fireEvent.keyDown(cards[0], { key: "ArrowDown", code: "ArrowDown" });
+    expect(cards[1]).toHaveFocus();
+
+    // Simulate arrow up
+    fireEvent.keyDown(cards[1], { key: "ArrowUp", code: "ArrowUp" });
+    expect(cards[0]).toHaveFocus();
+
+    // Simulate enter on first item
+    fireEvent.keyDown(cards[0], { key: "Enter", code: "Enter" });
+    expect(mockOnOpenDetails).toHaveBeenCalledWith(mockVenues[0]);
+  });
 });

--- a/src/components/chat/ChatMessages.tsx
+++ b/src/components/chat/ChatMessages.tsx
@@ -21,7 +21,7 @@ import {
   LayoutGrid,
   List,
 } from "lucide-react";
-import { RefObject, useState, useEffect } from "react";
+import { RefObject, useState, useEffect, useRef } from "react";
 import { BrainTerminal } from "./BrainTerminal";
 import { trackVenueInteraction } from "@/lib/analytics";
 import { MessageRenderer } from "./GenerativeUI";
@@ -101,6 +101,9 @@ interface VenueChatCardProps {
   onOpenDetails: (venue: Venue) => void;
   onBook: (venue: Venue) => void;
   viewMode?: "card" | "list";
+  tabIndex?: number;
+  onKeyDown?: (e: React.KeyboardEvent) => void;
+  "data-index"?: number;
 }
 
 export function VenueChatCard({
@@ -112,6 +115,9 @@ export function VenueChatCard({
   onOpenDetails,
   onBook,
   viewMode = "card",
+  tabIndex,
+  onKeyDown,
+  "data-index": dataIndex,
 }: VenueChatCardProps) {
   const [photoUrl, setPhotoUrl] = useState<string | null>(null);
   const [photoLoading, setPhotoLoading] = useState(false);
@@ -177,7 +183,10 @@ export function VenueChatCard({
       <>
         <div
           onClick={() => onOpenDetails(venue)}
-          className="border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 bg-white dark:bg-zinc-900 hover:shadow-md hover:scale-[1.01] transition-all cursor-pointer shadow-sm my-1 active:scale-[0.99] flex items-center gap-3"
+          tabIndex={tabIndex}
+          onKeyDown={onKeyDown}
+          data-index={dataIndex}
+          className="border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 bg-white dark:bg-zinc-900 hover:shadow-md hover:scale-[1.01] transition-all cursor-pointer shadow-sm my-1 active:scale-[0.99] flex items-center gap-3 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500"
         >
           {/* Photo thumbnail */}
           {photoLoading ? (
@@ -287,7 +296,10 @@ export function VenueChatCard({
     <>
       <div
         onClick={() => onOpenDetails(venue)}
-        className="border-2 border-zinc-200 dark:border-zinc-800 rounded-2xl overflow-hidden bg-white dark:bg-zinc-900 hover:shadow-2xl hover:scale-[1.02] transition-all cursor-pointer shadow-lg my-2 active:scale-95"
+        tabIndex={tabIndex}
+        onKeyDown={onKeyDown}
+        data-index={dataIndex}
+        className="border-2 border-zinc-200 dark:border-zinc-800 rounded-2xl overflow-hidden bg-white dark:bg-zinc-900 hover:shadow-2xl hover:scale-[1.02] transition-all cursor-pointer shadow-lg my-2 active:scale-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500"
       >
         {/* Venue photo */}
         {photoLoading ? (
@@ -497,9 +509,35 @@ export function VenueListings({
   onBook,
 }: VenueListingsProps) {
   const [viewMode, setViewMode] = useState<"card" | "list">("card");
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleKeyDown = (
+    e: React.KeyboardEvent,
+    index: number,
+    venue: Venue,
+  ) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      const nextIndex = Math.min(index + 1, venues.length - 1);
+      const nextEl = containerRef.current?.querySelector(
+        `[data-index="${nextIndex}"]`,
+      ) as HTMLElement;
+      nextEl?.focus();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      const prevIndex = Math.max(index - 1, 0);
+      const prevEl = containerRef.current?.querySelector(
+        `[data-index="${prevIndex}"]`,
+      ) as HTMLElement;
+      prevEl?.focus();
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      onOpenDetails(venue);
+    }
+  };
 
   return (
-    <div className="space-y-3 pl-2">
+    <div className="space-y-3 pl-2" ref={containerRef}>
       <div className="flex items-center justify-between border-b border-zinc-100 dark:border-zinc-800 pb-2 mb-1">
         <p className="text-[10px] uppercase font-black tracking-widest text-zinc-400">
           Recommended Venues ({venues.length})
@@ -533,7 +571,7 @@ export function VenueListings({
       </div>
 
       <div className={viewMode === "card" ? "space-y-3" : "space-y-2"}>
-        {venues.slice(0, 5).map((venue) => (
+        {venues.slice(0, 5).map((venue, index) => (
           <VenueChatCard
             key={venue.id}
             venue={venue}
@@ -544,6 +582,9 @@ export function VenueListings({
             onOpenDetails={onOpenDetails}
             onBook={onBook}
             viewMode={viewMode}
+            tabIndex={0}
+            data-index={index}
+            onKeyDown={(e) => handleKeyDown(e, index, venue)}
           />
         ))}
       </div>


### PR DESCRIPTION
- closes #554

### Description
This PR enhances the accessibility and power-user experience of the AI Chat interface by allowing users to navigate through the generated venue search listings entirely via the keyboard.

### Changes Made
- **Keyboard Event Handling:** Added `onKeyDown` listeners inside the `VenueListings` container component to intercept `ArrowDown`, `ArrowUp`, and `Enter` key presses.
- **Focus Management:** 
  - Passed down `tabIndex` and `data-index` props to the `VenueChatCard` component.
  - Arrow keys dynamically shift the DOM focus between active venue listing cards.
  - Hitting `Enter` on a focused card triggers the `onOpenDetails` handler to focus the venue directly on the map.
- **Visual Feedback:** Standardized the visual focus outline across both "card" and "list" views by adding `focus-visible:outline-blue-500` to the active elements.
- **Testing:** Added a new automated unit test in `src/__tests__/components/VenueListings.test.tsx` that simulates arrow key navigation and Enter selection using `fireEvent`.

### How to Test
1. Send a query to the AI to fetch venue recommendations.
2. Hit the `Tab` key to focus the first venue card (you should see a blue focus ring).
3. Use `Arrow Down` / `Arrow Up` to cycle through the options.
4. Hit `Enter` on any venue card to ensure it successfully selects the venue.
5. All automated unit tests in `VenueListings.test.tsx` pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard navigation for venue listings using the Arrow Up and Arrow Down keys.
  * Added Enter-key support to open venue details.
  * Added visible focus indicators to improve keyboard accessibility.

* **Tests**
  * Added coverage verifying venue card focus movement and detail opening via keyboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->