### PR TITLE
Fix receipt date formatting using ISO-8601

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17811,7 +17811,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/app/api/bookings/[bookingId]/download/route.ts
+++ b/src/app/api/bookings/[bookingId]/download/route.ts
@@ -135,11 +135,8 @@ export async function GET(
           return String(rawDate);
         }
 
-        return new Intl.DateTimeFormat("en-GB", {
-          day: "2-digit",
-          month: "2-digit",
-          year: "numeric",
-        }).format(dateObj);
+        // Standardize to ISO-8601 format (YYYY-MM-DD)
+        return dateObj.toISOString().split("T")[0];
       } catch (err) {
         console.warn(
           "[PDF date format warning]: Failed to format booking date, using raw fallback",


### PR DESCRIPTION
## Summary
This PR updates the receipt date formatting to use the ISO-8601 standard format (`YYYY-MM-DD`) before passing the date to the PDF generation logic.

## Changes Made
* Updated the `formatBookingDate` helper in `src/app/api/bookings/[bookingId]/download/route.ts`.
* Replaced locale-based formatting using `Intl.DateTimeFormat("en-GB")` with ISO-8601 formatting using `dateObj.toISOString().split("T")[0]`.
* Preserved the existing null checks, invalid date handling, and fallback behavior.

## Why
Using locale-specific date formats (such as `DD/MM/YYYY`) can lead to parsing issues in the PDF compiler. Standardizing dates to ISO-8601 ensures consistent and reliable date handling across different locales.


fixes #323 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized booking dates in downloaded PDFs to the ISO-8601 `YYYY-MM-DD` format.
  * Preserved existing fallback behavior for invalid or unavailable dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->