### PR TITLE
fix: keep chat input above mobile keyboard on iOS

### DIFF
--- a/src/__tests__/components/ChatInput.test.tsx
+++ b/src/__tests__/components/ChatInput.test.tsx
@@ -137,3 +137,50 @@ describe("ChatInput Recent Searches", () => {
     expect(screen.queryByText("Recent Searches")).not.toBeInTheDocument();
   });
 });
+
+describe("ChatInput keyboard inset", () => {
+  const listeners: Record<string, Array<() => void>> = {};
+
+  beforeEach(() => {
+    Object.keys(listeners).forEach((k) => delete listeners[k]);
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 800,
+    });
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: {
+        height: 500,
+        offsetTop: 0,
+        addEventListener: (type: string, cb: () => void) => {
+          listeners[type] = listeners[type] || [];
+          listeners[type].push(cb);
+        },
+        removeEventListener: (type: string, cb: () => void) => {
+          listeners[type] = (listeners[type] || []).filter((fn) => fn !== cb);
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it("pads the composer when the visual viewport shrinks", () => {
+    const { container } = render(
+      <ChatInput
+        input=""
+        isLoading={false}
+        onInputChange={jest.fn()}
+        onSubmit={jest.fn()}
+      />,
+    );
+
+    const wrap = container.firstChild as HTMLElement;
+    expect(wrap.style.paddingBottom).toContain("300px");
+  });
+});

--- a/src/app/ai/page.tsx
+++ b/src/app/ai/page.tsx
@@ -667,7 +667,7 @@ function AppPage() {
   }
 
   return (
-    <div className="flex flex-col h-screen bg-zinc-50 dark:bg-black overflow-hidden">
+    <div className="flex flex-col h-dvh bg-zinc-50 dark:bg-black overflow-hidden">
       <OnboardingTour />
       {/* Offline Banner */}
       {!isOnline && (

--- a/src/components/chat/ChatMessages.tsx
+++ b/src/components/chat/ChatMessages.tsx
@@ -1077,6 +1077,7 @@ export function ChatInput({
 
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
   const [isFocused, setIsFocused] = useState(false);
+  const [keyboardInset, setKeyboardInset] = useState(0);
 
   useEffect(() => {
     const history = localStorage.getItem("ws-recent-searches");
@@ -1087,6 +1088,25 @@ export function ChatInput({
         console.error(e);
       }
     }
+  }, []);
+
+  // Keep the composer above the iOS soft keyboard / browser chrome.
+  useEffect(() => {
+    const vv = window.visualViewport;
+    if (!vv) return;
+
+    const sync = () => {
+      const inset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
+      setKeyboardInset(inset);
+    };
+
+    sync();
+    vv.addEventListener("resize", sync);
+    vv.addEventListener("scroll", sync);
+    return () => {
+      vv.removeEventListener("resize", sync);
+      vv.removeEventListener("scroll", sync);
+    };
   }, []);
 
   const saveToHistory = (term: string) => {
@@ -1200,7 +1220,14 @@ export function ChatInput({
       : "Start voice input";
 
   return (
-    <div className="relative p-4 bg-white dark:bg-zinc-950 border-t border-zinc-200 dark:border-zinc-800">
+    <div
+      className="relative p-4 bg-white dark:bg-zinc-950 border-t border-zinc-200 dark:border-zinc-800 pb-[max(1rem,env(safe-area-inset-bottom))]"
+      style={
+        keyboardInset > 0
+          ? { paddingBottom: `calc(${keyboardInset}px + env(safe-area-inset-bottom, 0px))` }
+          : undefined
+      }
+    >
       <AnimatePresence>
         {isFocused && recentSearches.length > 0 && (
           <motion.div


### PR DESCRIPTION
## Summary
- Switch `/ai` layout height to `dvh` so the shell tracks the mobile viewport
- Offset the chat composer using `visualViewport` + safe-area inset when the keyboard opens

Closes #869

## Test plan
- [ ] Open `/ai` on iOS Safari
- [ ] Focus the chat input — composer should stay visible above the keyboard
- [ ] Dismiss keyboard — layout returns to normal without jump
- [ ] `npm test -- --testPathPattern=ChatInput.test --no-coverage`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the chat interface on mobile devices by keeping the message composer visible when the on-screen keyboard or browser controls appear.
  * Adjusted viewport sizing for more reliable behavior on mobile Safari.
  * Preserved bottom safe-area spacing for devices with display cutouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->