### PR TITLE
feat: add user authentication dashboard

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -107,7 +107,7 @@ export default function Home() {
                 Collections
               </Link>
               <div className="flex items-center justify-center w-8 h-8 rounded-full overflow-hidden shrink-0 ml-1">
-                <UserButton />
+                <UserButton userProfileMode="navigation" userProfileUrl="/user-profile" />
               </div>
             </Show>
           </div>

--- a/src/app/user-profile/[[...user-profile]]/page.tsx
+++ b/src/app/user-profile/[[...user-profile]]/page.tsx
@@ -1,0 +1,24 @@
+import { UserProfile } from "@clerk/nextjs";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+
+export default function UserProfilePage() {
+  return (
+    <div className="min-h-screen bg-zinc-50 dark:bg-zinc-950">
+      <div className="container mx-auto px-4 py-8 max-w-4xl">
+        <div className="mb-8">
+          <Link 
+            href="/" 
+            className="inline-flex items-center text-sm font-medium text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-white transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4 mr-2" />
+            Back to Home
+          </Link>
+        </div>
+        <div className="flex justify-center">
+          <UserProfile path="/user-profile" routing="path" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -305,7 +305,7 @@ export function ChatHeader({
                 PROFILE
               </div>
             </div>
-            <UserButton />
+            <UserButton userProfileMode="navigation" userProfileUrl="/user-profile" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
# Pull Request

## Description

Added a dedicated User Authentication Dashboard accessible from the user's profile dropdown menu. The dashboard uses Clerk's `<UserProfile />` component to allow users to view their active sessions, change their password, and enable two-factor authentication (2FA).

### Changes
- **Auth**: Created a new page route at `/user-profile/[[...user-profile]]/page.tsx` displaying the `UserProfile` component.
- **UI**: Updated the `<UserButton />` in `src/app/page.tsx` and `src/components/chat/ChatHeader.tsx` with `userProfileMode="navigation"` and `userProfileUrl="/user-profile"` props.

## Type of Change

- [x] New Feature (or Bug Fix, etc.)
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #788

## Testing

Verified the rendering of the `/user-profile` page and that the profile dropdown links to it correctly.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A - Standard Clerk UI component integrated.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated user profile page accessible at `/user-profile`.
  * Added a “Back to Home” navigation link on the profile page.
  * Updated user menu controls to navigate directly to the profile page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->