### PR TITLE
feat: recent searches history dropdown in search bar (#673)

### DIFF
--- a/src/__tests__/components/ChatInput.test.tsx
+++ b/src/__tests__/components/ChatInput.test.tsx
@@ -1,0 +1,152 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ChatInput } from "@/components/chat/ChatMessages";
+jest.mock("framer-motion", () => ({
+  motion: {
+    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  },
+  AnimatePresence: ({ children }: any) => <>{children}</>,
+}));
+
+describe("ChatInput recent searches history", () => {
+  const mockOnInputChange = jest.fn();
+  const mockOnSubmit = jest.fn();
+
+  beforeEach(() => {
+    mockOnInputChange.mockClear();
+    mockOnSubmit.mockClear();
+    localStorage.clear();
+  });
+
+  it("renders input field correctly", () => {
+    render(
+      <ChatInput
+        input=""
+        isLoading={false}
+        onInputChange={mockOnInputChange}
+        onSubmit={mockOnSubmit}
+      />,
+    );
+
+    const inputEl = screen.getByPlaceholderText(
+      "Where's the focus mode hotspot?",
+    );
+    expect(inputEl).toBeInTheDocument();
+  });
+
+  it("does not display recent searches panel when focused if history is empty", () => {
+    render(
+      <ChatInput
+        input=""
+        isLoading={false}
+        onInputChange={mockOnInputChange}
+        onSubmit={mockOnSubmit}
+      />,
+    );
+
+    const inputEl = screen.getByPlaceholderText(
+      "Where's the focus mode hotspot?",
+    );
+    fireEvent.focus(inputEl);
+
+    expect(screen.queryByText("Recent Searches")).not.toBeInTheDocument();
+  });
+
+  it("displays recent searches panel when focused if history has entries", () => {
+    localStorage.setItem(
+      "ws-recent-searches",
+      JSON.stringify(["quiet cafe", "coworking space"]),
+    );
+
+    render(
+      <ChatInput
+        input=""
+        isLoading={false}
+        onInputChange={mockOnInputChange}
+        onSubmit={mockOnSubmit}
+      />,
+    );
+
+    const inputEl = screen.getByPlaceholderText(
+      "Where's the focus mode hotspot?",
+    );
+    fireEvent.focus(inputEl);
+
+    expect(screen.getByText("Recent Searches")).toBeInTheDocument();
+    expect(screen.getByText("quiet cafe")).toBeInTheDocument();
+    expect(screen.getByText("coworking space")).toBeInTheDocument();
+  });
+
+  it("adds query to localStorage on submit", () => {
+    render(
+      <ChatInput
+        input="starbucks wifi"
+        isLoading={false}
+        onInputChange={mockOnInputChange}
+        onSubmit={mockOnSubmit}
+      />,
+    );
+
+    const form = screen.getByRole("button").closest("form");
+    expect(form).toBeInTheDocument();
+    fireEvent.submit(form!);
+
+    expect(mockOnSubmit).toHaveBeenCalledTimes(1);
+
+    const stored = JSON.parse(
+      localStorage.getItem("ws-recent-searches") || "[]",
+    );
+    expect(stored).toContain("starbucks wifi");
+  });
+
+  it("calls onInputChange with search term on chip mouse down", () => {
+    localStorage.setItem(
+      "ws-recent-searches",
+      JSON.stringify(["library outlets"]),
+    );
+
+    render(
+      <ChatInput
+        input=""
+        isLoading={false}
+        onInputChange={mockOnInputChange}
+        onSubmit={mockOnSubmit}
+      />,
+    );
+
+    const inputEl = screen.getByPlaceholderText(
+      "Where's the focus mode hotspot?",
+    );
+    fireEvent.focus(inputEl);
+
+    const chip = screen.getByText("library outlets");
+    fireEvent.mouseDown(chip);
+
+    expect(mockOnInputChange).toHaveBeenCalledWith("library outlets");
+  });
+
+  it("clears history when clear is clicked", () => {
+    localStorage.setItem("ws-recent-searches", JSON.stringify(["old search"]));
+
+    render(
+      <ChatInput
+        input=""
+        isLoading={false}
+        onInputChange={mockOnInputChange}
+        onSubmit={mockOnSubmit}
+      />,
+    );
+
+    const inputEl = screen.getByPlaceholderText(
+      "Where's the focus mode hotspot?",
+    );
+    fireEvent.focus(inputEl);
+
+    const clearBtn = screen.getByText("Clear");
+    fireEvent.mouseDown(clearBtn);
+
+    expect(localStorage.getItem("ws-recent-searches")).toBeNull();
+    expect(screen.queryByText("Recent Searches")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/chat/ChatMessages.tsx
+++ b/src/components/chat/ChatMessages.tsx
@@ -20,8 +20,11 @@ import {
   Zap,
   LayoutGrid,
   List,
+  Clock,
+  Trash2,
 } from "lucide-react";
 import { RefObject, useState, useEffect, useRef } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 import { BrainTerminal } from "./BrainTerminal";
 import { trackVenueInteraction } from "@/lib/analytics";
 import { MessageRenderer } from "./GenerativeUI";
@@ -866,6 +869,42 @@ export function ChatInput({
   const charCount = safeInput.length;
   const isOverLimit = charCount > MAX_CHARS;
 
+  const [recentSearches, setRecentSearches] = useState<string[]>([]);
+  const [isFocused, setIsFocused] = useState(false);
+
+  useEffect(() => {
+    const history = localStorage.getItem("ws-recent-searches");
+    if (history) {
+      try {
+        setRecentSearches(JSON.parse(history));
+      } catch (e) {
+        console.error(e);
+      }
+    }
+  }, []);
+
+  const saveToHistory = (term: string) => {
+    const updated = [
+      term,
+      ...recentSearches.filter((item) => item !== term),
+    ].slice(0, 5);
+    setRecentSearches(updated);
+    localStorage.setItem("ws-recent-searches", JSON.stringify(updated));
+  };
+
+  const clearHistory = () => {
+    setRecentSearches([]);
+    localStorage.removeItem("ws-recent-searches");
+  };
+
+  const handleFormSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (safeInput.trim() && !isOverLimit) {
+      saveToHistory(safeInput.trim());
+    }
+    onSubmit(e);
+  };
+
   let counterColor = "text-zinc-500 dark:text-zinc-400"; // gray
   if (isOverLimit) {
     counterColor = "text-red-500";
@@ -874,16 +913,63 @@ export function ChatInput({
   }
 
   return (
-    <div className="p-4 bg-white dark:bg-zinc-950 border-t border-zinc-200 dark:border-zinc-800">
+    <div className="relative p-4 bg-white dark:bg-zinc-950 border-t border-zinc-200 dark:border-zinc-800">
+      <AnimatePresence>
+        {isFocused && recentSearches.length > 0 && (
+          <motion.div
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 8 }}
+            className="absolute bottom-full left-4 right-4 mb-2 z-50 p-4 rounded-2xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 shadow-2xl flex flex-col gap-3"
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-[10px] uppercase font-black tracking-widest text-zinc-400 dark:text-zinc-500 flex items-center gap-1.5">
+                <Clock className="w-3.5 h-3.5 text-zinc-400" />
+                Recent Searches
+              </span>
+              <button
+                type="button"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  clearHistory();
+                }}
+                className="text-[10px] font-black uppercase tracking-wider text-red-500 hover:text-red-600 transition-colors flex items-center gap-1"
+              >
+                <Trash2 className="w-3 h-3" />
+                Clear
+              </button>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              {recentSearches.map((term) => (
+                <button
+                  key={term}
+                  type="button"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    onInputChange(term);
+                  }}
+                  className="px-3 py-1.5 bg-zinc-100 hover:bg-blue-50 dark:bg-zinc-900 dark:hover:bg-blue-950/30 border border-zinc-200/50 dark:border-zinc-800 hover:border-blue-200 dark:hover:border-blue-900/50 text-[11px] font-black uppercase tracking-tight rounded-xl text-zinc-600 hover:text-blue-600 dark:text-zinc-400 dark:hover:text-blue-400 transition-all flex items-center gap-1"
+                >
+                  {term}
+                </button>
+              ))}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
       <form
         id="ws-chat-form"
-        onSubmit={onSubmit}
+        onSubmit={handleFormSubmit}
         className="flex gap-2 p-1 rounded-2xl bg-zinc-100 dark:bg-zinc-900 border-2 border-zinc-200 dark:border-zinc-800 focus-within:border-blue-600 transition-all shadow-inner"
       >
         <input
           type="text"
           value={safeInput}
           onChange={(e) => onInputChange(e.target.value ?? "")}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
           placeholder="Where's the focus mode hotspot?"
           disabled={isLoading}
           className="flex-1 px-4 py-3 bg-transparent text-zinc-900 dark:text-zinc-50 placeholder:text-zinc-500 focus:placeholder-transparent focus:outline-none disabled:opacity-50 text-sm font-bold"


### PR DESCRIPTION
## Description
This PR resolves #673 by implementing a search history dropdown below the chatbot input.

### Key Highlights
- **Recent Searches Panel**: Displays the user's last 5 searches as clickable chips in an animated sliding panel when focusing the search input.
- **Auto-Save on Submit**: Automatically de-duplicates and saves new searches to `localStorage` upon form submission.
- **Quick Actions**: Clicking on a search chip instantly fills the search input. A "Clear" button is provided to erase the query history.
- **Focus Preservation**: Utilizes `onMouseDown` handlers to prevent input blur events from dismissing the panel prematurely when clicking items.


## Related Issue
Closes #673



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Recent Searches to the chat input.
  * Automatically saves up to five recent search terms and removes duplicates.
  * Added quick selection of previous searches and a Clear option.
  * Recent searches are restored when returning to the input.

* **Tests**
  * Added coverage for displaying, selecting, saving, and clearing recent searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->