### PR TITLE
fix: use microsecond stamps in Redis rate limit Lua

### DIFF
--- a/src/__tests__/lib/rateLimit.test.ts
+++ b/src/__tests__/lib/rateLimit.test.ts
@@ -1,4 +1,9 @@
-import { rateLimit, getRateLimitInfo, resetRateLimit } from "@/lib/rateLimit";
+import {
+  rateLimit,
+  getRateLimitInfo,
+  resetRateLimit,
+  microTimestampMember,
+} from "@/lib/rateLimit";
 
 describe("Rate Limiting", () => {
   beforeEach(() => {
@@ -71,5 +76,19 @@ describe("Rate Limiting", () => {
     expect(info?.count).toBe(5);
     expect(info?.remaining).toBe(0);
     expect(info?.isLimited).toBe(true);
+  });
+});
+
+describe("microTimestampMember", () => {
+  it("stringifies sec+usec so same-ms hits stay unique", () => {
+    const a = microTimestampMember(1700000000, 12, "a");
+    const b = microTimestampMember(1700000000, 13, "a");
+    expect(a).toBe("1700000000000012:a");
+    expect(b).toBe("1700000000000013:a");
+    expect(a).not.toBe(b);
+  });
+
+  it("pads usec to 6 digits", () => {
+    expect(microTimestampMember("100", 5, "x")).toBe("100000005:x");
   });
 });

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -5,9 +5,54 @@
  * Development: Falls back to an in-memory sliding window automatically
  */
 
-const upstashLimiters = new Map<number, any>();
+const WINDOW_MS = 60_000;
 
-function getUpstashRatelimit(limitPerMinute: number) {
+// ZSET sliding window. Member = stringified microsecond stamp so concurrent
+// hits in the same ms don't collide / get dropped under load.
+const SLIDING_WINDOW_LUA = `
+local key = KEYS[1]
+local limit = tonumber(ARGV[1])
+local windowMs = tonumber(ARGV[2])
+local nonce = ARGV[3]
+
+local t = redis.call("TIME")
+local sec = t[1]
+local usec = t[2]
+local nowMs = tonumber(sec) * 1000 + math.floor(tonumber(usec) / 1000)
+local member = sec .. string.format("%06d", tonumber(usec)) .. ":" .. nonce
+
+redis.call("ZREMRANGEBYSCORE", key, "-inf", nowMs - windowMs)
+local count = redis.call("ZCARD", key)
+if count >= limit then
+  return 0
+end
+
+redis.call("ZADD", key, nowMs, member)
+redis.call("PEXPIRE", key, windowMs)
+return 1
+`;
+
+/** ZSET member id used by the Lua script (exported for tests). */
+export function microTimestampMember(
+  sec: string | number,
+  usec: string | number,
+  nonce: string,
+): string {
+  const u = String(usec).padStart(6, "0");
+  return `${sec}${u}:${nonce}`;
+}
+
+type RedisScript = {
+  eval: (keys: string[], args: string[]) => Promise<unknown>;
+};
+
+type RedisClient = {
+  createScript: (script: string) => RedisScript;
+};
+
+const scriptByLimit = new Map<number, RedisScript>();
+
+function getRedisScript(limitPerMinute: number): RedisScript | null {
   if (
     !process.env.UPSTASH_REDIS_REST_URL ||
     !process.env.UPSTASH_REDIS_REST_TOKEN
@@ -15,29 +60,44 @@ function getUpstashRatelimit(limitPerMinute: number) {
     return null;
   }
 
+  const cached = scriptByLimit.get(limitPerMinute);
+  if (cached) return cached;
+
   try {
-    // Dynamic require so the build doesn't fail if packages aren't present yet
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { Ratelimit } = require("@upstash/ratelimit");
+    // Dynamic require so jest doesn't pull in @upstash/redis ESM
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { Redis } = require("@upstash/redis");
 
     const redis = new Redis({
       url: process.env.UPSTASH_REDIS_REST_URL,
       token: process.env.UPSTASH_REDIS_REST_TOKEN,
-    });
+    }) as RedisClient;
 
-    return new Ratelimit({
-      redis,
-      limiter: Ratelimit.slidingWindow(limitPerMinute, "1 m"),
-      analytics: true,
-      prefix: "worksphere:ratelimit",
-    }) as {
-      limit: (
-        identifier: string,
-      ) => Promise<{ success: boolean; remaining: number; reset: number }>;
-    };
+    const script = redis.createScript(SLIDING_WINDOW_LUA);
+    scriptByLimit.set(limitPerMinute, script);
+    return script;
   } catch {
+    return null;
+  }
+}
+
+async function redisSlidingWindow(
+  identifier: string,
+  limit: number,
+): Promise<boolean | null> {
+  const script = getRedisScript(limit);
+  if (!script) return null;
+
+  try {
+    const key = `worksphere:ratelimit:${limit}:${identifier}`;
+    const nonce = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+    const result = await script.eval(
+      [key],
+      [String(limit), String(WINDOW_MS), nonce],
+    );
+    return Number(result) === 1;
+  } catch (err) {
+    console.error("[rateLimit] redis eval failed, falling back to memory", err);
     return null;
   }
 }
@@ -48,7 +108,6 @@ interface MemEntry {
   resetTime: number;
 }
 const memStore = new Map<string, MemEntry>();
-const WINDOW_MS = 60_000;
 
 interface RateLimitInfo {
   count: number;
@@ -58,7 +117,6 @@ interface RateLimitInfo {
 }
 const rateLimitInfoStore = new Map<string, RateLimitInfo>();
 
-// Run cleanup in the background instead of on the request path.
 const CLEANUP_INTERVAL_MS = 60_000;
 
 function cleanupExpiredEntries() {
@@ -77,7 +135,6 @@ function cleanupExpiredEntries() {
   }
 }
 
-// Start a single background cleanup task.
 const globalCleanup = globalThis as typeof globalThis & {
   __rateLimitCleanupTimer?: NodeJS.Timeout;
 };
@@ -138,17 +195,9 @@ export async function rateLimit(
   identifier: string,
   limit = 10,
 ): Promise<boolean> {
-  let rl = upstashLimiters.get(limit);
-  if (!rl) {
-    rl = getUpstashRatelimit(limit);
-    if (rl) {
-      upstashLimiters.set(limit, rl);
-    }
-  }
-
-  if (rl) {
-    const { success } = await rl.limit(identifier);
-    return success;
+  const redisResult = await redisSlidingWindow(identifier, limit);
+  if (redisResult !== null) {
+    return redisResult;
   }
 
   return memRateLimit(identifier, limit);


### PR DESCRIPTION
## Summary
- Replaces Upstash sliding-window limiter with a Lua ZSET script that stores stringified microsecond member ids so concurrent same-ms hits don't collide under load
- Keeps the existing in-memory fallback when Redis env vars are missing

Closes #913

## Test plan
- [ ] `npm test -- --testPathPattern='rateLimit.test|api/venues.test'`
- [ ] With Upstash env set, hit `/api/venues` under burst and confirm it no longer 429s after a few requests prematurely
- [ ] Without Redis env, rate limit still works via memory fallback


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved distributed rate limiting for greater reliability and more accurate sliding-window enforcement.
  * Prevented rate-limit entry collisions during high-frequency requests.
  * Added a reliable fallback when the distributed rate-limiting service is unavailable.
* **Tests**
  * Added coverage for unique high-frequency rate-limit keys and consistent timestamp formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->