### PR TITLE
feat: add drag-and-drop file upload zone for venue photos (#561)

### DIFF
--- a/src/components/VenueSubmissionModal.tsx
+++ b/src/components/VenueSubmissionModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { useUser, useAuth } from "@clerk/nextjs";
 import { X, MapPin, Loader2 } from "lucide-react";
 
@@ -41,12 +41,18 @@ export function VenueSubmissionModal({
 }: VenueSubmissionModalProps) {
   const { isSignedIn } = useUser();
   const { getToken } = useAuth();
+
+  // Existing State
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
   const [file, setFile] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [uploadStatus, setUploadStatus] = useState("");
+
+  // New Drag & Drop State and Ref
+  const [dragActive, setDragActive] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const [formData, setFormData] = useState<VenueFormData>({
     name: "",
@@ -195,15 +201,50 @@ export function VenueSubmissionModal({
     }
   };
 
+  // Centralized File Validation and Processing
+  const processFile = (selected: File) => {
+    const allowedTypes = ["image/jpeg", "image/png", "image/webp"];
+
+    if (!allowedTypes.includes(selected.type)) {
+      setError("Invalid file type. Please upload a JPEG, PNG, or WEBP.");
+      return;
+    }
+
+    if (selected.size > 5 * 1024 * 1024) {
+      setError("Image must be smaller than 5MB");
+      return;
+    }
+
+    setError(null);
+    setFile(selected);
+    setImagePreview(URL.createObjectURL(selected));
+  };
+
+  // Dropzone Event Handlers
+  const handleDrag = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.type === "dragenter" || e.type === "dragover") {
+      setDragActive(true);
+    } else if (e.type === "dragleave") {
+      setDragActive(false);
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragActive(false);
+
+    if (e.dataTransfer.files && e.dataTransfer.files[0]) {
+      processFile(e.dataTransfer.files[0]);
+    }
+  };
+
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const selected = e.target.files?.[0];
     if (selected) {
-      if (selected.size > 5 * 1024 * 1024) {
-        setError("Image must be smaller than 5MB");
-        return;
-      }
-      setFile(selected);
-      setImagePreview(URL.createObjectURL(selected));
+      processFile(selected);
     }
   };
 
@@ -248,6 +289,7 @@ export function VenueSubmissionModal({
             Suggest a Workspace
           </h2>
           <button
+            type="button"
             onClick={onClose}
             className="p-2 rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
           >
@@ -353,25 +395,63 @@ export function VenueSubmissionModal({
             <label className="block text-[10px] font-black uppercase tracking-widest text-zinc-500 mb-1">
               Venue Photo (Optional)
             </label>
+
+            {/* Drag & Drop File Zone */}
             <div className="flex flex-col gap-2">
-              <input
-                type="file"
-                accept="image/jpeg, image/png, image/webp"
-                onChange={handleFileChange}
-                className="block w-full text-sm text-zinc-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-bold file:bg-blue-50 file:text-blue-700 dark:file:bg-blue-900/30 dark:file:text-blue-400 hover:file:bg-blue-100 dark:hover:file:bg-blue-900/50"
-              />
+              <div
+                className={`relative flex flex-col items-center justify-center w-full p-6 border-2 border-dashed rounded-lg cursor-pointer transition-all ${
+                  dragActive
+                    ? "border-blue-500 bg-blue-50 dark:bg-blue-900/20"
+                    : "border-zinc-300 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-900/50 hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                }`}
+                onDragEnter={handleDrag}
+                onDragLeave={handleDrag}
+                onDragOver={handleDrag}
+                onDrop={handleDrop}
+                onClick={() => inputRef.current?.click()}
+              >
+                <input
+                  ref={inputRef}
+                  type="file"
+                  accept="image/jpeg, image/png, image/webp"
+                  onChange={handleFileChange}
+                  className="hidden"
+                />
+
+                <div className="text-center pointer-events-none">
+                  <p className="text-sm text-zinc-600 dark:text-zinc-300 font-bold">
+                    Drag & drop a venue photo here
+                  </p>
+                  <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-1">
+                    or click to browse (JPEG, PNG, WEBP max 5MB)
+                  </p>
+                </div>
+              </div>
+
               {imagePreview && (
-                <div className="relative w-full h-32 rounded-lg overflow-hidden border border-zinc-200 dark:border-zinc-800">
+                <div className="relative w-full h-32 rounded-lg overflow-hidden border border-zinc-200 dark:border-zinc-800 mt-2">
                   {/* eslint-disable-next-line @next/next/no-img-element */}
                   <img
                     src={imagePreview}
                     alt="Preview"
                     className="object-cover w-full h-full"
                   />
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setFile(null);
+                      setImagePreview(null);
+                      if (inputRef.current) inputRef.current.value = "";
+                    }}
+                    className="absolute top-2 right-2 p-1 bg-black/60 text-white rounded-full hover:bg-black/80 transition-colors"
+                  >
+                    <X className="w-4 h-4" />
+                  </button>
                 </div>
               )}
             </div>
-            <p className="text-[10px] text-zinc-400 mt-1">
+            <p className="text-[10px] text-zinc-400 mt-2">
               Photos are scanned by AI to verify amenities.
             </p>
           </div>

--- a/src/components/VenueSubmissionModal.tsx
+++ b/src/components/VenueSubmissionModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useUser, useAuth } from "@clerk/nextjs";
 import { X, MapPin, Loader2 } from "lucide-react";
 
@@ -75,6 +75,15 @@ export function VenueSubmissionModal({
     patioOnly: false,
     waterBowlsProvided: false,
   });
+
+  // Cleanup memory leak when component unmounts or imagePreview changes
+  useEffect(() => {
+    return () => {
+      if (imagePreview) {
+        URL.revokeObjectURL(imagePreview);
+      }
+    };
+  }, [imagePreview]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -190,6 +199,7 @@ export function VenueSubmissionModal({
           waterBowlsProvided: false,
         });
         setFile(null);
+        if (imagePreview) URL.revokeObjectURL(imagePreview);
         setImagePreview(null);
         setUploadStatus("");
       }, 2000);
@@ -205,17 +215,31 @@ export function VenueSubmissionModal({
   const processFile = (selected: File) => {
     const allowedTypes = ["image/jpeg", "image/png", "image/webp"];
 
+    const clearState = () => {
+      setFile(null);
+      if (imagePreview) {
+        URL.revokeObjectURL(imagePreview);
+      }
+      setImagePreview(null);
+      if (inputRef.current) inputRef.current.value = "";
+    };
+
     if (!allowedTypes.includes(selected.type)) {
       setError("Invalid file type. Please upload a JPEG, PNG, or WEBP.");
+      clearState();
       return;
     }
 
     if (selected.size > 5 * 1024 * 1024) {
       setError("Image must be smaller than 5MB");
+      clearState();
       return;
     }
 
     setError(null);
+    if (imagePreview) {
+      URL.revokeObjectURL(imagePreview);
+    }
     setFile(selected);
     setImagePreview(URL.createObjectURL(selected));
   };
@@ -441,6 +465,9 @@ export function VenueSubmissionModal({
                     onClick={(e) => {
                       e.stopPropagation();
                       setFile(null);
+                      if (imagePreview) {
+                        URL.revokeObjectURL(imagePreview);
+                      }
                       setImagePreview(null);
                       if (inputRef.current) inputRef.current.value = "";
                     }}


### PR DESCRIPTION
## Description
Closes #561 

This PR implements the drag-and-drop file upload zone for venue photos inside `VenueSubmissionModal.tsx` as requested.

**Key additions:**
* Created drag-and-drop event listeners (`onDragEnter`, `onDragLeave`, `onDragOver`, `onDrop`).
* Added file verification checks (restricted to 5MB max, and valid MIME types: JPEG, PNG, WEBP).
* Replaced the standard file input with a responsive dropzone styled using Tailwind CSS (supports both dark and light modes).

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)
<!-- No visual changes uploaded -->

## Breaking Changes
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop photo uploads for venue submissions.
  * Added image previews with the ability to remove a selected photo.
* **Bug Fixes**
  * Improved upload validation for allowed JPEG, PNG, and WEBP images up to 5 MB.
  * Enhanced handling of failed uploads by clearing prior selections and previews.
  * Reduced memory usage by cleaning up image preview data when no longer needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->