### PR TITLE
feat: export collection folders as PDF summary reports

### DIFF
--- a/src/__tests__/lib/folderPdfExport.test.ts
+++ b/src/__tests__/lib/folderPdfExport.test.ts
@@ -1,0 +1,42 @@
+import { generateFolderSummaryPdf } from "@/lib/folderPdfExport";
+
+describe("generateFolderSummaryPdf", () => {
+  it("builds a PDF with venue wifi, outlets, and notes", async () => {
+    const bytes = await generateFolderSummaryPdf({
+      folderName: "Team Hubs",
+      folderDescription: "Places we like",
+      venues: [
+        {
+          name: "Focus Cafe",
+          wifiQuality: 5,
+          hasOutlets: true,
+          notes: "Quiet mornings",
+        },
+        {
+          name: "Library Annex",
+          wifiQuality: null,
+          hasOutlets: false,
+          notes: "",
+        },
+      ],
+    });
+
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes.length).toBeGreaterThan(100);
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { PDFDocument } = require("pdf-lib");
+    const doc = await PDFDocument.load(bytes);
+    expect(doc.getPageCount()).toBeGreaterThanOrEqual(1);
+  });
+
+  it("handles an empty folder", async () => {
+    const bytes = await generateFolderSummaryPdf({
+      folderName: "Empty List",
+      venues: [],
+    });
+
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes.length).toBeGreaterThan(0);
+  });
+});

