### PR TITLE
fix: reconnect EventSource on tab visibility change instead of unconditional reconnect

### DIFF
--- a/src/hooks/useRealTime.tsx
+++ b/src/hooks/useRealTime.tsx
@@ -106,7 +106,6 @@ export function useRealTimeUpdates(options: UseRealTimeUpdatesOptions = {}) {
     };
 
     // Handle online/offline events automatically
-    // Handle online/offline events automatically
     const handleOnline = () => {
       console.log("[RealTime] Browser online, reconnecting...");
       currentBackoff = 1000;
@@ -128,20 +127,11 @@ export function useRealTimeUpdates(options: UseRealTimeUpdatesOptions = {}) {
           currentBackoff = 1000;
           connect();
         }
-
-        console.log("[RealTime] Tab became visible, resetting connection");
-        currentBackoff = 1000;
-        if (eventSource) {
-          eventSource.close();
-        }
-        connect();
       }
     };
 
     window.addEventListener("online", handleOnline);
     window.addEventListener("offline", handleOffline);
-
-    window.addEventListener("visibilitychange", handleVisibilityChange); // 🌟 ADD THIS LINE
 
     document.addEventListener("visibilitychange", handleVisibilityChange);
 
@@ -152,8 +142,6 @@ export function useRealTimeUpdates(options: UseRealTimeUpdatesOptions = {}) {
       clearTimeout(reconnectTimeout);
       window.removeEventListener("online", handleOnline);
       window.removeEventListener("offline", handleOffline);
-
-      window.removeEventListener("visibilitychange", handleVisibilityChange); // 🌟 ADD THIS LINE
 
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };


### PR DESCRIPTION
Description

The useRealTimeUpdates hook had two bugs that caused EventSource connections to freeze during browser memory-saver suspension:
1. Unconditional reconnect on visibility change — When the tab became visible, the handler always called connect() twice (once conditionally inside the if block and once unconditionally after it), even if the stream was healthy. This caused unnecessary connection churn.
2. Wrong event target — visibilitychange was listened on both window (ineffective) and document (correct). The window listener was redundant and its cleanup was mismatched.
The useRealtimeCapacity hook already handled this correctly with a 30-second heartbeat watchdog that detects frozen connections and a visibility change handler that reconnects when the tab refocuses.
Related Issue
Fixes #328 
Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
Screenshots / Screen Recordings (if applicable)
N/A — functional fix with no UI changes.
Breaking Changes
- No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved real-time update handling when the browser reconnects or loses connectivity.
  * Improved synchronization of real-time updates when switching between visible and hidden browser tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->