### PR TITLE
[Feature]: add live character counter to chat input

### DIFF
--- a/src/components/chat/ChatMessages.tsx
+++ b/src/components/chat/ChatMessages.tsx
@@ -805,6 +805,17 @@ export function ChatInput({
   onInputChange,
   onSubmit,
 }: ChatInputProps) {
+  const MAX_CHARS = 2000;
+  const charCount = input.length;
+  const isOverLimit = charCount > MAX_CHARS;
+
+  let counterColor = "text-zinc-500 dark:text-zinc-400"; // gray
+  if (isOverLimit) {
+    counterColor = "text-red-500";
+  } else if (charCount >= MAX_CHARS - 200) {
+    counterColor = "text-yellow-500";
+  }
+
   return (
     <div className="p-4 bg-white dark:bg-zinc-950 border-t border-zinc-200 dark:border-zinc-800">
       <form
@@ -822,7 +833,7 @@ export function ChatInput({
         />
         <button
           type="submit"
-          disabled={isLoading || !input.trim()}
+          disabled={isLoading || !input.trim() || isOverLimit}
           className="p-3 bg-blue-600 hover:bg-blue-700 text-white rounded-xl disabled:opacity-30 transition-all active:scale-95 shadow-lg group"
         >
           {isLoading ? (
@@ -832,6 +843,13 @@ export function ChatInput({
           )}
         </button>
       </form>
+      <div className="mt-2 text-right">
+        <span
+          className={`text-xs font-semibold transition-colors ${counterColor}`}
+        >
+          {charCount}/{MAX_CHARS}
+        </span>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
- closes #610

### Description:
This PR introduces a live character counter to the AI chatbot input field to help users stay within the 2000-character limit and prevents them from submitting overly long messages.

### Changes Included:
- Input Tracking: The ChatInput component now actively tracks the length of the user's input string.
- Dynamic Counter UI: Added a `[current]/2000` text indicator just below the input field that provides real-time visual feedback:
  - Standard state is gray (`text-zinc-500`).
  - Transitions to a yellow warning (`text-yellow-500`) when the input hits 1800+ characters (within 200 chars of the limit).
  - Transitions to a red error (`text-red-500`) when the 2000-character limit is exceeded.
- Submission Guard: The submit button now automatically disables if the character count exceeds the 2000-character limit, preventing API rejection.

### Screenshot

<img width="1980" height="278" alt="image" src="https://github.com/user-attachments/assets/b1363bda-1f77-4d5f-ba80-227318cb9584" />

### Testing Instructions:
1. Run `npm run dev` and navigate to the chatbot page (e.g., `/ai`).
2. Type in the input field and observe the character counter updating.
3. Paste a block of text containing more than 1800 characters and verify the counter turns yellow.
4. Paste a block of text containing more than 2000 characters and verify the counter turns red and the "Send" button becomes disabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a live character counter to the chat input.
  * Limited chat messages to 2,000 characters.
  * Added visual warnings as users approach or exceed the limit.

* **Bug Fixes**
  * Prevented submitting blank, loading, or over-limit messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->