--- a/src/app/api/folders/[id]/export-pdf/route.ts
+++ b/src/app/api/folders/[id]/export-pdf/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/prisma";
+import { hasFolderAccess } from "@/lib/folders";
+import { generateFolderSummaryPdf } from "@/lib/folderPdfExport";
+
+// GET /api/folders/[id]/export-pdf — styled PDF summary of folder venues
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    const { id } = await params;
+    const { folder, hasAccess } = await hasFolderAccess(id, userId);
+
+    if (!folder) {
+      return new NextResponse("Folder not found", { status: 404 });
+    }
+    if (!hasAccess) {
+      return new NextResponse("Forbidden", { status: 403 });
+    }
+
+    const folderVenues = await prisma.folderVenue.findMany({
+      where: { folderId: id },
+      include: {
+        venue: {
+          select: {
+            id: true,
+            name: true,
+            wifiQuality: true,
+            hasOutlets: true,
+            address: true,
+          },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    const venueIds = folderVenues.map((fv) => fv.venue.id);
+    const favorites =
+      venueIds.length === 0
+        ? []
+        : await prisma.favorite.findMany({
+            where: { userId, venueId: { in: venueIds } },
+            select: { venueId: true, notes: true },
+          });
+
+    const notesByVenue = new Map(
+      favorites.map((f) => [f.venueId, f.notes ?? ""]),
+    );
+
+    const pdfBytes = await generateFolderSummaryPdf({
+      folderName: folder.name,
+      folderDescription: folder.description,
+      venues: folderVenues.map((fv) => ({
+        name: fv.venue.name,
+        wifiQuality: fv.venue.wifiQuality,
+        hasOutlets: fv.venue.hasOutlets,
+        address: fv.venue.address,
+        notes: notesByVenue.get(fv.venue.id) || "",
+      })),
+    });
+
+    const slug = folder.name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "");
+
+    return new NextResponse(Buffer.from(pdfBytes), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `attachment; filename="collection-${slug || "report"}.pdf"`,
+      },
+    });
+  } catch (error) {
+    console.error("GET /api/folders/[id]/export-pdf error:", error);
+    return new NextResponse("Failed to export PDF", { status: 500 });
+  }
+}

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -37,6 +37,7 @@ export default function FolderDetailsPage({
   const [sendingInvite, setSendingInvite] = useState(false);
   const [updatingPublic, setUpdatingPublic] = useState(false);
   const [exporting, setExporting] = useState(false);
+  const [exportingPdf, setExportingPdf] = useState(false);
   const [filters, setFilters] = useState({
     hasOutlets: false,
     wifiQualityMin: false,
@@ -63,6 +64,29 @@ export default function FolderDetailsPage({
       alert("Failed to export billing codes. Please try again.");
     } finally {
       setExporting(false);
+    }
+  };
+
+  const handleExportPdf = async () => {
+    try {
+      setExportingPdf(true);
+      const response = await fetch(`/api/folders/${id}/export-pdf`);
+      if (!response.ok) throw new Error("PDF export failed");
+
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `collection-${folder.name.toLowerCase().replace(/\s+/g, "-")}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+    } catch (error) {
+      console.error("PDF export error:", error);
+      alert("Failed to export PDF. Please try again.");
+    } finally {
+      setExportingPdf(false);
     }
   };
 
@@ -344,6 +368,29 @@ export default function FolderDetailsPage({
                   Quiet Only
                 </label>
               </div>
+            </div>
+
+            {/* PDF Export */}
+            <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-6 shadow-sm">
+              <h2 className="text-lg font-semibold text-zinc-900 dark:text-white flex items-center gap-2 mb-4">
+                <FileDown className="w-5 h-5 text-blue-500" /> Export Report
+              </h2>
+              <p className="text-xs text-zinc-500 mb-4">
+                Download a PDF summary of venues in this collection for team
+                sharing.
+              </p>
+              <button
+                onClick={handleExportPdf}
+                disabled={exportingPdf}
+                className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-xl text-sm transition-all disabled:opacity-50 shadow-lg shadow-blue-500/20 active:scale-[0.98]"
+              >
+                {exportingPdf ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <FileDown className="w-4 h-4" />
+                )}
+                Export to PDF
+              </button>
             </div>
 
             {/* Billing Export Section */}

--- a/src/lib/folderPdfExport.ts
+++ b/src/lib/folderPdfExport.ts
@@ -1,0 +1,137 @@
+import { PDFDocument, StandardFonts, rgb } from "pdf-lib";
+import { drawSafeText, safeText } from "@/lib/pdfHelpers";
+
+export type FolderPdfVenue = {
+  name: string;
+  wifiQuality: number | null;
+  hasOutlets: boolean;
+  notes?: string | null;
+  address?: string | null;
+};
+
+export async function generateFolderSummaryPdf(options: {
+  folderName: string;
+  folderDescription?: string | null;
+  venues: FolderPdfVenue[];
+}): Promise<Uint8Array> {
+  const { folderName, folderDescription, venues } = options;
+
+  const pdfDoc = await PDFDocument.create();
+  const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+  const bold = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
+
+  let page = pdfDoc.addPage([595, 842]);
+  const { width, height } = page.getSize();
+  const margin = 48;
+  let y = height - margin;
+
+  const newPage = () => {
+    page = pdfDoc.addPage([595, 842]);
+    y = height - margin;
+  };
+
+  const ensureSpace = (needed: number) => {
+    if (y - needed < margin) newPage();
+  };
+
+  page.drawRectangle({
+    x: 0,
+    y: height - 8,
+    width,
+    height: 8,
+    color: rgb(0.23, 0.51, 0.96),
+  });
+
+  drawSafeText(page, "WorkSphere Collection Report", {
+    x: margin,
+    y,
+    size: 18,
+    font: bold,
+    color: rgb(0.1, 0.1, 0.1),
+  });
+  y -= 28;
+
+  drawSafeText(page, safeText(folderName), {
+    x: margin,
+    y,
+    size: 14,
+    font: bold,
+    color: rgb(0.15, 0.15, 0.15),
+  });
+  y -= 18;
+
+  if (folderDescription) {
+    drawSafeText(page, safeText(folderDescription).slice(0, 90), {
+      x: margin,
+      y,
+      size: 10,
+      font,
+      color: rgb(0.4, 0.4, 0.4),
+    });
+    y -= 16;
+  }
+
+  drawSafeText(
+    page,
+    `Generated ${new Date().toLocaleDateString()}  ·  ${venues.length} venue${venues.length === 1 ? "" : "s"}`,
+    {
+      x: margin,
+      y,
+      size: 9,
+      font,
+      color: rgb(0.45, 0.45, 0.45),
+    },
+  );
+  y -= 28;
+
+  if (venues.length === 0) {
+    drawSafeText(page, "No venues in this collection.", {
+      x: margin,
+      y,
+      size: 11,
+      font,
+      color: rgb(0.4, 0.4, 0.4),
+    });
+    return pdfDoc.save();
+  }
+
+  for (let i = 0; i < venues.length; i++) {
+    const venue = venues[i];
+    ensureSpace(72);
+
+    drawSafeText(page, `${i + 1}. ${safeText(venue.name)}`, {
+      x: margin,
+      y,
+      size: 12,
+      font: bold,
+      color: rgb(0.1, 0.1, 0.1),
+    });
+    y -= 16;
+
+    const wifi =
+      venue.wifiQuality != null ? `${venue.wifiQuality}/5` : "N/A";
+    const outlets = venue.hasOutlets ? "Yes" : "No";
+
+    drawSafeText(page, `WiFi: ${wifi}    Outlets: ${outlets}`, {
+      x: margin + 8,
+      y,
+      size: 10,
+      font,
+      color: rgb(0.25, 0.25, 0.25),
+    });
+    y -= 14;
+
+    const notes = (venue.notes || "").trim() || "—";
+    const notesLine = `Notes: ${safeText(notes).slice(0, 100)}`;
+    drawSafeText(page, notesLine, {
+      x: margin + 8,
+      y,
+      size: 10,
+      font,
+      color: rgb(0.35, 0.35, 0.35),
+    });
+    y -= 22;
+  }
+
+  return pdfDoc.save();
+}


### PR DESCRIPTION
## Summary
- Add Export to PDF on collection detail pages
- Generate a pdf-lib summary with venue name, WiFi rating, outlets, and notes
- Download the report asynchronously via `/api/folders/[id]/export-pdf`

Closes #864

## Test plan
- [ ] Open a collection with venues
- [ ] Click Export to PDF — file downloads
- [ ] Confirm PDF lists name / WiFi / outlets / notes
- [ ] `npm test -- --testPathPattern=folderPdfExport.test --no-coverage`