### PR TITLE
fix(download): load fonts asynchronously to prevent event loop blocking

### DIFF
--- a/src/__tests__/api/download.test.ts
+++ b/src/__tests__/api/download.test.ts
@@ -1,0 +1,101 @@
+import { GET } from "../../app/api/bookings/[bookingId]/download/route";
+import { prisma } from "@/lib/prisma";
+import { auth } from "@clerk/nextjs/server";
+import fs from "fs";
+
+jest.mock("@clerk/nextjs/server", () => ({
+  auth: jest.fn(),
+}));
+
+jest.mock("@/lib/auth", () => ({
+  ensureUserExists: jest.fn(),
+}));
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    booking: {
+      findFirst: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("fs", () => {
+  const actual = jest.requireActual("fs");
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      readFile: jest.fn(),
+    },
+  };
+});
+
+describe("GET /api/bookings/[bookingId]/download", () => {
+  const mockAuth = auth as jest.Mock;
+  const mockFindFirst = (prisma as any).booking.findFirst as jest.Mock;
+  const mockReadFile = fs.promises.readFile as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 401 if unauthorized", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+
+    const req = {
+      nextUrl: new URL("http://localhost/api/bookings/123/download"),
+    };
+    const context = { params: Promise.resolve({ bookingId: "123" }) };
+
+    const res = await GET(req as any, context);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 if booking not found", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_123" });
+    mockFindFirst.mockResolvedValue(null);
+
+    const req = {
+      nextUrl: new URL("http://localhost/api/bookings/123/download"),
+    };
+    const context = { params: Promise.resolve({ bookingId: "123" }) };
+
+    const res = await GET(req as any, context);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 200 with PDF content type and reads fonts asynchronously", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_123" });
+    mockFindFirst.mockResolvedValue({
+      id: "booking_123",
+      confirmationId: "WS-CONF-123",
+      date: "2026-07-19",
+      time: "12:00",
+      duration: 3,
+      projectBillingCode: "BILL-123",
+      customerEmail: "customer@example.com",
+      venue: {
+        name: "Test Venue",
+        category: "cafe",
+        address: "123 Test St",
+      },
+      user: {
+        firstName: "John",
+        lastName: "Doe",
+      },
+    });
+
+    // Mock readFile to return a dummy buffer
+    mockReadFile.mockResolvedValue(Buffer.from("dummy-font-data"));
+
+    const req = {
+      nextUrl: new URL("http://localhost/api/bookings/booking_123/download?showLogo=true"),
+    };
+    const context = { params: Promise.resolve({ bookingId: "booking_123" }) };
+
+    const res = await GET(req as any, context);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/pdf");
+    expect(mockReadFile).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app/api/bookings/[bookingId]/download/route.ts
+++ b/src/app/api/bookings/[bookingId]/download/route.ts
@@ -73,8 +73,10 @@ export async function GET(
     let boldFont: PDFFont;
 
     try {
-      const regularFontBytes = fs.readFileSync(regularFontPath);
-      const boldFontBytes = fs.readFileSync(boldFontPath);
+      const [regularFontBytes, boldFontBytes] = await Promise.all([
+        fs.promises.readFile(regularFontPath),
+        fs.promises.readFile(boldFontPath),
+      ]);
 
       font = await pdfDoc.embedFont(regularFontBytes);
       boldFont = await pdfDoc.embedFont(boldFontBytes);


### PR DESCRIPTION
Fixes #533

### Description
This PR resolves a performance issue where the main event loop is blocked due to synchronous file reading (`fs.readFileSync`) of custom Noto Sans fonts during PDF receipt generation in the download route.

The bug is resolved by:
- Refactoring `fs.readFileSync` calls to use `fs.promises.readFile` inside `Promise.all` for non-blocking asynchronous file reading.

### Verification
- Added a new unit test suite in `src/__tests__/api/download.test.ts` to mock Clerk auth, database queries, and async file loading, verifying correct execution.
- Verified all unit tests pass cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF download performance by loading fonts asynchronously.
  * Preserved fallback behavior when custom fonts cannot be loaded.

* **Tests**
  * Added coverage for unauthorized requests, missing bookings, successful PDF downloads, and font loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->