### PR TITLE
feat: add custom user profile avatar upload

### DIFF
--- a/src/app/user-profile/[[...user-profile]]/page.tsx
+++ b/src/app/user-profile/[[...user-profile]]/page.tsx
@@ -1,6 +1,7 @@
 import { UserProfile } from "@clerk/nextjs";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
+import { CustomAvatarUpload } from "@/components/CustomAvatarUpload";
 
 export default function UserProfilePage() {
   return (
@@ -15,6 +16,11 @@ export default function UserProfilePage() {
             Back to Home
           </Link>
         </div>
+        
+        <div className="mb-8 max-w-[880px] mx-auto w-full">
+          <CustomAvatarUpload />
+        </div>
+
         <div className="flex justify-center">
           <UserProfile path="/user-profile" routing="path" />
         </div>

--- a/src/components/CustomAvatarUpload.tsx
+++ b/src/components/CustomAvatarUpload.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { useUser } from "@clerk/nextjs";
+import { Upload, Loader2, Image as ImageIcon } from "lucide-react";
+
+export function CustomAvatarUpload() {
+  const { user, isLoaded } = useUser();
+  const [isUploading, setIsUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  if (!isLoaded || !user) return null;
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    // Validate file type and size
+    if (!file.type.startsWith("image/")) {
+      setError("Please select an image file.");
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      setError("Image must be smaller than 5MB.");
+      return;
+    }
+
+    setError(null);
+    setIsUploading(true);
+
+    try {
+      await user.setProfileImage({ file });
+    } catch (err: any) {
+      console.error("Failed to upload image:", err);
+      setError(err.errors?.[0]?.message || "Failed to upload image. Please try again.");
+    } finally {
+      setIsUploading(false);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    }
+  };
+
+  return (
+    <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-6 shadow-sm">
+      <div className="flex items-start gap-4">
+        <div className="w-16 h-16 rounded-full overflow-hidden shrink-0 border border-zinc-200 dark:border-zinc-800 bg-zinc-100 dark:bg-zinc-800 flex items-center justify-center">
+          {user.hasImage ? (
+            <img 
+              src={user.imageUrl} 
+              alt={user.fullName || "User avatar"} 
+              className="w-full h-full object-cover"
+            />
+          ) : (
+            <ImageIcon className="w-6 h-6 text-zinc-400" />
+          )}
+        </div>
+        
+        <div className="flex-1">
+          <h3 className="text-lg font-semibold text-zinc-900 dark:text-white mb-1">
+            Profile Picture
+          </h3>
+          <p className="text-sm text-zinc-500 dark:text-zinc-400 mb-4">
+            Upload a custom avatar to personalize your profile.
+          </p>
+          
+          <div className="flex items-center gap-4">
+            <input
+              type="file"
+              accept="image/*"
+              className="hidden"
+              ref={fileInputRef}
+              onChange={handleFileChange}
+              disabled={isUploading}
+            />
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              disabled={isUploading}
+              className="inline-flex items-center gap-2 px-4 py-2 bg-zinc-900 dark:bg-white text-white dark:text-zinc-900 text-sm font-medium rounded-lg hover:bg-zinc-800 dark:hover:bg-zinc-100 disabled:opacity-50 transition-colors"
+            >
+              {isUploading ? (
+                <>
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  Uploading...
+                </>
+              ) : (
+                <>
+                  <Upload className="w-4 h-4" />
+                  Upload Image
+                </>
+              )}
+            </button>
+            {error && <span className="text-sm text-red-500">{error}</span>}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION

# Pull Request

## Description

This pull request implements a custom avatar upload feature on the user profile page as requested in Issue #817. Instead of relying solely on the default Clerk profile picture interface, users now have a dedicated, prominent section at the top of their user profile page to upload a custom avatar.

### Changes
- **New Component**: Created `CustomAvatarUpload.tsx` in `src/components`, a client component that leverages `@clerk/nextjs` to use `user.setProfileImage({ file })` for seamless API integration with Clerk.
- **Profile Integration**: Embedded the new component into the `/user-profile` page directly above the existing Clerk `<UserProfile />` to make it easily accessible.

## Type of Change

- [x] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #817

## Testing

Verified the new component structure and ensured that the proper Clerk SDK methods are invoked.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added profile image upload functionality to the user profile page.
  * Users can select an image, preview their current avatar, and update their profile picture.
  * Added validation for supported image files up to 5 MB, with upload status and error feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->