### PR TITLE
fix: improve rating star focus ring accessibility

### DIFF
--- a/src/components/VenueRatingDialog.tsx
+++ b/src/components/VenueRatingDialog.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import { NoiseMeasurement, NoiseMeter } from "@/components/noise/NoiseMeter";
+import { Star, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
-import { Star, X } from "lucide-react";
-import { NoiseMeasurement, NoiseMeter } from "@/components/noise/NoiseMeter";
 
 interface VenueRatingDialogProps {
   venueName: string;
@@ -263,7 +263,7 @@ export function VenueRatingDialog({
                   key={rating}
                   type="button"
                   onClick={() => setWifiQuality(rating)}
-                  className={`rounded-lg p-2 transition ${
+                  className={`rounded-lg p-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2  ${
                     rating <= wifiQuality
                       ? "bg-blue-100 text-blue-600 dark:bg-blue-900/30"
                       : "bg-zinc-100 text-zinc-400 dark:bg-zinc-800"


### PR DESCRIPTION
Fixes #570

## Fix: Rating star icons focus ring overlaps adjacent buttons

### Problem
Keyboard navigation on rating star buttons displayed focus outlines that overlapped neighboring star icons.

### Changes Made
- Updated star button focus styles with a visible focus ring.
- Added focus ring offset to prevent overlap with adjacent buttons.
- Improved spacing between rating buttons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved keyboard focus visibility for WiFi Quality rating buttons with clear focus indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->