### PR TITLE
fix(venue-dialog): prevent iOS Safari edge-swipe back-nav on venue photo (fixes #715)

### DIFF
--- a/src/components/chat/VenueDetailDialog.tsx
+++ b/src/components/chat/VenueDetailDialog.tsx
@@ -735,7 +735,10 @@ export function VenueDetailDialog({
   const scannerLowConfidence = isLibrary && voteMetrics.scanner.hidden;
 
   return (
-    <div className="fixed inset-0 z-[10000] flex items-end sm:items-center justify-center p-0 sm:p-4 bg-zinc-950/95 animate-in fade-in duration-300">
+    <div
+      className="fixed inset-0 z-[10000] flex items-end sm:items-center justify-center p-0 sm:p-4 bg-zinc-950/95 animate-in fade-in duration-300"
+      style={{ touchAction: "pan-y" }}
+    >
       <div
         className="bg-white dark:bg-zinc-900 w-full max-w-2xl max-h-[90vh] overflow-hidden rounded-t-3xl sm:rounded-3xl shadow-[0_20px_100px_rgba(0,0,0,0.9)] border border-zinc-200 dark:border-zinc-800 animate-in slide-in-from-bottom-12 zoom-in-95 duration-500"
         onClick={(e) => e.stopPropagation()}
@@ -790,11 +793,12 @@ export function VenueDetailDialog({
           {photoLoading ? (
             <div className="w-full h-full bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
           ) : (
-            /* eslint-disable-next-line @next/next/no-img-element */
+            // eslint-disable-next-line @next/next/no-img-element
             <img
               src={displayPhoto}
               alt={venue.name}
               className="w-full h-full object-cover"
+              style={{ touchAction: "pan-y" }}
               onError={() => setImageError(true)}
             />
           )}


### PR DESCRIPTION
## Problem
Swiping right on the venue photo in the detail modal triggered iOS Safari's
native edge-swipe back-navigation instead of staying in the modal, because
neither the modal's outer container nor the photo `<img>` claimed horizontal
touch ownership.

## Fix
Added `touch-action: pan-y` to:
- the modal's outer `fixed inset-0` container
- the venue photo `<img>` element

This tells iOS Safari that vertical scroll should pass through natively,
while horizontal gestures on/near this modal are claimed by the app rather
than the system back-gesture recognizer. No custom swipe/gesture JS was
needed — there was no existing carousel or touch handler in this component
to begin with.

## Testing
- Verified via `tsc --noEmit` and `eslint --max-warnings=0` (clean)
- ⚠️ Not yet verified on a physical iOS Safari device — this fix is based on
  documented `touch-action` semantics for this exact gesture conflict, but
  the bug doesn't reliably reproduce in simulators. Would appreciate a
  reviewer confirming on-device before merge.

Fixes #715

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved touch interactions in the venue details dialog by enabling smooth vertical scrolling while viewing venue photos.
  * Prevented unintended horizontal gestures within the dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->