### PR TITLE
fix: batch folder cascade deletes in a timed transaction

### DIFF
--- a/src/__tests__/lib/folders.test.ts
+++ b/src/__tests__/lib/folders.test.ts
@@ -1,0 +1,62 @@
+import { deleteFolderWithRelations } from "@/lib/folders";
+import { prisma } from "@/lib/prisma";
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    $transaction: jest.fn(),
+  },
+}));
+
+describe("deleteFolderWithRelations", () => {
+  const mockTransaction = prisma.$transaction as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("batches folderVenue deletes inside a timed transaction", async () => {
+    const findMany = jest
+      .fn()
+      // first pass: 50 rows, second: 10, then done
+      .mockResolvedValueOnce(
+        Array.from({ length: 50 }, (_, i) => ({ id: `fv-${i}` })),
+      )
+      .mockResolvedValueOnce(
+        Array.from({ length: 10 }, (_, i) => ({ id: `fv-extra-${i}` })),
+      )
+      .mockResolvedValueOnce([]);
+
+    const deleteManyVenues = jest.fn().mockResolvedValue({ count: 50 });
+    const deleteManyMembers = jest.fn().mockResolvedValue({ count: 2 });
+    const deleteManyUpvotes = jest.fn().mockResolvedValue({ count: 1 });
+    const deleteFolder = jest.fn().mockResolvedValue({ id: "folder-1" });
+
+    mockTransaction.mockImplementation(async (fn: any, options: any) => {
+      expect(options).toEqual({ maxWait: 10_000, timeout: 30_000 });
+      return fn({
+        folderVenue: {
+          findMany,
+          deleteMany: deleteManyVenues,
+        },
+        folderMember: { deleteMany: deleteManyMembers },
+        folderUpvote: { deleteMany: deleteManyUpvotes },
+        folder: { delete: deleteFolder },
+      });
+    });
+
+    await deleteFolderWithRelations("folder-1");
+
+    expect(findMany).toHaveBeenCalledTimes(3);
+    expect(deleteManyVenues).toHaveBeenCalledTimes(2);
+    expect(deleteManyVenues).toHaveBeenNthCalledWith(1, {
+      where: { id: { in: expect.arrayContaining(["fv-0", "fv-49"]) } },
+    });
+    expect(deleteManyMembers).toHaveBeenCalledWith({
+      where: { folderId: "folder-1" },
+    });
+    expect(deleteManyUpvotes).toHaveBeenCalledWith({
+      where: { folderId: "folder-1" },
+    });
+    expect(deleteFolder).toHaveBeenCalledWith({ where: { id: "folder-1" } });
+  });
+});

--- a/src/app/api/folders/[id]/route.ts
+++ b/src/app/api/folders/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { prisma } from "@/lib/prisma";
 import { z } from "zod";
-import { hasFolderAccess } from "@/lib/folders";
+import { deleteFolderWithRelations, hasFolderAccess } from "@/lib/folders";
 
 const updateFolderSchema = z.object({
   name: z.string().min(1, "Folder name is required").max(100).optional(),
@@ -138,9 +138,7 @@ export async function DELETE(
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    await prisma.folder.delete({
-      where: { id }
-    });
+    await deleteFolderWithRelations(id);
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/lib/folders.ts
+++ b/src/lib/folders.ts
@@ -1,5 +1,8 @@
 import { prisma } from "@/lib/prisma";
 
+/** How many folder↔venue rows to delete per round inside the transaction. */
+const FOLDER_VENUE_DELETE_BATCH = 50;
+
 export async function hasFolderAccess(folderId: string, userId: string) {
   const folder = await prisma.folder.findUnique({
     where: { id: folderId },
@@ -23,4 +26,36 @@ export async function hasFolderAccess(folderId: string, userId: string) {
   }
 
   return { folder, hasAccess: false, role: null };
+}
+
+/**
+ * Deletes a folder and its related rows without relying on a single cascade
+ * wipe (which can exhaust the pool on large shared collections).
+ */
+export async function deleteFolderWithRelations(folderId: string) {
+  await prisma.$transaction(
+    async (tx) => {
+      // Batch venue links first — big shared folders can have 100+ rows.
+      for (;;) {
+        const batch = await tx.folderVenue.findMany({
+          where: { folderId },
+          select: { id: true },
+          take: FOLDER_VENUE_DELETE_BATCH,
+        });
+        if (batch.length === 0) break;
+
+        await tx.folderVenue.deleteMany({
+          where: { id: { in: batch.map((row) => row.id) } },
+        });
+      }
+
+      await tx.folderMember.deleteMany({ where: { folderId } });
+      await tx.folderUpvote.deleteMany({ where: { folderId } });
+      await tx.folder.delete({ where: { id: folderId } });
+    },
+    {
+      maxWait: 10_000,
+      timeout: 30_000,
+    },
+  );
 }


### PR DESCRIPTION
## Description
Deletes large shared collection folders by batching related FK rows inside `prisma.$transaction` with explicit timeouts, so cascade deletes no longer exhaust the Postgres connection pool.


closes #915

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Breaking Changes
- [ ] Yes (please describe below)
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved folder deletion to reliably remove all associated venues, members, and upvotes.
  - Large folders are now deleted in batches to reduce failures and improve reliability.
  - Existing access checks and error handling remain unchanged.

- **Tests**
  - Added coverage for folder deletion, including batch processing and removal of related records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->