### PR TITLE
fix: return friendly error for expired folder invite tokens

### DIFF
--- a/src/__tests__/api/folders-join.test.ts
+++ b/src/__tests__/api/folders-join.test.ts
@@ -1,0 +1,94 @@
+import { POST } from "@/app/api/folders/join/route";
+import { auth, currentUser } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/prisma";
+
+jest.mock("@clerk/nextjs/server", () => ({
+  auth: jest.fn(),
+  currentUser: jest.fn(),
+}));
+
+jest.mock("@/lib/auth", () => ({
+  ensureUserExists: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    folderInvite: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    folderMember: {
+      upsert: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  },
+}));
+
+describe("POST /api/folders/join", () => {
+  const mockAuth = auth as unknown as jest.Mock;
+  const mockCurrentUser = currentUser as unknown as jest.Mock;
+  const mockFindUnique = prisma.folderInvite.findUnique as jest.Mock;
+  const mockUpdate = prisma.folderInvite.update as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuth.mockResolvedValue({ userId: "user_1" });
+    mockCurrentUser.mockResolvedValue({
+      emailAddresses: [{ emailAddress: "guest@example.com" }],
+    });
+  });
+
+  it("returns 410 with an expired message instead of 500", async () => {
+    mockFindUnique.mockResolvedValue({
+      id: "inv_1",
+      folderId: "folder_1",
+      email: "guest@example.com",
+      role: "MEMBER",
+      status: "PENDING",
+      expiresAt: new Date("2020-01-01T00:00:00.000Z"),
+      folder: { id: "folder_1", name: "Team desks" },
+    });
+    mockUpdate.mockResolvedValue({});
+
+    const req = {
+      json: async () => ({
+        token: "a".repeat(32),
+      }),
+    } as any;
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(410);
+    expect(body.error).toMatch(/expired/i);
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: "inv_1" },
+      data: { status: "EXPIRED" },
+    });
+  });
+
+  it("still returns 410 when marking the invite expired fails", async () => {
+    mockFindUnique.mockResolvedValue({
+      id: "inv_2",
+      folderId: "folder_1",
+      email: "guest@example.com",
+      role: "MEMBER",
+      status: "PENDING",
+      expiresAt: new Date("2020-01-01T00:00:00.000Z"),
+      folder: { id: "folder_1", name: "Team desks" },
+    });
+    mockUpdate.mockRejectedValue(new Error("db write failed"));
+
+    const req = {
+      json: async () => ({
+        token: "b".repeat(32),
+      }),
+    } as any;
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(410);
+    expect(body.error).toMatch(/expired/i);
+  });
+});

--- a/src/__tests__/lib/collectionInvite.test.ts
+++ b/src/__tests__/lib/collectionInvite.test.ts
@@ -27,5 +27,7 @@ describe("collection invitation utilities", () => {
     expect(
       isCollectionInviteExpired(new Date("2026-07-20T12:00:01.000Z"), now),
     ).toBe(false);
+    expect(isCollectionInviteExpired(null, now)).toBe(true);
+    expect(isCollectionInviteExpired("not-a-date", now)).toBe(true);
   });
 });

--- a/src/app/api/folders/join/route.ts
+++ b/src/app/api/folders/join/route.ts
@@ -19,7 +19,18 @@ export async function POST(request: NextRequest) {
     }
 
     await ensureUserExists(userId);
-    const parsed = joinSchema.safeParse(await request.json());
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json(
+        { error: "Invalid invitation token" },
+        { status: 400 },
+      );
+    }
+
+    const parsed = joinSchema.safeParse(body);
     if (!parsed.success) {
       return NextResponse.json(
         { error: "Invalid invitation token" },
@@ -39,19 +50,33 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (
-      invite.status !== "PENDING" ||
-      isCollectionInviteExpired(invite.expiresAt)
-    ) {
-      if (
-        invite.status === "PENDING" &&
-        isCollectionInviteExpired(invite.expiresAt)
-      ) {
-        await prisma.folderInvite.update({
-          where: { id: invite.id },
-          data: { status: "EXPIRED" },
-        });
+    const expired =
+      invite.status === "EXPIRED" ||
+      isCollectionInviteExpired(invite.expiresAt);
+
+    if (expired) {
+      // Best-effort status flip — never turn an expired invite into a 500
+      if (invite.status === "PENDING") {
+        try {
+          await prisma.folderInvite.update({
+            where: { id: invite.id },
+            data: { status: "EXPIRED" },
+          });
+        } catch (err) {
+          console.error("Failed to mark invitation expired:", err);
+        }
       }
+
+      return NextResponse.json(
+        {
+          error:
+            "This invitation has expired. Ask the collection owner for a new invite link.",
+        },
+        { status: 410 },
+      );
+    }
+
+    if (invite.status !== "PENDING") {
       return NextResponse.json(
         { error: "This invitation is no longer valid" },
         { status: 410 },

--- a/src/lib/collections/invite-utils.ts
+++ b/src/lib/collections/invite-utils.ts
@@ -8,6 +8,15 @@ export function createCollectionInviteExpiry(now = Date.now()) {
   return new Date(now + COLLECTION_INVITE_TTL_MS);
 }
 
-export function isCollectionInviteExpired(expiresAt: Date, now = new Date()) {
-  return expiresAt.getTime() <= now.getTime();
+export function isCollectionInviteExpired(
+  expiresAt: Date | string | null | undefined,
+  now = new Date(),
+) {
+  if (!expiresAt) return true;
+  const ms =
+    expiresAt instanceof Date
+      ? expiresAt.getTime()
+      : new Date(expiresAt).getTime();
+  if (Number.isNaN(ms)) return true;
+  return ms <= now.getTime();
 }


### PR DESCRIPTION
## Description
Expired collection invite tokens now return HTTP 410 with a clear expired message instead of a 500 when `/collections/join` is opened with an expired token.

this pr resolves issue #877
closes #877 

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Breaking Changes
- [ ] Yes (please describe below)
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid or malformed invitation requests now return a clear `400` error.
  - Expired folder invitations now consistently return a `410` response with guidance to request a new invitation.
  - Missing or invalid invitation expiration dates are correctly treated as expired.
  - Expiration status updates no longer prevent users from receiving the appropriate expired-invitation response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->