### PR TITLE
fix: cap service worker cache at 20MB with LRU eviction

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,9 +1,53 @@
 // Service Worker for WorkSphere PWA
-const CACHE_NAME = "worksphere-v3";
+const CACHE_NAME = "worksphere-v4";
 const OFFLINE_URL = "/offline";
+// iOS Safari PWAs get killed around ~50MB of Cache Storage — keep a buffer.
+const MAX_CACHE_BYTES = 20 * 1024 * 1024;
 
 // Assets to cache on install
 const PRECACHE_ASSETS = ["/", "/offline", "/icons/icon.svg", "/manifest.json"];
+
+async function estimateResponseSize(response) {
+  const header = response.headers.get("content-length");
+  if (header) {
+    const n = Number(header);
+    if (Number.isFinite(n) && n >= 0) return n;
+  }
+  try {
+    const buf = await response.clone().arrayBuffer();
+    return buf.byteLength;
+  } catch (e) {
+    return 0;
+  }
+}
+
+// Drop oldest cache entries until we're under MAX_CACHE_BYTES (LRU-ish:
+// Cache.keys() is insertion order; we re-put on hit to bump recency).
+async function trimCacheToMaxBytes(cache) {
+  const keys = await cache.keys();
+  const entries = [];
+  let total = 0;
+
+  for (const request of keys) {
+    const response = await cache.match(request);
+    if (!response) continue;
+    const size = await estimateResponseSize(response);
+    entries.push({ request, size });
+    total += size;
+  }
+
+  let i = 0;
+  while (total > MAX_CACHE_BYTES && i < entries.length) {
+    const entry = entries[i++];
+    await cache.delete(entry.request);
+    total -= entry.size;
+  }
+}
+
+async function cachePutWithLimit(cache, request, response) {
+  await cache.put(request, response);
+  await trimCacheToMaxBytes(cache);
+}
 
 // Install event - precache essential assets
 self.addEventListener("install", (event) => {
@@ -84,7 +128,7 @@ self.addEventListener("fetch", (event) => {
             const responseClone = response.clone();
             event.waitUntil(
               caches.open(CACHE_NAME).then((cache) => {
-                return cache.put(event.request, responseClone);
+                return cachePutWithLimit(cache, event.request, responseClone);
               }),
             );
           }
@@ -102,6 +146,13 @@ self.addEventListener("fetch", (event) => {
         return cache.match(event.request).then((cachedResponse) => {
           // Agar cache mein mil gaya, toh turant return karo
           if (cachedResponse) {
+            // Re-put so this entry counts as most-recently-used for eviction
+            event.waitUntil(
+              cache
+                .put(event.request, cachedResponse.clone())
+                .then(() => trimCacheToMaxBytes(cache))
+                .catch(() => {}),
+            );
             return cachedResponse;
           }
 
@@ -113,7 +164,13 @@ self.addEventListener("fetch", (event) => {
                 networkResponse.status === 200 ||
                 networkResponse.status === 0
               ) {
-                cache.put(event.request, networkResponse.clone());
+                event.waitUntil(
+                  cachePutWithLimit(
+                    cache,
+                    event.request,
+                    networkResponse.clone(),
+                  ),
+                );
               }
               return networkResponse;
             })
@@ -128,9 +185,11 @@ self.addEventListener("fetch", (event) => {
         .then((response) => {
           if (response.ok) {
             const responseClone = response.clone();
-            caches.open(CACHE_NAME).then((cache) => {
-              cache.put(event.request, responseClone);
-            });
+            event.waitUntil(
+              caches.open(CACHE_NAME).then((cache) => {
+                return cachePutWithLimit(cache, event.request, responseClone);
+              }),
+            );
           }
           return response;
         })

--- a/src/__tests__/lib/swCacheLru.test.ts
+++ b/src/__tests__/lib/swCacheLru.test.ts
@@ -1,0 +1,104 @@
+import {
+  MAX_CACHE_BYTES,
+  cachePutWithLruLimit,
+  estimateResponseSize,
+  trimCacheToMaxBytes,
+} from "@/lib/swCacheLru";
+
+describe("swCacheLru", () => {
+  it("exposes a 20MB cap", () => {
+    expect(MAX_CACHE_BYTES).toBe(20 * 1024 * 1024);
+  });
+
+  it("prefers content-length when present", async () => {
+    const response = new Response("hello", {
+      headers: { "content-length": "42" },
+    });
+    expect(await estimateResponseSize(response)).toBe(42);
+  });
+
+  it("evicts oldest entries until under the byte limit", async () => {
+    const store = new Map<string, Response>();
+    const order: string[] = [];
+
+    const cache = {
+      async keys() {
+        return order.map((url) => new Request(url));
+      },
+      async match(request: Request) {
+        return store.get(request.url);
+      },
+      async delete(request: Request) {
+        store.delete(request.url);
+        const idx = order.indexOf(request.url);
+        if (idx >= 0) order.splice(idx, 1);
+        return true;
+      },
+      async put(request: Request, response: Response) {
+        if (!store.has(request.url)) order.push(request.url);
+        store.set(request.url, response);
+      },
+    };
+
+    // three ~10 byte payloads, cap at 25 → must drop the oldest
+    await cache.put(
+      new Request("https://img/a.jpg"),
+      new Response("aaaaaaaaaa", { headers: { "content-length": "10" } }),
+    );
+    await cache.put(
+      new Request("https://img/b.jpg"),
+      new Response("bbbbbbbbbb", { headers: { "content-length": "10" } }),
+    );
+    await cache.put(
+      new Request("https://img/c.jpg"),
+      new Response("cccccccccc", { headers: { "content-length": "10" } }),
+    );
+
+    await trimCacheToMaxBytes(cache, 25);
+
+    expect(order).toEqual([
+      "https://img/b.jpg",
+      "https://img/c.jpg",
+    ]);
+    expect(store.has("https://img/a.jpg")).toBe(false);
+  });
+
+  it("puts then trims in cachePutWithLruLimit", async () => {
+    const store = new Map<string, Response>();
+    const order: string[] = [];
+    const cache = {
+      async keys() {
+        return order.map((url) => new Request(url));
+      },
+      async match(request: Request) {
+        return store.get(request.url);
+      },
+      async delete(request: Request) {
+        store.delete(request.url);
+        const idx = order.indexOf(request.url);
+        if (idx >= 0) order.splice(idx, 1);
+        return true;
+      },
+      async put(request: Request, response: Response) {
+        if (!store.has(request.url)) order.push(request.url);
+        store.set(request.url, response);
+      },
+    };
+
+    await cachePutWithLruLimit(
+      cache,
+      new Request("https://img/old.jpg"),
+      new Response("x".repeat(20), { headers: { "content-length": "20" } }),
+      30,
+    );
+    await cachePutWithLruLimit(
+      cache,
+      new Request("https://img/new.jpg"),
+      new Response("y".repeat(20), { headers: { "content-length": "20" } }),
+      30,
+    );
+
+    expect(store.has("https://img/old.jpg")).toBe(false);
+    expect(store.has("https://img/new.jpg")).toBe(true);
+  });
+});

--- a/src/lib/swCacheLru.ts
+++ b/src/lib/swCacheLru.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared helpers for Service Worker cache size limits.
+ * Used by unit tests; mirrored in public/sw.js (classic SW, no module imports).
+ */
+
+export const MAX_CACHE_BYTES = 20 * 1024 * 1024; // 20MB — under iOS Safari ~50MB PWA quota
+
+export async function estimateResponseSize(response: Response): Promise<number> {
+  const header = response.headers.get("content-length");
+  if (header) {
+    const n = Number(header);
+    if (Number.isFinite(n) && n >= 0) return n;
+  }
+  try {
+    const buf = await response.clone().arrayBuffer();
+    return buf.byteLength;
+  } catch {
+    return 0;
+  }
+}
+
+type CacheLike = {
+  keys: () => Promise<Request[]>;
+  match: (request: Request) => Promise<Response | undefined>;
+  delete: (request: Request) => Promise<boolean>;
+  put: (request: Request, response: Response) => Promise<void>;
+};
+
+/** Drop oldest entries until total estimated size fits under maxBytes. */
+export async function trimCacheToMaxBytes(
+  cache: CacheLike,
+  maxBytes: number = MAX_CACHE_BYTES,
+): Promise<void> {
+  const keys = await cache.keys();
+  const entries: { request: Request; size: number }[] = [];
+  let total = 0;
+
+  for (const request of keys) {
+    const response = await cache.match(request);
+    if (!response) continue;
+    const size = await estimateResponseSize(response);
+    entries.push({ request, size });
+    total += size;
+  }
+
+  // Cache#keys is insertion-ordered in major browsers; oldest first.
+  let i = 0;
+  while (total > maxBytes && i < entries.length) {
+    const entry = entries[i++];
+    await cache.delete(entry.request);
+    total -= entry.size;
+  }
+}
+
+export async function cachePutWithLruLimit(
+  cache: CacheLike,
+  request: Request,
+  response: Response,
+  maxBytes: number = MAX_CACHE_BYTES,
+): Promise<void> {
+  await cache.put(request, response);
+  await trimCacheToMaxBytes(cache, maxBytes);
+}


### PR DESCRIPTION
## Description
Caps the PWA Cache Storage budget at 20MB and evicts least-recently-used entries so high-res venue photos no longer blow past iOS Safari’s ~50MB quota and crash the PWA.

closes #914

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Breaking Changes
- [ ] Yes (please describe below)
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline and cached content handling by reducing the image cache quota to ~20 MB and updating cache namespace to a newer version.
  * Cache trimming now more accurately estimates response size (preferring `content-length` when available).
  * Automatically evicts the oldest cached entries until the cache is back under the configured limit.

* **Tests**
  * Added unit tests covering cache size estimation, the ~20 MB cap, eviction behavior, and enforcement after cache writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->