### PR TITLE
fix: wrap long venue addresses in PDF receipts

### DIFF
--- a/src/app/api/bookings/[bookingId]/download/route.ts
+++ b/src/app/api/bookings/[bookingId]/download/route.ts
@@ -13,6 +13,7 @@ import {
   PDFPageDrawTextOptions,
   StandardFonts,
   rgb,
+  breakTextIntoLines,
 } from "pdf-lib";
 export const dynamic = "force-dynamic";
 
@@ -213,13 +214,24 @@ export async function GET(
       { x: 50, y: yPosition, size: 10, font },
     );
     yPosition -= 18;
-    drawSafeText(`ADDRESS: ${booking.venue.address || "Verified Workspace"}`, {
-      x: 50,
-      y: yPosition,
-      size: 10,
-      font,
-    });
-    yPosition -= 18;
+    const addressText = `ADDRESS: ${booking.venue.address || "Verified Workspace"}`;
+    const addressLines = breakTextIntoLines(
+      addressText,
+      [" ", ",", "-"],
+      450, // max width before reaching the edge
+      (t) => font.widthOfTextAtSize(t, 10),
+    );
+
+    for (const line of addressLines) {
+      drawSafeText(line, {
+        x: 50,
+        y: yPosition,
+        size: 10,
+        font,
+      });
+      yPosition -= 12; // line height for wrapped text
+    }
+    yPosition -= 6; // adjust remaining margin to equal original 18 total
     drawSafeText(
       `SCHEDULE: ${formatBookingDate(booking.date)} @ ${booking.time}`,
       {


### PR DESCRIPTION
## Description

This PR fixes the PDF receipt layout issue where long venue addresses could overlap with the payment summary section.

### Changes made
- Added proper wrapping for long venue addresses in generated PDF receipts.
- Updated the layout to adjust vertical spacing dynamically based on the wrapped address.
- Preserved the existing layout for short addresses while preventing text overlap for longer ones.

## Related Issue

Fixes #873

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

N/A (PDF layout fix)

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved booking download layouts by wrapping long venue addresses across multiple lines.
  * Adjusted spacing so content below the address remains aligned and readable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->