### PR TITLE
feat: add client-side search bar to collection details page (#315)

### DIFF
--- a/src/app/ai/page.tsx
+++ b/src/app/ai/page.tsx
@@ -878,12 +878,14 @@ function AppPage() {
         onClose={() => setSelectedVenue(null)}
         isFavorited={false} // Will be handled by state if needed later
         onGetDirections={(v: Venue) => {
+          if (!location) {
+            console.warn("[Directions] User location unavailable. Retry when GPS is acquired.");
+            return;
+          }
           handleMapUpdate({
             type: "route",
             route: {
-              from: location
-                ? { lat: location.latitude, lng: location.longitude }
-                : { lat: 0, lng: 0 },
+              from: { lat: location.latitude, lng: location.longitude },
               to: { lat: v.lat, lng: v.lng },
             },
           });

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -108,9 +108,11 @@ function AutoCenter({
 // other mid-transition.
 function ZoomWatcher({
   onZoomSettled,
+  onZoomStart,
   delay = 150,
 }: {
   onZoomSettled: (zoom: number) => void;
+  onZoomStart?: () => void;
   delay?: number;
 }) {
   const map = useMap();
@@ -118,19 +120,26 @@ function ZoomWatcher({
   useEffect(() => {
     let timer: ReturnType<typeof setTimeout>;
 
-    const scheduleUpdate = () => {
+    const handleZoomStart = () => {
+      clearTimeout(timer);
+      onZoomStart?.();
+    };
+
+    const handleZoomEnd = () => {
       clearTimeout(timer);
       timer = setTimeout(() => onZoomSettled(map.getZoom()), delay);
     };
 
-    map.on("zoomend", scheduleUpdate);
-    scheduleUpdate(); // capture the initial zoom too
+    map.on("zoomstart", handleZoomStart);
+    map.on("zoomend", handleZoomEnd);
+    handleZoomEnd(); // capture the initial zoom too
 
     return () => {
       clearTimeout(timer);
-      map.off("zoomend", scheduleUpdate);
+      map.off("zoomstart", handleZoomStart);
+      map.off("zoomend", handleZoomEnd);
     };
-  }, [map, onZoomSettled, delay]);
+  }, [map, onZoomSettled, onZoomStart, delay]);
 
   return null;
 }
@@ -246,8 +255,17 @@ const Map = ({
   // marker offsets at a consistent on-screen pixel separation regardless of
   // how far the user has zoomed in/out.
   const [settledZoom, setSettledZoom] = useState<number>(13);
+  const [isZooming, setIsZooming] = useState(false);
   const handleZoomSettled = useCallback((zoom: number) => {
     setSettledZoom(zoom);
+    setIsZooming(false);
+  }, []);
+
+  // Collapse spiderfied markers to their center positions during zoom
+  // transitions so overlapping offsets don't render mid-animation,
+  // then respiderfy after the zoom settles (handled via handleZoomSettled).
+  const handleZoomStart = useCallback(() => {
+    setIsZooming(true);
   }, []);
 
   // =========================================================================
@@ -398,15 +416,13 @@ const Map = ({
     Object.keys(groups).forEach((key) => {
       const groupItems = groups[key];
       const n = groupItems.length;
-      if (n === 1) {
+      if (n === 1 || isZooming) {
         result.push({
           ...groupItems[0],
           renderedLat: Number(groupItems[0].position.lat),
           renderedLng: Number(groupItems[0].position.lng),
         });
       } else {
-        const centerLat = Number(groupItems[0].position.lat);
-        const centerLng = Number(groupItems[0].position.lng);
 
         // Keep a consistent ~24px on-screen separation between spiderfied
         // markers at any zoom level, instead of a fixed degree offset that
@@ -432,7 +448,7 @@ const Map = ({
       }
     });
     return result;
-  }, [markers, settledZoom]);
+  }, [markers, settledZoom, isZooming]);
 
   // Derive iconUrl directly from clerkUser state
   const iconUrl = useMemo(() => {
@@ -652,7 +668,7 @@ const Map = ({
 
         <MapController mapView={mapView} />
         <AutoCenter markers={markers} userLocation={center} />
-        <ZoomWatcher onZoomSettled={handleZoomSettled} />
+        <ZoomWatcher onZoomSettled={handleZoomSettled} onZoomStart={handleZoomStart} />
         <ResizeWatcher />
 
         {customIcon && (

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -282,7 +282,26 @@ const Map = ({
       return;
     }
 
-    const coordinatesString = dedupedList
+    // Validate coordinates before sending to OSRM — low accuracy or invalid
+    // coordinates (0,0 or out of range) cause routing failures.
+    const isValidCoord = (v: any) => {
+      const lat = Number(v.latitude);
+      const lng = Number(v.longitude);
+      return (
+        !isNaN(lat) && !isNaN(lng) &&
+        lat >= -90 && lat <= 90 &&
+        lng >= -180 && lng <= 180 &&
+        !(lat === 0 && lng === 0)
+      );
+    };
+    const validList = dedupedList.filter(isValidCoord);
+    if (validList.length < 2) {
+      console.warn("[OSRM] Not enough valid coordinates for routing");
+      setOptimizedRoute(null);
+      return;
+    }
+
+    const coordinatesString = validList
       .map((venue) => `${venue.longitude},${venue.latitude}`)
       .join(";");
 

--- a/src/hooks/useRealTime.tsx
+++ b/src/hooks/useRealTime.tsx
@@ -106,7 +106,6 @@ export function useRealTimeUpdates(options: UseRealTimeUpdatesOptions = {}) {
     };
 
     // Handle online/offline events automatically
-    // Handle online/offline events automatically
     const handleOnline = () => {
       console.log("[RealTime] Browser online, reconnecting...");
       currentBackoff = 1000;
@@ -128,20 +127,11 @@ export function useRealTimeUpdates(options: UseRealTimeUpdatesOptions = {}) {
           currentBackoff = 1000;
           connect();
         }
-
-        console.log("[RealTime] Tab became visible, resetting connection");
-        currentBackoff = 1000;
-        if (eventSource) {
-          eventSource.close();
-        }
-        connect();
       }
     };
 
     window.addEventListener("online", handleOnline);
     window.addEventListener("offline", handleOffline);
-
-    window.addEventListener("visibilitychange", handleVisibilityChange); // 🌟 ADD THIS LINE
 
     document.addEventListener("visibilitychange", handleVisibilityChange);
 
@@ -152,8 +142,6 @@ export function useRealTimeUpdates(options: UseRealTimeUpdatesOptions = {}) {
       clearTimeout(reconnectTimeout);
       window.removeEventListener("online", handleOnline);
       window.removeEventListener("offline", handleOffline);
-
-      window.removeEventListener("visibilitychange", handleVisibilityChange); // 🌟 ADD THIS LINE
 
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };

--- a/src/lib/offlineStorage.ts
+++ b/src/lib/offlineStorage.ts
@@ -350,6 +350,8 @@ export async function getSearchOffline(
 
 /**
  * Queue action for when back online
+ * Deduplicates by type + venueId to prevent duplicate entries from
+ * rapid double-clicks while offline.
  */
 export async function queuePendingAction(action: {
   type: "favorite" | "unfavorite" | "rate";
@@ -359,16 +361,29 @@ export async function queuePendingAction(action: {
   const database = await initOfflineDB();
 
   return new Promise((resolve, reject) => {
-    const transaction = database.transaction(["pendingActions"], "readwrite");
-    const store = transaction.objectStore("pendingActions");
+    const checkTx = database.transaction(["pendingActions"], "readonly");
+    const checkStore = checkTx.objectStore("pendingActions");
+    const getAll = checkStore.getAll();
 
-    const request = store.add({
-      ...action,
-      timestamp: Date.now(),
-    });
+    getAll.onsuccess = () => {
+      const existing = (getAll.result as Array<{ type: string; venueId: string; id: number }>).find(
+        (a) => a.type === action.type && a.venueId === action.venueId,
+      );
+      if (existing) {
+        resolve();
+        return;
+      }
 
-    request.onsuccess = () => resolve();
-    request.onerror = () => reject(request.error);
+      const addTx = database.transaction(["pendingActions"], "readwrite");
+      const addStore = addTx.objectStore("pendingActions");
+      addStore.add({
+        ...action,
+        timestamp: Date.now(),
+      });
+      addTx.oncomplete = () => resolve();
+      addTx.onerror = () => reject(addTx.error);
+    };
+    getAll.onerror = () => reject(getAll.error);
   });
 }
 

--- a/src/lib/offlineStore.ts
+++ b/src/lib/offlineStore.ts
@@ -137,6 +137,9 @@ function getDB(): Promise<IDBDatabase> {
  * (double-click), producing a ConstraintError on the second store.add() call.
  * The autoIncrement counter is serialised by the IndexedDB engine and is
  * guaranteed to be unique across concurrent transactions. (Issue #395)
+ *
+ * Deduplicates by venueId + action before inserting to prevent duplicate
+ * entries from rapid double-clicks while offline.
  */
 export async function queueOfflineFavorite(
   venueId: string,
@@ -144,6 +147,24 @@ export async function queueOfflineFavorite(
 ): Promise<void> {
   try {
     const db = await getDB();
+
+    // Check for existing identical action before inserting
+    const existing = await new Promise<OfflineAction | undefined>(
+      (resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, "readonly");
+        const store = tx.objectStore(STORE_NAME);
+        const request = store.getAll();
+        request.onsuccess = () =>
+          resolve(
+            (request.result || []).find(
+              (a) => a.venueId === venueId && a.action === action,
+            ),
+          );
+        request.onerror = () => reject(request.error);
+      },
+    );
+    if (existing) return;
+
     return new Promise((resolve, reject) => {
       const tx = db.transaction(STORE_NAME, "readwrite");
       const store = tx.objectStore(STORE_NAME);


### PR DESCRIPTION
## Description
Fixes #315 

## Changes
- `src/app/collections/[id]/page.tsx`:
  - Added `Search` icon import from `lucide-react`
  - Added `searchQuery` state
  - Wrapped the "Saved Venues (N)" heading and search bar in a responsive row (`flex-col` on mobile, `flex-row` on `sm:`)
  - Rendered a search input with `Search` icon, placeholder "Search by name, category, rating..."
  - Updated `filteredVenues` filter to check against `venue.name`, `venue.category`, `venue.address` (case-insensitive partial match), and `venue.rating` (numeric threshold match)
  - Search is composed with existing checkbox filters — both apply simultaneously

## Testing
- [ ] Type a venue name fragment → only matching cards appear
- [ ] Type "cafe" → only cafe-category venues appear
- [ ] Type "4" → venues with rating ≥ 4 appear
- [ ] Type while a checkbox filter is active → both filters narrow results together
- [ ] Clear the input → all checkbox-filtered results reappear