### PR TITLE
fix: prevent double scrollbar in venue rating dialog

### DIFF
--- a/src/components/VenueRatingDialog.tsx
+++ b/src/components/VenueRatingDialog.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import { NoiseMeasurement, NoiseMeter } from "@/components/noise/NoiseMeter";
+import { Star, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
-import { Star, X } from "lucide-react";
-import { NoiseMeasurement, NoiseMeter } from "@/components/noise/NoiseMeter";
 
 interface VenueRatingDialogProps {
   venueName: string;
@@ -86,6 +86,17 @@ export function VenueRatingDialog({
   useEffect(() => {
     setMounted(true);
   }, []);
+
+  // --- FIX  Lock document body scroll context when open ---
+  useEffect(() => {
+    if (isOpen && mounted) {
+      document.body.style.overflow = "hidden";
+    }
+
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen, mounted]);
 
   const compressImage = (file: File): Promise<Blob> => {
     return new Promise((resolve) => {


### PR DESCRIPTION
Fixes #711

## Fix: Double scrollbar in venue review submission dialog on Windows

### Problem
Opening the venue review submission dialog on Windows Chrome displayed two vertical scrollbars:
- Browser body scrollbar
- Modal scrollbar

### Cause
The background page remained scrollable while the review dialog was open, causing both the page and modal to have scrollbars.

### Changes Made
- Added body scroll locking when the rating dialog is opened.
- Restored body scrolling when the dialog is closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented background page scrolling while the venue rating dialog is open.
  * Restored normal page scrolling automatically when the dialog closes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->