### PR TITLE
fix: prevent wishlist heart animation from playing on initial load

### DIFF
--- a/src/components/VenueCard.tsx
+++ b/src/components/VenueCard.tsx
@@ -80,6 +80,7 @@ export function VenueCard({
   const [isLoading, setIsLoading] = useState(false);
   const [photoIndex, setPhotoIndex] = useState(0);
   const [showFolderModal, setShowFolderModal] = useState(false);
+  const [enableTransition, setEnableTransition] = useState(false);
 
   // =========================================================================
   // COMMUNITY VERIFICATION VOTE STATE TRACKING SYSTEM
@@ -195,6 +196,11 @@ export function VenueCard({
     }
     loadVoteMetrics();
   }, [venue.id]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setEnableTransition(true), 500);
+    return () => clearTimeout(timer);
+  }, []);
 
   // Async dynamic vote submittal query processor
   const submitAmenityVote = async (
@@ -404,13 +410,19 @@ export function VenueCard({
           <button
             onClick={handleFavorite}
             disabled={isSavingFavorite}
-            className={`p-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+            className={`p-2 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed ${
+              enableTransition ? "transition-colors duration-300" : ""
+            } ${
               isFavorited
                 ? "bg-red-100 dark:bg-red-900/20 text-red-600"
                 : "hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-400"
             }`}
           >
-            <Heart className={`w-5 h-5 ${isFavorited ? "fill-current" : ""}`} />
+            <Heart
+              className={`w-5 h-5 ${
+                enableTransition ? "transition-all duration-300" : ""
+              } ${isFavorited ? "fill-current" : ""}`}
+            />
           </button>
         </div>
 

--- a/src/components/chat/ChatMessages.tsx
+++ b/src/components/chat/ChatMessages.tsx
@@ -127,6 +127,7 @@ export function VenueChatCard({
   const [photoUrl, setPhotoUrl] = useState<string | null>(null);
   const [photoLoading, setPhotoLoading] = useState(false);
   const [showFolderModal, setShowFolderModal] = useState(false);
+  const [enableTransition, setEnableTransition] = useState(false);
 
   useEffect(() => {
     const params = new URLSearchParams({
@@ -151,6 +152,11 @@ export function VenueChatCard({
         setPhotoLoading(false);
       });
   }, [venue.id, venue.name, venue.lat, venue.lng]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setEnableTransition(true), 500);
+    return () => clearTimeout(timer);
+  }, []);
 
   const CategoryIcon =
     venue.category === "cafe"
@@ -274,7 +280,9 @@ export function VenueChatCard({
             </button>
             <button
               onClick={() => onToggleFavorite(venue)}
-              className={`p-1.5 rounded-lg border transition-all active:scale-[0.95] ${
+              className={`p-1.5 rounded-lg border active:scale-[0.95] ${
+                enableTransition ? "transition-all duration-300" : ""
+              } ${
                 isFavorited
                   ? "bg-red-500 text-white border-red-500"
                   : "bg-zinc-100 dark:bg-zinc-800 border-zinc-200 dark:border-zinc-700 text-zinc-500 hover:bg-zinc-200"
@@ -282,7 +290,9 @@ export function VenueChatCard({
               title="Save favorite"
             >
               <Heart
-                className={`w-3.5 h-3.5 ${isFavorited ? "fill-current" : ""}`}
+                className={`w-3.5 h-3.5 ${
+                  enableTransition ? "transition-all duration-300" : ""
+                } ${isFavorited ? "fill-current" : ""}`}
               />
             </button>
           </div>
@@ -444,14 +454,18 @@ export function VenueChatCard({
                       );
                       onToggleFavorite(venue);
                     }}
-                    className={`flex-1 flex items-center justify-center gap-1 px-2 py-2 text-[10px] uppercase font-black tracking-tighter rounded-lg transition-all ${
+                    className={`flex-1 flex items-center justify-center gap-1 px-2 py-2 text-[10px] uppercase font-black tracking-tighter rounded-lg ${
+                      enableTransition ? "transition-all duration-300" : ""
+                    } ${
                       isFavorited
                         ? "bg-red-500 text-white shadow-md shadow-red-500/20"
                         : "bg-zinc-100 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-200 dark:hover:bg-zinc-700"
                     }`}
                   >
                     <Heart
-                      className={`w-3 h-3 ${isFavorited ? "fill-current" : ""}`}
+                      className={`w-3 h-3 ${
+                        enableTransition ? "transition-all duration-300" : ""
+                      } ${isFavorited ? "fill-current" : ""}`}
                     />
                     {isFavorited ? "Saved" : "Save"}
                   </button>

--- a/src/components/chat/VenueDetailDialog.tsx
+++ b/src/components/chat/VenueDetailDialog.tsx
@@ -81,6 +81,7 @@ export function VenueDetailDialog({
   const [brokenMenuPhotos, setBrokenMenuPhotos] = useState<
     Record<number, boolean>
   >({});
+  const [enableTransition, setEnableTransition] = useState(false);
   const { t } = useTranslation();
   const [translatingReviewId, setTranslatingReviewId] = useState<string | null>(
     null,
@@ -481,6 +482,11 @@ export function VenueDetailDialog({
     }
     loadVoteMetrics();
   }, [venue, isOpen]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setEnableTransition(true), 500);
+    return () => clearTimeout(timer);
+  }, []);
 
   useEffect(() => {
     if (!venue) return;
@@ -1493,14 +1499,18 @@ export function VenueDetailDialog({
                 <div className="flex gap-3">
                   <button
                     onClick={() => onToggleFavorite(venue)}
-                    className={`flex-1 flex items-center justify-center gap-2 font-black uppercase tracking-widest py-3 px-6 rounded-2xl transition-all border-2 ${
+                    className={`flex-1 flex items-center justify-center gap-2 font-black uppercase tracking-widest py-3 px-6 rounded-2xl border-2 ${
+                      enableTransition ? "transition-all duration-300" : ""
+                    } ${
                       isFavorited
                         ? "bg-red-500 border-red-400 text-white shadow-xl shadow-red-500/20"
                         : "bg-white dark:bg-zinc-800 border-zinc-200 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 shadow-md"
                     }`}
                   >
                     <Heart
-                      className={`w-4 h-4 ${isFavorited ? "fill-current" : ""}`}
+                      className={`w-4 h-4 ${
+                        enableTransition ? "transition-all duration-300" : ""
+                      } ${isFavorited ? "fill-current" : ""}`}
                     />
                     {isFavorited ? "Saved" : "Save"}
                   </button>


### PR DESCRIPTION
**Description**:
This PR resolves the issue where the heart icon favorite button flashes transition/scale animations when the components initially mount.
**Key Changes:**
* Added an `enableTransition` state variable and a `useEffect` hook to set it to `true` 500ms after the component mounts.
* Conditionalized the favorite button and heart icon transition class names (`transition-colors`, `transition-all`) to only apply when `enableTransition` is true.
* Refactored `VenueCard.tsx`, `ChatMessages.tsx` (`VenueChatCard`), and `VenueDetailDialog.tsx`.
Closes #678

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved favorite button behavior by preventing visual transition effects during initial page loading.
  * Added smoother favorite button and heart icon animations after the interface finishes loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->