### PR TITLE
feat: add collaborative workspace collections

### DIFF
--- a/prisma/migrations/20260720170000_add_folder_email_invites/migration.sql
+++ b/prisma/migrations/20260720170000_add_folder_email_invites/migration.sql
@@ -1,0 +1,23 @@
+CREATE TYPE "FolderInviteStatus" AS ENUM ('PENDING', 'ACCEPTED', 'REVOKED', 'EXPIRED');
+
+CREATE TABLE "FolderInvite" (
+    "id" TEXT NOT NULL,
+    "folderId" TEXT NOT NULL,
+    "senderId" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "role" "FolderRole" NOT NULL DEFAULT 'MEMBER',
+    "token" TEXT NOT NULL,
+    "status" "FolderInviteStatus" NOT NULL DEFAULT 'PENDING',
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "FolderInvite_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "FolderInvite_token_key" ON "FolderInvite"("token");
+CREATE INDEX "FolderInvite_folderId_idx" ON "FolderInvite"("folderId");
+CREATE INDEX "FolderInvite_email_idx" ON "FolderInvite"("email");
+CREATE INDEX "FolderInvite_status_expiresAt_idx" ON "FolderInvite"("status", "expiresAt");
+
+ALTER TABLE "FolderInvite" ADD CONSTRAINT "FolderInvite_folderId_fkey" FOREIGN KEY ("folderId") REFERENCES "Folder"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "FolderInvite" ADD CONSTRAINT "FolderInvite_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,6 +42,7 @@ model User {
   notificationEnd    String?
   timezone           String?            @default("UTC")
   folderUpvotes      FolderUpvote[]
+  sentFolderInvites  FolderInvite[]      @relation("FolderInviteSender")
   workStyleProfile   String?
   checkIns           CheckIn[]
 }
@@ -440,6 +441,7 @@ model Folder {
   venues     FolderVenue[]
   members    FolderMember[]
   upvoteRefs FolderUpvote[]
+  invites     FolderInvite[]
 
   @@index([ownerId])
 }
