### PR TITLE
fix: keep typing indicator active until AI response finishes streaming (#619)

### DIFF
--- a/src/components/EnhancedChatbot.tsx
+++ b/src/components/EnhancedChatbot.tsx
@@ -745,6 +745,7 @@ export function EnhancedChatbot({
           id: assistantMessageId,
           role: "assistant",
           content: "",
+          isStreaming: true,
         },
       ]);
 
@@ -911,7 +912,9 @@ export function EnhancedChatbot({
             JSON.stringify({ type: "new-message", message: finalMsg }),
           );
         }
-        return prev;
+        return prev.map((m) =>
+          m.id === assistantMessageId ? { ...m, isStreaming: false } : m,
+        );
       });
     } catch (err) {
       console.error("Chat error:", err);
@@ -989,6 +992,9 @@ export function EnhancedChatbot({
       );
     } finally {
       setIsLoading(false);
+      setMessages((prev) =>
+        prev.map((m) => (m.isStreaming ? { ...m, isStreaming: false } : m)),
+      );
     }
   };
 

--- a/src/components/chat/ChatMessages.tsx
+++ b/src/components/chat/ChatMessages.tsx
@@ -67,6 +67,7 @@ export interface Message {
   suggestions?: string[];
   cached?: boolean;
   complexity?: string;
+  isStreaming?: boolean;
 }
 
 const AGENT_ICONS: Record<string, React.ElementType> = {
@@ -684,7 +685,36 @@ export function MessageList({
             >
               <div className="text-sm font-medium leading-relaxed">
                 {message.role === "assistant" ? (
-                  <MessageRenderer content={message.content} />
+                  message.content === "" ? (
+                    <div
+                      className="flex gap-1 items-center py-1"
+                      aria-label="WorkSphere AI is typing"
+                    >
+                      <span
+                        className="w-1.5 h-1.5 rounded-full bg-blue-600 dark:bg-blue-400 animate-bounce"
+                        style={{ animationDelay: "0ms" }}
+                      />
+                      <span
+                        className="w-1.5 h-1.5 rounded-full bg-blue-600 dark:bg-blue-400 animate-bounce"
+                        style={{ animationDelay: "150ms" }}
+                      />
+                      <span
+                        className="w-1.5 h-1.5 rounded-full bg-blue-600 dark:bg-blue-400 animate-bounce"
+                        style={{ animationDelay: "300ms" }}
+                      />
+                    </div>
+                  ) : (
+                    <div className="relative">
+                      <MessageRenderer content={message.content} />
+                      {message.isStreaming && (
+                        <span className="inline-flex gap-0.5 items-center ml-1 text-blue-600 dark:text-blue-400 font-black animate-pulse">
+                          <span>.</span>
+                          <span>.</span>
+                          <span>.</span>
+                        </span>
+                      )}
+                    </div>
+                  )
                 ) : (
                   <span className="whitespace-pre-wrap">{message.content}</span>
                 )}


### PR DESCRIPTION
## Description
This PR resolves #619 by keeping the chatbot typing indicator active until the assistant finishes streaming its response.

### Key Changes
- **`isStreaming` State Integration**: Added a lifecycle tracker property to assistant messages to capture when the stream reader is actively receiving and outputting text.
- **Empty State Typing Indicator**: Renders three bouncing blue dots inside the assistant bubble when the message content is empty and the API is streaming (addressing slow 3G connection lags).
- **Subtle Pulsing Stream Indicator**: Appends a pulsing `...` indicator at the end of the text while the stream is printing.
- **Robust Exception Handling**: Clears `isStreaming` states in the `finally` hook to prevent indicators from hanging on fetch failures.

## Related Issue
Closes #619



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a typing indicator while the assistant is preparing a response.
  * Added a subtle streaming indicator while assistant responses are being generated.
  * Indicators now disappear reliably when responses finish or encounter an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->