### PR TITLE
feat: add ICS calendar download for workspace reservations

### DIFF
--- a/src/__tests__/lib/calendar.test.ts
+++ b/src/__tests__/lib/calendar.test.ts
@@ -1,0 +1,67 @@
+import {
+  formatDateTimeForCalendar,
+  generateICSContent,
+} from "@/lib/calendar";
+
+describe("formatDateTimeForCalendar", () => {
+  it("returns empty strings when date or time is missing", () => {
+    expect(formatDateTimeForCalendar("", "10:00")).toEqual({
+      start: "",
+      end: "",
+    });
+    expect(formatDateTimeForCalendar("2026-07-20", "")).toEqual({
+      start: "",
+      end: "",
+    });
+  });
+
+  it("uses the given duration in minutes for DTEND", () => {
+    const oneHour = formatDateTimeForCalendar("2026-07-20", "09:00", 60);
+    const twoHours = formatDateTimeForCalendar("2026-07-20", "09:00", 120);
+
+    expect(oneHour.start).toBeTruthy();
+    expect(oneHour.end).toBeTruthy();
+    expect(twoHours.start).toBe(oneHour.start);
+    expect(twoHours.end).not.toBe(oneHour.end);
+  });
+});
+
+describe("generateICSContent", () => {
+  const ics = generateICSContent(
+    "Indie Desk Hub",
+    "42 Market Street, Austin",
+    "2026-07-20",
+    "14:30",
+    90,
+    "WS-#482910",
+  );
+
+  it("uses CRLF line endings", () => {
+    expect(ics.includes("\r\n")).toBe(true);
+    expect(ics.replace(/\r\n/g, "").includes("\n")).toBe(false);
+  });
+
+  it("includes required VCALENDAR / VEVENT markers", () => {
+    expect(ics).toContain("BEGIN:VCALENDAR");
+    expect(ics).toContain("VERSION:2.0");
+    expect(ics).toContain("BEGIN:VEVENT");
+    expect(ics).toContain("END:VEVENT");
+    expect(ics).toContain("END:VCALENDAR");
+  });
+
+  it("puts venue address, duration, and confirmation id in SUMMARY", () => {
+    expect(ics).toContain("SUMMARY:");
+    expect(ics).toContain("Indie Desk Hub");
+    expect(ics).toContain("90 min");
+    expect(ics).toContain("WS-#482910");
+    expect(ics).toContain("42 Market Street");
+  });
+
+  it("sets LOCATION to the venue address", () => {
+    expect(ics).toContain("LOCATION:42 Market Street\\, Austin");
+  });
+
+  it("returns empty string for invalid date/time", () => {
+    expect(generateICSContent("X", "Y", "", "10:00")).toBe("");
+  });
+});

