### PR TITLE
fix(chat): safeguard chat input value and prevent WebSocket InvalidStateError on presence updates (closes #562)

### DIFF
--- a/src/components/EnhancedChatbot.tsx
+++ b/src/components/EnhancedChatbot.tsx
@@ -116,6 +116,18 @@ export function EnhancedChatbot({
   const { isSignedIn, user } = useUser();
 
   const { socket } = useMultiplayerSession(roomId || null);
+  const sendSocketMessage = useCallback(
+    (data: string) => {
+      if (socket && socket.readyState === 1) {
+        try {
+          socket.send(data);
+        } catch (err) {
+          console.error("[Socket] Failed to send message:", err);
+        }
+      }
+    },
+    [socket],
+  );
   const { getToken } = useAuth();
 
   // Presence state
@@ -166,7 +178,7 @@ export function EnhancedChatbot({
     const handleMouseMove = (e: MouseEvent) => {
       // Throttle mouse moves to avoid flooding
       if (Math.random() > 0.8) {
-        socket.send(
+        sendSocketMessage(
           JSON.stringify({
             type: "cursor",
             x: e.clientX,
@@ -179,7 +191,7 @@ export function EnhancedChatbot({
 
     window.addEventListener("mousemove", handleMouseMove);
     return () => window.removeEventListener("mousemove", handleMouseMove);
-  }, [socket, roomId, user]);
+  }, [socket, roomId, user, sendSocketMessage]);
 
   // Handle incoming presence
   useEffect(() => {
@@ -295,7 +307,7 @@ export function EnhancedChatbot({
       onMapUpdate?.(update);
 
       if (socket && roomId) {
-        socket.send(JSON.stringify({ type: "map-update", update }));
+        sendSocketMessage(JSON.stringify({ type: "map-update", update }));
       }
     }
   };
@@ -648,12 +660,13 @@ export function EnhancedChatbot({
 
   // Main submit
   const handleInputChange = (val: string) => {
-    setInput(val);
+    const safeVal = typeof val === "string" ? val : "";
+    setInput(safeVal);
     if (socket && roomId) {
-      socket.send(
+      sendSocketMessage(
         JSON.stringify({
           type: "typing",
-          isTyping: val.length > 0,
+          isTyping: safeVal.length > 0,
           name: user?.firstName || "Anonymous",
         }),
       );
@@ -665,7 +678,7 @@ export function EnhancedChatbot({
     if (!input.trim() || isLoading) return;
 
     if (socket && roomId) {
-      socket.send(
+      sendSocketMessage(
         JSON.stringify({
           type: "typing",
           isTyping: false,
@@ -694,7 +707,7 @@ export function EnhancedChatbot({
     setMessages((prev) => [...prev, newUserMessage]);
 
     if (socket && roomId) {
-      socket.send(
+      sendSocketMessage(
         JSON.stringify({ type: "new-message", message: newUserMessage }),
       );
     }
@@ -820,7 +833,9 @@ export function EnhancedChatbot({
                   };
                   onMapUpdate(update);
                   if (socket && roomId) {
-                    socket.send(JSON.stringify({ type: "map-update", update }));
+                    sendSocketMessage(
+                      JSON.stringify({ type: "map-update", update }),
+                    );
                   }
                 }
               } catch (e) {
@@ -889,11 +904,10 @@ export function EnhancedChatbot({
         }
       }
 
-      // Final message sync for socket
       setMessages((prev) => {
         const finalMsg = prev.find((m) => m.id === assistantMessageId);
         if (finalMsg && socket && roomId) {
-          socket.send(
+          sendSocketMessage(
             JSON.stringify({ type: "new-message", message: finalMsg }),
           );
         }

--- a/src/components/chat/ChatMessages.tsx
+++ b/src/components/chat/ChatMessages.tsx
@@ -817,13 +817,14 @@ interface ChatInputProps {
 }
 
 export function ChatInput({
-  input,
+  input = "",
   isLoading,
   onInputChange,
   onSubmit,
 }: ChatInputProps) {
+  const safeInput = input || "";
   const MAX_CHARS = 2000;
-  const charCount = input.length;
+  const charCount = safeInput.length;
   const isOverLimit = charCount > MAX_CHARS;
 
   let counterColor = "text-zinc-500 dark:text-zinc-400"; // gray
@@ -842,8 +843,8 @@ export function ChatInput({
       >
         <input
           type="text"
-          value={input}
-          onChange={(e) => onInputChange(e.target.value)}
+          value={safeInput}
+          onChange={(e) => onInputChange(e.target.value ?? "")}
           placeholder="Where's the focus mode hotspot?"
           disabled={isLoading}
           className="flex-1 px-4 py-3 bg-transparent text-zinc-900 dark:text-zinc-50 placeholder:text-zinc-500 focus:placeholder-transparent focus:outline-none disabled:opacity-50 text-sm font-bold"


### PR DESCRIPTION
### Description
Closes #562

Pasting multiple rich emojis in rapid succession from the Windows Clipboard (`Win+.` / `Win+V`) or emoji panel triggers consecutive input change updates. This PR resolves the resulting React rendering crashes and WebSocket connection exceptions.

### Key Changes
1. **Chat Input State Safeguard (`src/components/chat/ChatMessages.tsx`, `src/components/EnhancedChatbot.tsx`)**:
   - Added a safe default fallback string (`input = ""`) and defined `safeInput = input || ""`.
   - Prevented potential `TypeError` exceptions on `undefined` values during character calculations or component value bindings when rich/formatted emojis are pasted.

2. **WebSocket Send Error Prevention (`src/components/EnhancedChatbot.tsx`)**:
   - Implemented a unified `sendSocketMessage(data: string)` callback wrapped in a `try-catch` block.
   - Guarded socket transmissions by validating that the socket is present and has successfully established a connection (`socket.readyState === 1` i.e. `WebSocket.OPEN`). This completely eliminates unhandled `InvalidStateError` exceptions when presence or typing alerts fire during connection state transitions.
   - Updated all socket messaging invocations to route through the new `sendSocketMessage` helper.

### Verification & Testing
- Ran all Jest unit tests (all 195 passed successfully):
  ```bash
  npx jest
  ```
- Compiled Next.js production build:
  ```bash
  npm run build
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of real-time chat, typing indicators, cursor presence, map locations, and marker updates when connectivity is interrupted.
  - Prevented messaging errors from disrupting the chat experience.
  - Improved chat input behavior when no text is provided, including consistent display and character counting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->