### PR TITLE
fix: stop MediaStream tracks when voice dictation ends

### DIFF
--- a/src/__tests__/hooks/useSpeechRecognition.test.tsx
+++ b/src/__tests__/hooks/useSpeechRecognition.test.tsx
@@ -1,0 +1,71 @@
+import { act, renderHook } from "@testing-library/react";
+import { useSpeechRecognition } from "@/hooks/useSpeechRecognition";
+
+describe("useSpeechRecognition media track cleanup", () => {
+  const stop = jest.fn();
+  let recognitionInstance: {
+    start: jest.Mock;
+    stop: jest.Mock;
+    abort: jest.Mock;
+    onstart: ((ev: Event) => void) | null;
+    onend: ((ev: Event) => void) | null;
+    onresult: ((ev: unknown) => void) | null;
+    onerror: ((ev: unknown) => void) | null;
+    lang: string;
+    interimResults: boolean;
+    maxAlternatives: number;
+    continuous: boolean;
+  };
+
+  beforeEach(() => {
+    stop.mockClear();
+    recognitionInstance = {
+      start: jest.fn(),
+      stop: jest.fn(),
+      abort: jest.fn(),
+      onstart: null,
+      onend: null,
+      onresult: null,
+      onerror: null,
+      lang: "",
+      interimResults: false,
+      maxAlternatives: 1,
+      continuous: false,
+    };
+
+    (window as unknown as { SpeechRecognition: unknown }).SpeechRecognition =
+      jest.fn(() => recognitionInstance);
+
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia: jest.fn().mockResolvedValue({
+          getTracks: () => [{ stop }, { stop }],
+        }),
+      },
+    });
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { SpeechRecognition?: unknown })
+      .SpeechRecognition;
+  });
+
+  it("stops all MediaStream tracks when dictation ends", async () => {
+    const { result } = renderHook(() => useSpeechRecognition(jest.fn()));
+
+    await act(async () => {
+      await result.current.startListening();
+    });
+
+    expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({
+      audio: true,
+    });
+
+    act(() => {
+      result.current.stopListening();
+    });
+
+    expect(stop).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -127,11 +127,22 @@ export function useSpeechRecognition(
 ): UseSpeechRecognitionReturn {
   const RecognitionCtor = useRef<SpeechRecognitionConstructor | null>(null);
   const recognitionRef = useRef<ISpeechRecognition | null>(null);
+  // Keep the mic MediaStream around so we can call track.stop() when
+  // dictation ends — otherwise repeated start/stop leaves tracks alive and
+  // the browser tab keeps showing the recording indicator.
+  const mediaStreamRef = useRef<MediaStream | null>(null);
 
   const [isSupported, setIsSupported] = useState(false);
   const [status, setStatus] = useState<SpeechRecognitionStatus>("idle");
   const [transcript, setTranscript] = useState("");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const releaseMediaTracks = useCallback(() => {
+    const stream = mediaStreamRef.current;
+    if (!stream) return;
+    stream.getTracks().forEach((track) => track.stop());
+    mediaStreamRef.current = null;
+  }, []);
 
   // Run support check once on the client (avoids SSR mismatch)
   useEffect(() => {
@@ -145,7 +156,7 @@ export function useSpeechRecognition(
     }
   }, []);
 
-  const startListening = useCallback(() => {
+  const startListening = useCallback(async () => {
     if (!isSupported || !RecognitionCtor.current) {
       // Surface a message so callers can display it even if they call this
       // without checking isSupported first.
@@ -156,9 +167,22 @@ export function useSpeechRecognition(
       return;
     }
 
-    // Clean up any existing instance before starting a new one
+    // Clean up any existing instance + tracks before starting a new one
     if (recognitionRef.current) {
       recognitionRef.current.abort();
+    }
+    releaseMediaTracks();
+
+    try {
+      mediaStreamRef.current = await navigator.mediaDevices.getUserMedia({
+        audio: true,
+      });
+    } catch {
+      setErrorMessage(
+        "Microphone access was denied. Please allow microphone permissions in your browser settings.",
+      );
+      setStatus("error");
+      return;
     }
 
     const recognition = new RecognitionCtor.current();
@@ -207,11 +231,13 @@ export function useSpeechRecognition(
           message = `Voice recognition error: ${event.error}. Please try again.`;
       }
 
+      releaseMediaTracks();
       setErrorMessage(message);
       setStatus("error");
     };
 
     recognition.onend = () => {
+      releaseMediaTracks();
       // Only revert to idle if we weren't already in an error or processing state
       setStatus((prev) =>
         prev === "listening" || prev === "processing" ? "idle" : prev,
@@ -223,22 +249,24 @@ export function useSpeechRecognition(
 
     try {
       recognition.start();
-    } catch (err) {
+    } catch {
       // Some browsers throw synchronously (e.g. when already listening)
+      releaseMediaTracks();
       setErrorMessage(
         "Could not start voice recognition. Please refresh and try again.",
       );
       setStatus("error");
     }
-  }, [isSupported, onTranscript]);
+  }, [isSupported, onTranscript, releaseMediaTracks]);
 
   const stopListening = useCallback(() => {
     if (recognitionRef.current) {
       recognitionRef.current.stop();
       recognitionRef.current = null;
     }
+    releaseMediaTracks();
     setStatus("idle");
-  }, []);
+  }, [releaseMediaTracks]);
 
   // Cleanup on unmount
   useEffect(() => {
@@ -246,8 +274,9 @@ export function useSpeechRecognition(
       if (recognitionRef.current) {
         recognitionRef.current.abort();
       }
+      releaseMediaTracks();
     };
-  }, []);
+  }, [releaseMediaTracks]);
 
   return {
     isSupported,


### PR DESCRIPTION
## Description
Stops all MediaStream audio tracks when AI chat voice dictation ends so repeated mic toggles no longer leave the browser recording indicator stuck on.

closes  #916

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Breaking Changes
- [ ] Yes (please describe below)
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved microphone cleanup when voice listening stops, ends, encounters an error, or the related screen closes.
  * Added clearer handling when microphone access is denied or listening cannot start.
  * Prevented microphone activity indicators from persisting across repeated listening sessions.

* **Tests**
  * Added coverage verifying microphone tracks are properly stopped after listening ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->