--- a/src/app/reserve/[venueId]/reservation-client.tsx
+++ b/src/app/reserve/[venueId]/reservation-client.tsx
@@ -226,8 +226,13 @@ export default function ReservationClient({ venue }: { venue: Venue }) {
               <div className="mt-4 flex flex-wrap items-center gap-3">
                 <a
                   href={
-                    getCalendarUrls(venue.name, venue.address || "", date, time)
-                      .googleUrl
+                    getCalendarUrls(
+                      venue.name,
+                      venue.address || "",
+                      date,
+                      time,
+                      duration,
+                    ).googleUrl
                   }
                   target="_blank"
                   rel="noopener noreferrer"
@@ -237,8 +242,13 @@ export default function ReservationClient({ venue }: { venue: Venue }) {
                 </a>
                 <a
                   href={
-                    getCalendarUrls(venue.name, venue.address || "", date, time)
-                      .outlookUrl
+                    getCalendarUrls(
+                      venue.name,
+                      venue.address || "",
+                      date,
+                      time,
+                      duration,
+                    ).outlookUrl
                   }
                   target="_blank"
                   rel="noopener noreferrer"
@@ -248,7 +258,14 @@ export default function ReservationClient({ venue }: { venue: Venue }) {
                 </a>
                 <button
                   onClick={() =>
-                    downloadICS(venue.name, venue.address || "", date, time)
+                    downloadICS(
+                      venue.name,
+                      venue.address || "",
+                      date,
+                      time,
+                      duration,
+                      confirmationId || "",
+                    )
                   }
                   className="flex items-center gap-2 rounded-xl bg-white/5 border border-white/10 px-4 py-2 hover:bg-white/10 transition-colors text-zinc-300"
                 >

--- a/src/components/chat/BookingModal.tsx
+++ b/src/components/chat/BookingModal.tsx
@@ -67,6 +67,7 @@ export function BookingModal({
   };
   const [bookingDate, setBookingDate] = useState("");
   const [bookingTime, setBookingTime] = useState("");
+  const [confirmationId, setConfirmationId] = useState("");
   const [email, setEmail] = useState("");
   const [billingCode, setBillingCode] = useState("");
   const [history, setHistory] = useState<Booking[]>([]);
@@ -354,6 +355,7 @@ export function BookingModal({
         );
       }
 
+      setConfirmationId(responseData.confirmationId || "");
       setStep("success");
       trackEvent("venue_rated", {
         venueId: venue?.id || "unknown",
@@ -593,6 +595,8 @@ export function BookingModal({
                                     booking.venue.address,
                                     booking.date,
                                     booking.time,
+                                    booking.duration || 60,
+                                    booking.confirmationId,
                                   )
                                 }
                                 title="Download .ics"
@@ -905,6 +909,8 @@ export function BookingModal({
                       venue.address || "",
                       bookingDate,
                       bookingTime,
+                      60,
+                      confirmationId,
                     )
                   }
                   className="w-full border-2 border-zinc-200 dark:border-zinc-700 hover:bg-zinc-50 dark:hover:bg-zinc-800 text-zinc-900 dark:text-zinc-100 font-black uppercase tracking-widest py-3 px-4 rounded-xl flex items-center justify-center gap-2 transition-all text-[10px]"

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -1,42 +1,130 @@
-export const formatDateTimeForCalendar = (dateStr: string, timeStr: string) => {
-    if (!dateStr || !timeStr) return { start: "", end: "" };
-    const start = new Date(`${dateStr}T${timeStr}`);
-    if (isNaN(start.getTime())) return { start: "", end: "" };
-    const end = new Date(start.getTime() + 60 * 60 * 1000);
-    
-    const format = (d: Date) => d.toISOString().replace(/-|:|\.\d\d\d/g, "");
-    
-    return {
-        start: format(start),
-        end: format(end)
-    };
+const escapeIcsText = (text: string) =>
+  text
+    .replace(/\\/g, "\\\\")
+    .replace(/;/g, "\\;")
+    .replace(/,/g, "\\,")
+    .replace(/\n/g, "\\n");
+
+export const formatDateTimeForCalendar = (
+  dateStr: string,
+  timeStr: string,
+  durationMinutes = 60,
+) => {
+  if (!dateStr || !timeStr) return { start: "", end: "" };
+  const start = new Date(`${dateStr}T${timeStr}`);
+  if (isNaN(start.getTime())) return { start: "", end: "" };
+  const end = new Date(start.getTime() + durationMinutes * 60 * 1000);
+
+  const format = (d: Date) => d.toISOString().replace(/-|:|\.\d\d\d/g, "");
+
+  return {
+    start: format(start),
+    end: format(end),
+  };
 };
 
-export const getCalendarUrls = (venueName: string, venueAddress: string, dateStr: string, timeStr: string) => {
-    const { start, end } = formatDateTimeForCalendar(dateStr, timeStr);
-    const title = encodeURIComponent(`Booking at ${venueName}`);
-    const details = encodeURIComponent(`Hot desk booking at ${venueName}`);
-    const location = encodeURIComponent(venueAddress);
+export const getCalendarUrls = (
+  venueName: string,
+  venueAddress: string,
+  dateStr: string,
+  timeStr: string,
+  durationMinutes = 60,
+) => {
+  const { start, end } = formatDateTimeForCalendar(
+    dateStr,
+    timeStr,
+    durationMinutes,
+  );
+  const title = encodeURIComponent(`Booking at ${venueName}`);
+  const details = encodeURIComponent(`Hot desk booking at ${venueName}`);
+  const location = encodeURIComponent(venueAddress);
 
-    const googleUrl = `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${title}&dates=${start}/${end}&details=${details}&location=${location}`;
-    const outlookUrl = `https://outlook.live.com/calendar/0/deeplink/compose?path=/calendar/action/compose&rru=addevent&subject=${title}&startdt=${start}&enddt=${end}&body=${details}&location=${location}`;
-    
-    return { googleUrl, outlookUrl, start, end };
+  const googleUrl = `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${title}&dates=${start}/${end}&details=${details}&location=${location}`;
+  const outlookUrl = `https://outlook.live.com/calendar/0/deeplink/compose?path=/calendar/action/compose&rru=addevent&subject=${title}&startdt=${start}&enddt=${end}&body=${details}&location=${location}`;
+
+  return { googleUrl, outlookUrl, start, end };
 };
 
-export const downloadICS = (venueName: string, venueAddress: string, dateStr: string, timeStr: string) => {
-    const { start, end } = formatDateTimeForCalendar(dateStr, timeStr);
-    if (!start) return;
-    const title = `Booking at ${venueName}`;
-    const description = `Hot desk booking at ${venueName}`;
-    
-    const icsContent = `BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nDTSTART:${start}\nDTEND:${end}\nSUMMARY:${title}\nDESCRIPTION:${description}\nLOCATION:${venueAddress}\nEND:VEVENT\nEND:VCALENDAR`;
+export const generateICSContent = (
+  venueName: string,
+  venueAddress: string,
+  dateStr: string,
+  timeStr: string,
+  durationMinutes = 60,
+  confirmationId = "",
+) => {
+  const { start, end } = formatDateTimeForCalendar(
+    dateStr,
+    timeStr,
+    durationMinutes,
+  );
+  if (!start) return "";
 
-    const blob = new Blob([icsContent], { type: 'text/calendar;charset=utf-8' });
-    const link = document.createElement('a');
-    link.href = URL.createObjectURL(blob);
-    link.download = `booking-${venueName.replace(/\\s+/g, '-').toLowerCase()}.ics`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
+  const durationLabel = `${durationMinutes} min`;
+  const summary = confirmationId
+    ? `Booking at ${venueName} (${durationLabel}) [${confirmationId}] - ${venueAddress}`
+    : `Booking at ${venueName} (${durationLabel}) - ${venueAddress}`;
+
+  const description = escapeIcsText(
+    [
+      `Hot desk booking at ${venueName}`,
+      `Duration: ${durationLabel}`,
+      confirmationId ? `Confirmation: ${confirmationId}` : "",
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  );
+
+  const uid = confirmationId
+    ? `${confirmationId.replace(/[^A-Za-z0-9#-]/g, "")}@worksphere.app`
+    : `booking-${start}@worksphere.app`;
+
+  const lines = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//WorkSphere//EN",
+    "CALSCALE:GREGORIAN",
+    "METHOD:PUBLISH",
+    "BEGIN:VEVENT",
+    `UID:${uid}`,
+    `DTSTAMP:${start}`,
+    `DTSTART:${start}`,
+    `DTEND:${end}`,
+    `SUMMARY:${escapeIcsText(summary)}`,
+    `DESCRIPTION:${description}`,
+    `LOCATION:${escapeIcsText(venueAddress)}`,
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ];
+
+  return lines.join("\r\n") + "\r\n";
+};
+
+export const downloadICS = (
+  venueName: string,
+  venueAddress: string,
+  dateStr: string,
+  timeStr: string,
+  durationMinutes = 60,
+  confirmationId = "",
+) => {
+  const icsContent = generateICSContent(
+    venueName,
+    venueAddress,
+    dateStr,
+    timeStr,
+    durationMinutes,
+    confirmationId,
+  );
+  if (!icsContent) return;
+
+  const blob = new Blob([icsContent], { type: "text/calendar;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `booking-${venueName.replace(/\s+/g, "-").toLowerCase()}.ics`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
 };


### PR DESCRIPTION
## Description
Adds a proper RFC 5545 `.ics` download on the booking confirmation screen so users can add reservations to Google Calendar, Outlook, or Apple Calendar.

Fixes #862

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Breaking Changes
- [ ] Yes (please describe below)
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar events now use the reservation’s actual duration.
  * Google Calendar, Outlook, and `.ics` downloads include venue details and confirmation information.
  * Downloaded calendar files provide improved event summaries, locations, and descriptions.

* **Bug Fixes**
  * Calendar exports now handle missing or invalid reservation details safely.
  * Venue addresses are formatted correctly in downloaded calendar files.

* **Tests**
  * Added coverage for event durations, calendar formatting, required calendar fields, and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->