### PR TITLE
fix: truncate long names in comparison and collection venue lists

### DIFF
--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -257,8 +257,11 @@ export default function FolderDetailsPage({
                         </div>
                       )}
                     </div>
-                    <div className="flex-1">
-                      <h3 className="text-lg font-bold text-zinc-900 dark:text-white mb-1">
+                    <div className="flex-1 min-w-0">
+                      <h3
+                        className="text-lg font-bold text-zinc-900 dark:text-white mb-1 truncate"
+                        title={fv.venue.name}
+                      >
                         {fv.venue.name}
                       </h3>
                       <p className="text-sm text-zinc-500 line-clamp-1">

--- a/src/components/collections/MetricsWidget.tsx
+++ b/src/components/collections/MetricsWidget.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Wifi, VolumeX, Plug, Activity } from 'lucide-react';
+import React from "react";
+import { Wifi, VolumeX, Plug, Activity } from "lucide-react";
 
 interface Venue {
   wifiSpeed?: number | null;
@@ -14,7 +14,8 @@ interface MetricsWidgetProps {
 }
 
 export function calculateMetrics(venues: { venue: Venue }[]) {
-  if (!venues || venues.length === 0) return { speed: null, quietness: null, outlets: null };
+  if (!venues || venues.length === 0)
+    return { speed: null, quietness: null, outlets: null };
 
   let totalSpeed = 0;
   let speedCount = 0;
@@ -30,13 +31,13 @@ export function calculateMetrics(venues: { venue: Venue }[]) {
       totalSpeed += venue.wifiSpeed;
       speedCount++;
     }
-    
+
     if (venue.noiseLevel) {
       const level = venue.noiseLevel.toLowerCase();
       let score = 3;
-      if (level === 'quiet') score = 5;
-      if (level === 'moderate') score = 3;
-      if (level === 'loud') score = 1;
+      if (level === "quiet") score = 5;
+      if (level === "moderate") score = 3;
+      if (level === "loud") score = 1;
       totalQuietness += score;
       quietnessCount++;
     }
@@ -47,27 +48,40 @@ export function calculateMetrics(venues: { venue: Venue }[]) {
   });
 
   const speed = speedCount > 0 ? Math.round(totalSpeed / speedCount) : null;
-  const quietness = quietnessCount > 0 ? Number((totalQuietness / quietnessCount).toFixed(1)) : null;
+  const quietness =
+    quietnessCount > 0
+      ? Number((totalQuietness / quietnessCount).toFixed(1))
+      : null;
   const outlets = Math.round((outletsCount / venues.length) * 100);
 
   return { speed, quietness, outlets };
 }
 
-export function MetricsWidget({ venues, title = "Collection Metrics", isCompact = false }: MetricsWidgetProps) {
+export function MetricsWidget({
+  venues,
+  title = "Collection Metrics",
+  isCompact = false,
+}: MetricsWidgetProps) {
   const { speed, quietness, outlets } = calculateMetrics(venues);
   return (
     <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-5 shadow-sm h-full flex flex-col justify-center">
-      {!isCompact && (
-        <h3 className="text-lg font-semibold text-zinc-900 dark:text-white flex items-center gap-2 mb-4">
-          <Activity className="w-5 h-5 text-indigo-500" /> {title}
-        </h3>
-      )}
-      
-      <div className={`grid ${isCompact ? 'grid-cols-1 gap-3' : 'grid-cols-3 gap-4'}`}>
+      <h3 className="text-lg font-semibold text-zinc-900 dark:text-white flex items-center gap-2 mb-4">
+        <Activity className="w-5 h-5 text-indigo-500 shrink-0" />
+        <span
+          className="truncate block max-w-[200px] sm:max-w-[280px]"
+          title={title}
+        >
+          {title}
+        </span>
+      </h3>
+
+      <div
+        className={`grid ${isCompact ? "grid-cols-1 gap-3" : "grid-cols-3 gap-4"}`}
+      >
         <div className="flex flex-col items-center justify-center p-3 bg-zinc-50 dark:bg-zinc-950 rounded-xl border border-zinc-100 dark:border-zinc-800">
           <Wifi className="w-6 h-6 text-blue-500 mb-2" />
           <div className="text-xl font-bold text-zinc-900 dark:text-white">
-            {speed !== null ? `${speed} Mbps` : '--'}
+            {speed !== null ? `${speed} Mbps` : "--"}
           </div>
           <div className="text-xs text-zinc-500 font-medium">Avg Speed</div>
         </div>
@@ -75,8 +89,10 @@ export function MetricsWidget({ venues, title = "Collection Metrics", isCompact 
         <div className="flex flex-col items-center justify-center p-3 bg-zinc-50 dark:bg-zinc-950 rounded-xl border border-zinc-100 dark:border-zinc-800">
           <VolumeX className="w-6 h-6 text-purple-500 mb-2" />
           <div className="text-xl font-bold text-zinc-900 dark:text-white flex items-center gap-1">
-            {quietness !== null ? quietness : '--'}
-            {quietness !== null && <span className="text-sm text-yellow-500">★</span>}
+            {quietness !== null ? quietness : "--"}
+            {quietness !== null && (
+              <span className="text-sm text-yellow-500">★</span>
+            )}
           </div>
           <div className="text-xs text-zinc-500 font-medium">Avg Quietness</div>
         </div>
@@ -84,7 +100,7 @@ export function MetricsWidget({ venues, title = "Collection Metrics", isCompact 
         <div className="flex flex-col items-center justify-center p-3 bg-zinc-50 dark:bg-zinc-950 rounded-xl border border-zinc-100 dark:border-zinc-800">
           <Plug className="w-6 h-6 text-green-500 mb-2" />
           <div className="text-xl font-bold text-zinc-900 dark:text-white">
-            {outlets !== null ? `${outlets}%` : '--'}
+            {outlets !== null ? `${outlets}%` : "--"}
           </div>
           <div className="text-xs text-zinc-500 font-medium">Outlet Avail.</div>
         </div>


### PR DESCRIPTION
**Description**:
This PR fixes horizontal layout corruption when rendering collections or folders with long names.
**Key Changes:**
* Rendered the folder/collection title in `MetricsWidget.tsx` using `truncate` and `title` attributes in all layout configurations (compact and standard).
* Restructured the venue card's title container on the collection detail page (`collections/[id]/page.tsx`) by adding `min-w-0` to the flex container and `truncate` to the `h3` title element.

Closes #686

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooltips and improved text truncation for long venue and metrics titles.
  * Metrics widget headers now remain visible in compact layouts, with an activity indicator for improved context.

* **Style**
  * Refined metrics widget formatting and presentation without changing calculations or displayed metric values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->