### PR TITLE
fix: stop theme toggle icon flashing wrong state on hydration

### DIFF
--- a/src/__tests__/components/ThemeToggle.test.tsx
+++ b/src/__tests__/components/ThemeToggle.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { ThemeToggle } from "@/components/ThemeToggle";
+import { ThemeProvider } from "@/components/ThemeProvider";
+
+describe("ThemeToggle", () => {
+  it("renders sun/moon icons with dark-mode CSS toggles (no hydration flash)", () => {
+    const { container } = render(
+      <ThemeProvider initialTheme="dark">
+        <ThemeToggle />
+      </ThemeProvider>,
+    );
+
+    const svgs = container.querySelectorAll("svg");
+    const classes = Array.from(svgs).map((el) => el.getAttribute("class") || "");
+
+    expect(classes.some((c) => c.includes("dark:hidden"))).toBe(true);
+    expect(classes.some((c) => c.includes("dark:block"))).toBe(true);
+
+    expect(
+      screen.getByRole("button", { name: /switch to light mode/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -95,12 +95,10 @@ export default async function RootLayout({
   const theme = (cookieStore.get("worksphere-theme")?.value as "light" | "dark") || "light";
 
   const innerContent = (
-    <ThemeProvider>
+    <ThemeProvider initialTheme={theme}>
       <SoundProvider>
         <I18nProvider>{children}</I18nProvider>
       </SoundProvider>
-    <ThemeProvider initialTheme={theme}>
-      <I18nProvider>{children}</I18nProvider>
     </ThemeProvider>
   );
 

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,39 +1,24 @@
 "use client";
 
 import { Sun, Moon } from "lucide-react";
-import { useEffect, useState } from "react";
 import { useTheme } from "./ThemeProvider";
 
 export function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
-  // ThemeProvider already reads the correct value synchronously from the
-  // <html> class on mount, but we still gate the icon on mount to be safe
-  // against any future SSR/CSR mismatch - renders an inert placeholder
-  // (not the wrong icon) for a single frame instead.
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
-
-  if (!mounted) {
-    return (
-      <div
-        className="p-2 w-8 h-8 bg-zinc-100 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl"
-        aria-hidden="true"
-      />
-    );
-  }
 
   return (
     <button
       onClick={toggleTheme}
       className="p-2 cursor-pointer bg-zinc-100 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl text-zinc-600 dark:text-zinc-400 hover:bg-blue-600 hover:text-white transition-all active:scale-95"
       title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
-      aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+      aria-label={
+        theme === "dark" ? "Switch to light mode" : "Switch to dark mode"
+      }
     >
-      {theme === "dark" ? (
-        <Moon className="w-4 h-4" />
-      ) : (
-        <Sun className="w-4 h-4" />
-      )}
+      {/* Icons follow html.dark (set before paint by the theme script / cookie),
+          not useState — avoids the sun→moon flash on hydration in dark mode. */}
+      <Sun className="w-4 h-4 dark:hidden" />
+      <Moon className="w-4 h-4 hidden dark:block" />
     </button>
   );
 }


### PR DESCRIPTION
 ## Description
Prevents the theme toggle from briefly showing the sun icon on dark-mode page loads by driving sun/moon visibility from the `html.dark` class (set before paint) and wiring `ThemeProvider` with the cookie theme again.

closes #878

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Breaking Changes
- [ ] Yes (please describe below)
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme toggle rendering to display the correct icon immediately, reducing visual flicker during page loading.
  * Ensured the selected theme is consistently applied across sound and language settings.

* **Tests**
  * Added coverage verifying dark-mode icon visibility and the light-mode toggle accessibility label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->