@@ -515,6 +517,33 @@ model WebhookDeliveryLog {
   @@index([endpointId])
   @@index([createdAt])
   @@index([endpointId, createdAt])
+}
+
+
+model FolderInvite {
+  id        String             @id @default(cuid())
+  folderId  String
+  folder    Folder             @relation(fields: [folderId], references: [id], onDelete: Cascade)
+  senderId  String
+  sender    User               @relation("FolderInviteSender", fields: [senderId], references: [id], onDelete: Cascade)
+  email     String
+  role      FolderRole         @default(MEMBER)
+  token     String             @unique
+  status    FolderInviteStatus @default(PENDING)
+  expiresAt DateTime
+  createdAt DateTime           @default(now())
+  updatedAt DateTime           @updatedAt
+
+  @@index([folderId])
+  @@index([email])
+  @@index([status, expiresAt])
+}
+
+enum FolderInviteStatus {
+  PENDING
+  ACCEPTED
+  REVOKED
+  EXPIRED
 }
 
 model FolderUpvote {

--- a/src/__tests__/lib/collectionInvite.test.ts
+++ b/src/__tests__/lib/collectionInvite.test.ts
@@ -1,0 +1,31 @@
+import {
+  COLLECTION_INVITE_TTL_MS,
+  createCollectionInviteExpiry,
+  isCollectionInviteExpired,
+  normalizeCollectionInviteEmail,
+} from "@/lib/collections/invite-utils";
+
+describe("collection invitation utilities", () => {
+  it("normalizes invitation email addresses", () => {
+    expect(normalizeCollectionInviteEmail("  Teammate@Example.COM ")).toBe(
+      "teammate@example.com",
+    );
+  });
+
+  it("creates a seven-day expiration time", () => {
+    const now = Date.UTC(2026, 6, 20, 12, 0, 0);
+    expect(createCollectionInviteExpiry(now).getTime()).toBe(
+      now + COLLECTION_INVITE_TTL_MS,
+    );
+  });
+
+  it("detects expired and active invitations", () => {
+    const now = new Date("2026-07-20T12:00:00.000Z");
+    expect(
+      isCollectionInviteExpired(new Date("2026-07-20T11:59:59.000Z"), now),
+    ).toBe(true);
+    expect(
+      isCollectionInviteExpired(new Date("2026-07-20T12:00:01.000Z"), now),
+    ).toBe(false);
+  });
+});

--- a/src/app/api/folders/[id]/invites/route.ts
+++ b/src/app/api/folders/[id]/invites/route.ts
@@ -1,12 +1,24 @@
-import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@clerk/nextjs/server";
-import { prisma } from "@/lib/prisma";
-import { hasFolderAccess } from "@/lib/folders";
 import crypto from "crypto";
+import { auth, currentUser } from "@clerk/nextjs/server";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 
-// POST /api/folders/[id]/invites - Generate or regenerate invite token
+import { ensureUserExists } from "@/lib/auth";
+import { sendCollectionInviteEmail } from "@/lib/collections/invite-email";
+import {
+  createCollectionInviteExpiry,
+  normalizeCollectionInviteEmail,
+} from "@/lib/collections/invite-utils";
+import { hasFolderAccess } from "@/lib/folders";
+import { prisma } from "@/lib/prisma";
+
+const inviteSchema = z.object({
+  email: z.string().trim().email(),
+  role: z.enum(["EDITOR", "MEMBER"]).default("MEMBER"),
+});
+
 export async function POST(
-  req: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
@@ -15,32 +27,121 @@ export async function POST(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
+    await ensureUserExists(userId);
     const { id } = await params;
-    const { folder, hasAccess, role } = await hasFolderAccess(id, userId);
+    const access = await hasFolderAccess(id, userId);
 
-    if (!folder) {
-      return NextResponse.json({ error: "Folder not found" }, { status: 404 });
-    }
-    if (!hasAccess || (role !== "OWNER" && role !== "EDITOR")) {
+    if (!access.folder) {
       return NextResponse.json(
-        { error: "Forbidden. Only owner or editor can generate invites." },
+        { error: "Collection not found" },
+        { status: 404 },
+      );
+    }
+
+    if (access.role !== "OWNER" && access.role !== "EDITOR") {
+      return NextResponse.json(
+        { error: "Only owners and editors can invite teammates" },
         { status: 403 },
       );
     }
 
-    const timestamp = Date.now();
-    const inviteToken = `${crypto.randomBytes(16).toString("hex")}_${timestamp}`;
+    const parsed = inviteSchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Enter a valid email and collaborator role" },
+        { status: 400 },
+      );
+    }
 
-    const updatedFolder = await prisma.folder.update({
-      where: { id },
-      data: { inviteToken },
+    const email = normalizeCollectionInviteEmail(parsed.data.email);
+    const role = parsed.data.role;
+    const inviter = await currentUser();
+    const inviterEmails =
+      inviter?.emailAddresses.map((entry) =>
+        entry.emailAddress.toLowerCase(),
+      ) ?? [];
+
+    if (inviterEmails.includes(email)) {
+      return NextResponse.json(
+        { error: "You are already part of this collection" },
+        { status: 400 },
+      );
+    }
+
+    const existingUser = await prisma.user.findUnique({
+      where: { email },
+      select: { id: true },
     });
 
-    return NextResponse.json({ inviteToken: updatedFolder.inviteToken });
-  } catch (error) {
-    console.error(`POST /api/folders/invites error:`, error);
+    if (existingUser) {
+      const membership = await prisma.folderMember.upsert({
+        where: {
+          folderId_userId: {
+            folderId: id,
+            userId: existingUser.id,
+          },
+        },
+        update: { role },
+        create: { folderId: id, userId: existingUser.id, role },
+      });
+
+      return NextResponse.json({
+        mode: "member_added",
+        membership,
+        message: "Existing WorkSphere user added to the collection.",
+      });
+    }
+
+    await prisma.folderInvite.updateMany({
+      where: { folderId: id, email, status: "PENDING" },
+      data: { status: "REVOKED" },
+    });
+
+    const expiresAt = createCollectionInviteExpiry();
+    const token = crypto.randomBytes(32).toString("hex");
+    const invite = await prisma.folderInvite.create({
+      data: { folderId: id, senderId: userId, email, role, token, expiresAt },
+    });
+
+    const appUrl =
+      process.env.NEXT_PUBLIC_APP_URL ||
+      request.nextUrl.origin ||
+      "http://localhost:3000";
+    const inviteUrl = `${appUrl}/collections/join?token=${invite.token}`;
+    const inviterName =
+      [inviter?.firstName, inviter?.lastName].filter(Boolean).join(" ") ||
+      "A WorkSphere teammate";
+
+    const mailResult = await sendCollectionInviteEmail({
+      to: invite.email,
+      collectionName: access.folder.name,
+      inviterName,
+      role,
+      inviteUrl,
+      expiresAt,
+    });
+
     return NextResponse.json(
-      { error: "Failed to generate invite token" },
+      {
+        mode: "invite_created",
+        message: mailResult.sent
+          ? "Invitation email sent."
+          : "Invitation created. SMTP is not configured, so copy the link manually.",
+        invite: {
+          id: invite.id,
+          email: invite.email,
+          role: invite.role,
+          expiresAt: invite.expiresAt,
+          inviteUrl,
+          emailSent: mailResult.sent,
+        },
+      },
+      { status: 201 },
+    );
+  } catch (error) {
+    console.error("POST /api/folders/[id]/invites error:", error);
+    return NextResponse.json(
+      { error: "Failed to invite teammate" },
       { status: 500 },
     );
   }

--- a/src/app/api/folders/[id]/venues/route.ts
+++ b/src/app/api/folders/[id]/venues/route.ts
@@ -19,7 +19,7 @@ const addVenueSchema = z.object({
 // POST /api/folders/[id]/venues - Add venue to folder
 export async function POST(
   req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
     const { userId } = await auth();
@@ -33,15 +33,18 @@ export async function POST(
     if (!folder) {
       return NextResponse.json({ error: "Folder not found" }, { status: 404 });
     }
-    if (!hasAccess || (role !== "OWNER" && role !== "EDITOR" && role !== "MEMBER")) {
+    if (!hasAccess || (role !== "OWNER" && role !== "EDITOR")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
     const body = await req.json();
     const validation = addVenueSchema.safeParse(body);
-    
+
     if (!validation.success) {
-      return NextResponse.json({ error: validation.error.format() }, { status: 400 });
+      return NextResponse.json(
+        { error: validation.error.format() },
+        { status: 400 },
+      );
     }
 
     const { venue } = validation.data;
@@ -50,11 +53,8 @@ export async function POST(
 
     let dbVenue = await prisma.venue.findFirst({
       where: {
-        OR: [
-          { id: venue.id },
-          { placeId: effectivePlaceId }
-        ]
-      }
+        OR: [{ id: venue.id }, { placeId: effectivePlaceId }],
+      },
     });
 
     if (!dbVenue) {
@@ -67,7 +67,7 @@ export async function POST(
           longitude: venue.longitude || 0,
           category: venue.category || "cafe",
           address: venue.address || "",
-        }
+        },
       });
     }
 
@@ -80,18 +80,22 @@ export async function POST(
       },
       include: {
         venue: true,
-      }
+      },
     });
 
     return NextResponse.json({ folderVenue }, { status: 201 });
   } catch (error: any) {
     console.error(`POST /api/folders/venues error:`, error);
-    if (error.code === 'P2002') { // Unique constraint
-      return NextResponse.json({ error: "Venue already in folder" }, { status: 400 });
+    if (error.code === "P2002") {
+      // Unique constraint
+      return NextResponse.json(
+        { error: "Venue already in folder" },
+        { status: 400 },
+      );
     }
     return NextResponse.json(
       { error: "Failed to add venue to folder" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/src/app/api/folders/join/route.ts
+++ b/src/app/api/folders/join/route.ts
@@ -1,85 +1,103 @@
+import { auth, currentUser } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@clerk/nextjs/server";
-import { prisma } from "@/lib/prisma";
 import { z } from "zod";
+
 import { ensureUserExists } from "@/lib/auth";
+import {
+  isCollectionInviteExpired,
+  normalizeCollectionInviteEmail,
+} from "@/lib/collections/invite-utils";
+import { prisma } from "@/lib/prisma";
 
-const joinSchema = z.object({
-  token: z.string(),
-});
+const joinSchema = z.object({ token: z.string().min(20) });
 
-// POST /api/folders/join - Join a folder using an invite token
-export async function POST(req: NextRequest) {
+export async function POST(request: NextRequest) {
   try {
     const { userId } = await auth();
     if (!userId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // Ensure the guest user exists in the local database to avoid foreign key violations
     await ensureUserExists(userId);
-
-    const body = await req.json();
-    const validation = joinSchema.safeParse(body);
-
-    if (!validation.success) {
+    const parsed = joinSchema.safeParse(await request.json());
+    if (!parsed.success) {
       return NextResponse.json(
-        { error: "Invalid token format" },
+        { error: "Invalid invitation token" },
         { status: 400 },
       );
     }
 
-    const { token } = validation.data;
-
-    const folder = await prisma.folder.findUnique({
-      where: { inviteToken: token },
-      include: { members: true },
+    const invite = await prisma.folderInvite.findUnique({
+      where: { token: parsed.data.token },
+      include: { folder: { select: { id: true, name: true } } },
     });
 
-    if (!folder) {
+    if (!invite) {
       return NextResponse.json(
-        { error: "Invalid or expired invite token" },
+        { error: "Invitation not found" },
         { status: 404 },
       );
     }
 
-    // Check validity timestamp (48 hours validity)
-    const parts = token.split("_");
-    const timestamp = Number(parts[parts.length - 1]);
-    const fortyEightHours = 48 * 60 * 60 * 1000;
-    if (isNaN(timestamp) || Date.now() - timestamp > fortyEightHours) {
+    if (
+      invite.status !== "PENDING" ||
+      isCollectionInviteExpired(invite.expiresAt)
+    ) {
+      if (
+        invite.status === "PENDING" &&
+        isCollectionInviteExpired(invite.expiresAt)
+      ) {
+        await prisma.folderInvite.update({
+          where: { id: invite.id },
+          data: { status: "EXPIRED" },
+        });
+      }
       return NextResponse.json(
-        { error: "Invalid or expired invite token" },
+        { error: "This invitation is no longer valid" },
         { status: 410 },
       );
     }
 
-    // Check if already a member
-    const existingMember = folder.members.find((m) => m.userId === userId);
-    if (existingMember) {
+    const user = await currentUser();
+    const signedInEmails =
+      user?.emailAddresses.map((entry) =>
+        normalizeCollectionInviteEmail(entry.emailAddress),
+      ) ?? [];
+
+    if (
+      !signedInEmails.includes(normalizeCollectionInviteEmail(invite.email))
+    ) {
       return NextResponse.json(
-        { message: "Already a member", folderId: folder.id },
-        { status: 200 },
+        {
+          error: "Sign in with the email address that received this invitation",
+        },
+        { status: 403 },
       );
     }
 
-    // Add user as member
-    await prisma.folderMember.create({
-      data: {
-        folderId: folder.id,
-        userId: userId,
-        role: "MEMBER",
-      },
-    });
+    await prisma.$transaction([
+      prisma.folderMember.upsert({
+        where: {
+          folderId_userId: { folderId: invite.folderId, userId },
+        },
+        update: { role: invite.role },
+        create: { folderId: invite.folderId, userId, role: invite.role },
+      }),
+      prisma.folderInvite.update({
+        where: { id: invite.id },
+        data: { status: "ACCEPTED" },
+      }),
+    ]);
 
-    return NextResponse.json(
-      { success: true, folderId: folder.id },
-      { status: 200 },
-    );
+    return NextResponse.json({
+      success: true,
+      folderId: invite.folder.id,
+      folderName: invite.folder.name,
+    });
   } catch (error) {
     console.error("POST /api/folders/join error:", error);
     return NextResponse.json(
-      { error: "Failed to join folder" },
+      { error: "Failed to accept collection invitation" },
       { status: 500 },
     );
   }

--- a/src/app/api/folders/route.ts
+++ b/src/app/api/folders/route.ts
@@ -1,90 +1,104 @@
+import { auth, currentUser } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@clerk/nextjs/server";
-import { prisma } from "@/lib/prisma";
 import { z } from "zod";
 
-const createFolderSchema = z.object({
-  name: z.string().min(1, "Folder name is required").max(100),
-  description: z.string().max(500).optional(),
-  isPublic: z.boolean().optional(),
-});
+import { ensureUserExists } from "@/lib/auth";
+import {
+  isCollectionInviteExpired,
+  normalizeCollectionInviteEmail,
+} from "@/lib/collections/invite-utils";
+import { prisma } from "@/lib/prisma";
 
-// GET /api/folders - List all folders for the user (owned or member)
-export async function GET(_req: NextRequest) {
+const joinSchema = z.object({ token: z.string().min(20) });
+
+export async function POST(request: NextRequest) {
   try {
     const { userId } = await auth();
     if (!userId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const folders = await prisma.folder.findMany({
-      where: {
-        OR: [
-          { ownerId: userId },
-          { members: { some: { userId } } },
-        ],
-      },
-      include: {
-        _count: {
-          select: { venues: true, members: true },
-        },
-      },
-      orderBy: { updatedAt: 'desc' }
+    await ensureUserExists(userId);
+    const parsed = joinSchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Invalid invitation token" },
+        { status: 400 },
+      );
+    }
+
+    const invite = await prisma.folderInvite.findUnique({
+      where: { token: parsed.data.token },
+      include: { folder: { select: { id: true, name: true } } },
     });
 
-    return NextResponse.json({ folders });
-  } catch (error) {
-    console.error("GET /api/folders error:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch folders" },
-      { status: 500 }
-    );
-  }
-}
-
-// POST /api/folders - Create a new folder
-export async function POST(req: NextRequest) {
-  try {
-    const { userId } = await auth();
-    if (!userId) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (!invite) {
+      return NextResponse.json(
+        { error: "Invitation not found" },
+        { status: 404 },
+      );
     }
 
-    const body = await req.json();
-    const validation = createFolderSchema.safeParse(body);
-    
-    if (!validation.success) {
-      return NextResponse.json({ error: validation.error.format() }, { status: 400 });
-    }
-
-    const { name, description, isPublic } = validation.data;
-
-    const folder = await prisma.folder.create({
-      data: {
-        name,
-        description,
-        isPublic: isPublic ?? false,
-        ownerId: userId,
-        members: {
-          create: {
-            userId,
-            role: "OWNER",
-          },
-        },
-      },
-      include: {
-        _count: {
-          select: { venues: true, members: true },
-        },
+    if (
+      invite.status !== "PENDING" ||
+      isCollectionInviteExpired(invite.expiresAt)
+    ) {
+      if (
+        invite.status === "PENDING" &&
+        isCollectionInviteExpired(invite.expiresAt)
+      ) {
+        await prisma.folderInvite.update({
+          where: { id: invite.id },
+          data: { status: "EXPIRED" },
+        });
       }
-    });
+      return NextResponse.json(
+        { error: "This invitation is no longer valid" },
+        { status: 410 },
+      );
+    }
 
-    return NextResponse.json({ folder }, { status: 201 });
+    const user = await currentUser();
+    const signedInEmails =
+      user?.emailAddresses.map((entry) =>
+        normalizeCollectionInviteEmail(entry.emailAddress),
+      ) ?? [];
+
+    if (
+      !signedInEmails.includes(normalizeCollectionInviteEmail(invite.email))
+    ) {
+      return NextResponse.json(
+        {
+          error: "Sign in with the email address that received this invitation",
+        },
+        { status: 403 },
+      );
+    }
+
+    await prisma.$transaction([
+      prisma.folderMember.upsert({
+        where: {
+          folderId_userId: { folderId: invite.folderId, userId },
+        },
+        update: { role: invite.role },
+        create: { folderId: invite.folderId, userId, role: invite.role },
+      }),
+      prisma.folderInvite.update({
+        where: { id: invite.id },
+        data: { status: "ACCEPTED" },
+      }),
+    ]);
+
+    return NextResponse.json({
+      success: true,
+      folderId: invite.folder.id,
+      folderName: invite.folder.name,
+    });
   } catch (error) {
-    console.error("POST /api/folders error:", error);
+    console.error("POST /api/folders/join error:", error);
     return NextResponse.json(
-      { error: "Failed to create folder" },
-      { status: 500 }
+      { error: "Failed to accept collection invitation" },
+      { status: 500 },
     );
   }
 }

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -5,7 +5,8 @@ import Link from "next/link";
 import {
   ArrowLeft,
   Users,
-  Link as LinkIcon,
+  Mail,
+  Copy,
   Trash2,
   MapPin,
   Loader2,
@@ -29,8 +30,11 @@ export default function FolderDetailsPage({
   const [userRole, setUserRole] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
-  const [inviteToken, setInviteToken] = useState("");
-  const [generatingInvite, setGeneratingInvite] = useState(false);
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteRole, setInviteRole] = useState<"EDITOR" | "MEMBER">("EDITOR");
+  const [inviteMessage, setInviteMessage] = useState("");
+  const [inviteLink, setInviteLink] = useState("");
+  const [sendingInvite, setSendingInvite] = useState(false);
   const [updatingPublic, setUpdatingPublic] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [filters, setFilters] = useState({
@@ -69,9 +73,6 @@ export default function FolderDetailsPage({
       if (data.folder) {
         setFolder(data.folder);
         setUserRole(data.role || null);
-        if (data.folder.inviteToken) {
-          setInviteToken(data.folder.inviteToken);
-        }
       } else {
         setError(data.error || "Failed to load folder");
       }
@@ -127,18 +128,34 @@ export default function FolderDetailsPage({
     },
   });
 
-  const generateInvite = async () => {
-    setGeneratingInvite(true);
+  const sendInvite = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSendingInvite(true);
+    setInviteMessage("");
+    setInviteLink("");
+
     try {
-      const res = await fetch(`/api/folders/${id}/invites`, { method: "POST" });
-      const data = await res.json();
-      if (data.inviteToken) {
-        setInviteToken(data.inviteToken);
+      const response = await fetch(`/api/folders/${id}/invites`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: inviteEmail, role: inviteRole }),
+      });
+      const data = await response.json();
+
+      if (!response.ok) {
+        setInviteMessage(data.error || "Unable to invite teammate");
+        return;
       }
-    } catch (e) {
-      console.error(e);
+
+      setInviteMessage(data.message || "Invitation created.");
+      setInviteLink(data.invite?.inviteUrl || "");
+      setInviteEmail("");
+      await fetchFolder();
+    } catch (error) {
+      console.error(error);
+      setInviteMessage("Unable to invite teammate");
     } finally {
-      setGeneratingInvite(false);
+      setSendingInvite(false);
     }
   };
 
@@ -158,11 +175,6 @@ export default function FolderDetailsPage({
     } catch (e) {
       console.error(e);
     }
-  };
-
-  const getInviteLink = () => {
-    if (typeof window === "undefined" || !inviteToken) return "";
-    return `${window.location.origin}/collections/join?token=${inviteToken}`;
   };
 
   if (loading)
@@ -436,50 +448,68 @@ export default function FolderDetailsPage({
               </div>
 
               {userRole !== "VIEWER" && (
-                <div className="border-t border-zinc-200 dark:border-zinc-800 pt-4">
-                  <h3 className="text-sm font-medium text-zinc-900 dark:text-white mb-2">
-                    Invite Link
-                  </h3>
-                  {inviteToken ? (
-                    <div className="space-y-2">
-                      <div className="flex items-center gap-2 px-3 py-2 bg-zinc-100 dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 rounded-lg">
-                        <LinkIcon className="w-4 h-4 text-zinc-400 shrink-0" />
-                        <input
-                          readOnly
-                          value={getInviteLink()}
-                          className="bg-transparent border-none outline-none text-xs text-zinc-600 dark:text-zinc-400 flex-1 min-w-0"
-                        />
-                      </div>
-                      <button
-                        onClick={() =>
-                          navigator.clipboard.writeText(getInviteLink())
-                        }
-                        className="text-xs text-blue-500 hover:underline"
-                      >
-                        Copy Link
-                      </button>
-                      <button
-                        onClick={generateInvite}
-                        disabled={generatingInvite}
-                        className="ml-4 text-xs text-zinc-500 hover:underline"
-                      >
-                        {generatingInvite ? "Generating..." : "Regenerate"}
-                      </button>
-                    </div>
-                  ) : (
+                <form
+                  onSubmit={sendInvite}
+                  className="border-t border-zinc-200 dark:border-zinc-800 pt-4 space-y-3"
+                >
+                  <div>
+                    <h3 className="text-sm font-medium text-zinc-900 dark:text-white flex items-center gap-2">
+                      <Mail className="w-4 h-4 text-blue-500" /> Invite teammate
+                    </h3>
+                    <p className="mt-1 text-xs text-zinc-500">
+                      Invite by email as an editor or read-only viewer.
+                    </p>
+                  </div>
+
+                  <input
+                    type="email"
+                    required
+                    value={inviteEmail}
+                    onChange={(event) => setInviteEmail(event.target.value)}
+                    placeholder="teammate@example.com"
+                    className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 outline-none focus:border-blue-500 dark:border-zinc-800 dark:bg-zinc-950 dark:text-white"
+                  />
+
+                  <select
+                    value={inviteRole}
+                    onChange={(event) =>
+                      setInviteRole(event.target.value as "EDITOR" | "MEMBER")
+                    }
+                    className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 outline-none focus:border-blue-500 dark:border-zinc-800 dark:bg-zinc-950 dark:text-white"
+                  >
+                    <option value="EDITOR">
+                      Editor — can add or remove venues
+                    </option>
+                    <option value="MEMBER">Viewer — read only</option>
+                  </select>
+
+                  <button
+                    type="submit"
+                    disabled={sendingInvite}
+                    className="w-full flex items-center justify-center gap-2 rounded-xl bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+                  >
+                    {sendingInvite && (
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                    )}
+                    {sendingInvite ? "Sending invitation…" : "Send invitation"}
+                  </button>
+
+                  {inviteMessage && (
+                    <p className="rounded-lg bg-zinc-100 px-3 py-2 text-xs text-zinc-600 dark:bg-zinc-950 dark:text-zinc-300">
+                      {inviteMessage}
+                    </p>
+                  )}
+
+                  {inviteLink && (
                     <button
-                      onClick={generateInvite}
-                      disabled={generatingInvite}
-                      className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-zinc-100 dark:bg-zinc-800 hover:bg-zinc-200 dark:hover:bg-zinc-700 text-zinc-900 dark:text-white font-medium rounded-xl text-sm transition-all"
+                      type="button"
+                      onClick={() => navigator.clipboard.writeText(inviteLink)}
+                      className="flex w-full items-center justify-center gap-2 rounded-xl border border-zinc-200 px-3 py-2 text-xs font-medium text-blue-600 hover:bg-blue-50 dark:border-zinc-800 dark:text-blue-400 dark:hover:bg-blue-950/30"
                     >
-                      {generatingInvite ? (
-                        <Loader2 className="w-4 h-4 animate-spin" />
-                      ) : (
-                        "Generate Invite Link"
-                      )}
+                      <Copy className="w-4 h-4" /> Copy fallback invite link
                     </button>
                   )}
-                </div>
+                </form>
               )}
             </div>
           </div>

--- a/src/components/collections/AddToFolderModal.tsx
+++ b/src/components/collections/AddToFolderModal.tsx
@@ -17,7 +17,14 @@ export function AddToFolderModal({ venue, onClose }: AddToFolderModalProps) {
     try {
       const res = await fetch("/api/folders");
       const data = await res.json();
-      if (data.folders) setFolders(data.folders);
+      if (data.folders) {
+        setFolders(
+          data.folders.filter(
+            (folder: { accessRole?: string }) =>
+              folder.accessRole === "OWNER" || folder.accessRole === "EDITOR",
+          ),
+        );
+      }
     } catch (e) {
       console.error(e);
     } finally {

--- a/src/lib/collections/invite-email.ts
+++ b/src/lib/collections/invite-email.ts
@@ -1,0 +1,78 @@
+import nodemailer from "nodemailer";
+
+type InviteEmailInput = {
+  to: string;
+  collectionName: string;
+  inviterName: string;
+  role: "EDITOR" | "MEMBER";
+  inviteUrl: string;
+  expiresAt: Date;
+};
+
+export async function sendCollectionInviteEmail({
+  to,
+  collectionName,
+  inviterName,
+  role,
+  inviteUrl,
+  expiresAt,
+}: InviteEmailInput) {
+  const user = process.env.SMTP_USER;
+  const pass = process.env.SMTP_PASS;
+
+  if (!user || !pass) {
+    return { sent: false as const, reason: "smtp_not_configured" as const };
+  }
+
+  const transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST || "smtp.gmail.com",
+    port: Number(process.env.SMTP_PORT || 587),
+    secure: process.env.SMTP_SECURE === "true",
+    auth: { user, pass },
+  });
+
+  const roleLabel = role === "EDITOR" ? "editor" : "viewer";
+
+  await transporter.sendMail({
+    from: process.env.SMTP_FROM || `"WorkSphere Collections" <${user}>`,
+    to,
+    subject: `${inviterName} invited you to \"${collectionName}\"`,
+    text: [
+      `${inviterName} invited you to join the WorkSphere collection \"${collectionName}\" as a ${roleLabel}.`,
+      "",
+      `Accept the invitation: ${inviteUrl}`,
+      "",
+      `This invitation expires on ${expiresAt.toLocaleString()}.`,
+    ].join("\n"),
+    html: `
+      <div style="font-family:Arial,sans-serif;max-width:560px;margin:auto;padding:24px;color:#18181b">
+        <h2 style="margin:0 0 12px">You have been invited to a WorkSphere collection</h2>
+        <p><strong>${escapeHtml(inviterName)}</strong> invited you to join
+        <strong>${escapeHtml(collectionName)}</strong> as a ${roleLabel}.</p>
+        <p style="margin:28px 0">
+          <a href="${inviteUrl}" style="background:#2563eb;color:#fff;padding:12px 18px;border-radius:10px;text-decoration:none">
+            Accept invitation
+          </a>
+        </p>
+        <p style="font-size:13px;color:#71717a">
+          This invitation expires on ${expiresAt.toLocaleString()}.
+        </p>
+      </div>
+    `,
+  });
+
+  return { sent: true as const };
+}
+
+function escapeHtml(value: string) {
+  return value.replace(/[&<>"']/g, (character) => {
+    const entities: Record<string, string> = {
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      '"': "&quot;",
+      "'": "&#039;",
+    };
+    return entities[character];
+  });
+}

--- a/src/lib/collections/invite-utils.ts
+++ b/src/lib/collections/invite-utils.ts
@@ -1,0 +1,13 @@
+export const COLLECTION_INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function normalizeCollectionInviteEmail(email: string) {
+  return email.trim().toLowerCase();
+}
+
+export function createCollectionInviteExpiry(now = Date.now()) {
+  return new Date(now + COLLECTION_INVITE_TTL_MS);
+}
+
+export function isCollectionInviteExpired(expiresAt: Date, now = new Date()) {
+  return expiresAt.getTime() <= now.getTime();
+}


### PR DESCRIPTION
## Description

This PR completes curated workspace collections and collaborative lists for WorkSphere.

Users can organize venues into purpose-specific collections, share them with teammates by email, and publish useful collections to a community discovery feed.

### Changes

- Preserved the existing Favorites feature while extending the existing Folder/Collection architecture.
- Added private and public custom collections with names and descriptions.
- Added a public discovery feed sorted by community upvotes and recency.
- Added email-address invitations with editor and read-only viewer roles.
- Added secure, unique, seven-day invitation tokens.
- Restricted invitation acceptance to the invited Clerk email address.
- Added SMTP email delivery with a copy-link fallback when SMTP is not configured.
- Added immediate membership creation when the invited email already belongs to a WorkSphere user.
- Added server-side authorization so only owners/editors can add or remove venues.
- Added invitation utility tests for normalization, expiry creation, and expiration checks.
- Added a Prisma migration for invitation persistence and status tracking.

## Related Issue

Fixes #91

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings

Add evidence showing:
<img width="1919" height="892" alt="Screenshot 2026-07-20 001830" src="https://github.com/user-attachments/assets/753463a4-d31d-4351-9211-143eaf59f8d1" />


## Breaking Changes

- [ ] Yes
- [x] No

Existing favorites and existing folder records remain compatible. The new invitation table is additive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email-based folder invitations with selectable Editor or Member access.
  * Existing users can be added directly to folders.
  * Invitation links expire, enforce recipient email matching, and track acceptance status.
  * Added invitation emails with copyable links and delivery status feedback.
  * Restricted venue additions and folder selection to owners and editors.
* **Bug Fixes**
  * Improved handling of expired, invalid, duplicate, and already-accepted invitations.
* **Tests**
  * Added coverage for email normalization and invitation expiration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->