### PR TITLE
fix(accessibility): respect prefers-reduced-motion settings for animations

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -309,3 +309,18 @@ textarea:focus::placeholder {
   color: transparent !important;
   opacity: 0 !important;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  ::before,
+  ::after {
+    animation-delay: -1ms !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    background-attachment: initial !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+  }
+}
+


### PR DESCRIPTION
Fixes #564

### Description
This PR addresses an accessibility issue where CSS skeleton shimmer animations continue to load continually even when users have disabled animations in their OS settings.

The bug is resolved by:
- Adding a global `@media (prefers-reduced-motion: reduce)` media query in `globals.css` that disables all transitions and animations (including skeleton `.animate-pulse` animations) when the user prefers reduced motion.

### Verification
- Verified all unit tests compile and pass successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added support for reduced-motion preferences, minimizing animations and transitions for users who enable this setting.
  * Adjusted scrolling and background behavior to reduce motion-related effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->