### PR TITLE
fix(map): preserve map center focus coordinates during window resizing

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -181,9 +181,11 @@ function ResizeWatcher({ delay = 150 }: { delay?: number }) {
 
     const handleResize = () => {
       clearTimeout(timer);
+      const centerBeforeResize = map.getCenter();
 
       timer = setTimeout(() => {
         map.invalidateSize();
+        map.setView(centerBeforeResize, map.getZoom(), { animate: false });
       }, delay);
     };
 


### PR DESCRIPTION
Fixes #567

### Description
This PR resolves an issue where resizing the browser window caused the Leaflet map center to drift or reset to default coordinates instead of maintaining the focused coordinates.

The fix resolves this by capturing the current map center right before the window resize handler triggers its debounce timer. After size recalculations are performed using `map.invalidateSize()`, the map is set back to the pre-resized center using `map.setView` to prevent layout reflows from shifting coordinates.

### Verification
- Verified all Map component unit tests pass successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the map’s current center and zoom when the display is resized.
  * Prevented the map view from shifting or losing its position during resizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->