### PR TITLE
[Feature]: Add copy button to AI response bubbles

### DIFF
--- a/src/components/chat/ChatMessages.tsx
+++ b/src/components/chat/ChatMessages.tsx
@@ -20,6 +20,8 @@ import {
   Zap,
   LayoutGrid,
   List,
+  Copy,
+  Check,
 } from "lucide-react";
 import { RefObject, useState, useEffect, useRef } from "react";
 import { BrainTerminal } from "./BrainTerminal";
@@ -833,13 +835,18 @@ export function MessageList({
               className={`flex ${message.role === "user" ? "justify-end" : "justify-start"}`}
             >
               <div
-                className={`max-w-[90%] rounded-2xl px-5 py-3 shadow-md border-2 ${
+                className={`group relative max-w-[90%] rounded-2xl px-5 py-3 shadow-md border-2 ${
                   message.role === "user"
                     ? "bg-zinc-950 border-zinc-800 text-white rounded-tr-none"
                     : "bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-50 border-zinc-100 dark:border-zinc-700 rounded-tl-none"
                 }`}
               >
-                <div className="text-sm font-medium leading-relaxed">
+                {message.role === "assistant" && (
+                  <CopyMessageButton text={message.content} />
+                )}
+                <div
+                  className={`text-sm font-medium leading-relaxed ${message.role === "assistant" ? "pr-6" : ""}`}
+                >
                   {message.role === "assistant" ? (
                     <div className="relative">
                       <MessageRenderer content={message.content} />
@@ -974,6 +981,31 @@ export function MessageList({
 
 function TerminalIcon(props: any) {
   return <span {...props}>💻</span>;
+}
+
+function CopyMessageButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="absolute top-2 right-2 p-1.5 rounded-md text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-700 transition-all opacity-0 group-hover:opacity-100"
+      title="Copy message"
+      aria-label="Copy message"
+    >
+      {copied ? (
+        <Check className="w-3.5 h-3.5 text-green-500" />
+      ) : (
+        <Copy className="w-3.5 h-3.5" />
+      )}
+    </button>
+  );
 }
 
 // ─── ChatInput ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
- closes #670

### Description
This PR adds a convenient "Copy" button to the AI assistant's response message bubbles in the chat interface. This allows users to easily copy AI-generated recommendations, details, or snippets to their clipboard with a single click.

### Changes Made
* Added a new `CopyMessageButton` component inside `ChatMessages.tsx` utilizing the native `Clipboard API`.
* Integrated the button into the assistant's message bubble layout.
* Implemented a smooth UI transition: the button remains hidden by default to keep the interface clean, fades in on hover (`group-hover`), and briefly turns into a green checkmark (`Check` icon from `lucide-react`) for 2 seconds to confirm a successful copy.

### Screenshot 

<img width="1688" height="696" alt="Screenshot 2026-07-19 125625" src="https://github.com/user-attachments/assets/6ddee8ad-cbe4-48b4-8b1c-a83fcf823f6e" />

### Testing Instructions
1. Navigate to the AI chat interface (`/ai`).
2. Generate an AI response or view an existing one.
3. Hover over the assistant's message bubble to reveal the copy icon in the top right corner.
4. Click the icon, verify that it transitions to a green checkmark.
5. Paste the clipboard contents anywhere to confirm the AI's exact text was copied successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a one-click copy button to assistant messages.
  * Copied message content is placed directly on the device clipboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->