### PR TITLE
fix: re-check scroll position on container resize, not just message c…

### DIFF
--- a/src/components/chat/ChatMessages.tsx
+++ b/src/components/chat/ChatMessages.tsx
@@ -788,19 +788,36 @@ export function MessageList({
 }: MessageListProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
 
+  const scrollToBottomIfNeeded = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const isAtBottom =
+      container.scrollHeight - container.scrollTop - container.clientHeight <
+      200;
+    if (isAtBottom || isLoading) {
+      requestAnimationFrame(() => {
+        container.scrollTop = container.scrollHeight;
+      });
+    }
+  }, [isLoading]);
+
+  // Re-check scroll position whenever messages change or loading state changes
+  useEffect(() => {
+    scrollToBottomIfNeeded();
+  }, [messages, isLoading, scrollToBottomIfNeeded]);
+
+  // Also re-check whenever the container's own size changes (e.g. the input
+  // box growing to multiple lines shrinks the visible message area, which
+  // previously left new messages hidden below the fold)
   useEffect(() => {
     const container = containerRef.current;
-    if (container) {
-      const isAtBottom =
-        container.scrollHeight - container.scrollTop - container.clientHeight <
-        200;
-      if (isAtBottom || isLoading) {
-        requestAnimationFrame(() => {
-          container.scrollTop = container.scrollHeight;
-        });
-      }
-    }
-  }, [messages, isLoading]);
+    if (!container) return;
+    const resizeObserver = new ResizeObserver(() => {
+      scrollToBottomIfNeeded();
+    });
+    resizeObserver.observe(container);
+    return () => resizeObserver.disconnect();
+  }, [scrollToBottomIfNeeded]);
 
   return (
     <div ref={containerRef} className="flex-1 overflow-y-auto p-4 space-y-4">


### PR DESCRIPTION
…hanges

## Description
The auto-scroll logic in `MessageList` (`ChatMessages.tsx`) only recalculated whether to scroll to the bottom inside a `useEffect` keyed on `[messages, isLoading]`. This meant the scroll position was never re-checked when the message container's visible height changed for other reasons (e.g. the input area growing). As a result, new content could end up hidden below the fold without the scroll handler ever re-firing, matching the bug described in this issue.
Fix-Extracted the scroll check into a `scrollToBottomIfNeeded` callback, and added a `ResizeObserver` on the message container that re-runs this check whenever the container's size changes, not just when messages arrive.
<!-- Provide a clear and concise description of what this PR does and why it is needed. -->

## Related Issue

<!-- 
Please link to the issue here using the standard keywords. 
Example: Fixes #123 or Closes #123
-->
Fixes #452

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

<!-- Add visual evidence if this PR changes UI/UX. -->

## Breaking Changes

- [ ] Yes (please describe below)
- [X] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat auto-scrolling when messages load or update.
  * Chat now better stays positioned at the latest message when the layout or available viewing area changes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->