### PR TITLE
fix: resolve footer overlapping with main content on small screens

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -119,7 +119,7 @@ export default function DashboardPage() {
   };
 
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-black p-6">
+    <div className="min-h-screen bg-zinc-50 dark:bg-black p-6 pb-24">
       {/* Header */}
       <div className="max-w-7xl mx-auto">
         <div className="flex items-center justify-between mb-8">


### PR DESCRIPTION

Closes #816

# Pull Request

## Description

This pull request fixes an issue where the footer would overlap with the lowest cards on the main dashboard when the browser window was resized to mobile width (below 640px).

### Changes
- **Layout Adjustments**: Added padding-bottom (`pb-24`) to the main dashboard container class in `src/app/dashboard/page.tsx` to ensure that there is always sufficient space above the footer, preventing overlapping on small screens.

## Type of Change

- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #816

## Testing

Verified by checking the dashboard layout on a resized browser window.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A - Backend changes only

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added extra bottom spacing to the dashboard page for improved layout and scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->