### PR TITLE
fix: resolve collections page grid layout break on 5K viewports (#620)

### DIFF
--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -193,7 +193,7 @@ export default function FolderDetailsPage({
 
   return (
     <div className="min-h-screen bg-zinc-50 dark:bg-zinc-950 p-4 sm:p-6 lg:p-8 pt-8">
-      <div className="max-w-5xl mx-auto">
+      <div className="max-w-[1600px] mx-auto">
         <div className="flex items-center gap-4 mb-8">
           <Link
             href="/collections"
@@ -215,8 +215,8 @@ export default function FolderDetailsPage({
 
         <ComparisonTool currentFolder={folder} />
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          <div className="md:col-span-2 space-y-4">
+        <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-6">
+          <div className="md:col-span-2 lg:col-span-3 space-y-4">
             <h2 className="text-lg font-semibold text-zinc-900 dark:text-white flex items-center gap-2">
               <MapPin className="w-5 h-5 text-blue-500" /> Saved Venues (
               {filteredVenues.length})
@@ -243,7 +243,7 @@ export default function FolderDetailsPage({
                 </p>
               </div>
             ) : (
-              <div className="grid gap-4">
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
                 {filteredVenues.map((fv: any) => (
                   <div
                     key={fv.id}

--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -199,7 +199,7 @@ export default function CollectionsPage() {
 
   return (
     <div className="min-h-screen bg-zinc-50 dark:bg-zinc-950">
-      <div className="max-w-5xl mx-auto p-4 sm:p-6 lg:p-8 pt-8">
+      <div className="max-w-[1600px] mx-auto p-4 sm:p-6 lg:p-8 pt-8">
         {/* Header and Tabs Switcher */}
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-8">
           <div className="flex items-center gap-4">
@@ -246,7 +246,7 @@ export default function CollectionsPage() {
           </div>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-6">
           {/* Creation Form */}
           <div className="md:col-span-1">
             <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-6 shadow-sm sticky top-24">
@@ -304,7 +304,7 @@ export default function CollectionsPage() {
           </div>
 
           {/* List Views */}
-          <div className="md:col-span-2 space-y-4">
+          <div className="md:col-span-2 lg:col-span-3 space-y-4">
             {activeTab === "my" ? (
               // My Collections tab
               loading ? (
@@ -322,7 +322,7 @@ export default function CollectionsPage() {
                   </p>
                 </div>
               ) : (
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
                   {folders.map((folder, index) => (
                     <div
                       key={folder.id}
@@ -399,7 +399,7 @@ export default function CollectionsPage() {
                 </p>
               </div>
             ) : (
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
                 {publicFolders.map((pubFolder) => (
                   <Link
                     href={`/collections/${pubFolder.id}`}


### PR DESCRIPTION
## Description
This PR resolves #620 by upgrading the collections page and collection details viewports scaling to support ultra-wide resolutions (up to 5K and 4K displays).

### Key Highlights
- **Fluid Layout Max-Width Limits**: Shifted main containers from a constrained `max-w-5xl` (1024px) to a widescreen-friendly `max-w-[1600px]`.
- **Responsive Columns Scaling**: Upgraded the grid column breakpoints dynamically:
  - Curated folders: scales up to `lg:grid-cols-3` to prevent card distortion.
  - Venue lists: scales up to `lg:grid-cols-2` of horizontal cards instead of stretching rows.
- **Improved Spacing Ratios**: Keeps gaps and column widths extremely balanced (~400px-600px width metrics) on any 5K resolution.


## Related Issue
Closes #620



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Expanded collection and folder pages to better use available screen space.
  * Improved responsive layouts for larger screens.
  * Saved venues now display in a two-column layout on large screens.
  * Collection and discovery cards now support three-column layouts on large screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->