### PR TITLE
fix: defer WebSocket presence binding until post-hydration

### DIFF
--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -43,6 +43,11 @@ export default function FolderDetailsPage({
     quietOnly: false,
   });
 
+  const [isMounted, setIsMounted] = useState(false);
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
   const handleExportBilling = async () => {
     try {
       setExporting(true);
@@ -115,7 +120,7 @@ export default function FolderDetailsPage({
   // Real-time synchronization
   usePartySocket({
     host: "127.0.0.1:1999",
-    room: `folder-${id}`,
+    room: isMounted ? `folder-${id}` : null,
     onMessage(event) {
       try {
         const data = JSON.parse(event.data);

--- a/src/hooks/useRealTime.tsx
+++ b/src/hooks/useRealTime.tsx
@@ -248,6 +248,11 @@ export function useMultiplayerSession(roomId: string | null) {
   const [yDoc, setYDoc] = useState<Y.Doc | null>(null);
   const { getToken } = useAuth();
   const [token, setToken] = useState<string | null>(null);
+  
+  const [isMounted, setIsMounted] = useState(false);
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
 
   useEffect(() => {
     getToken().then(setToken).catch(console.error);
@@ -278,7 +283,7 @@ export function useMultiplayerSession(roomId: string | null) {
   // Use standard websocket for simple presence broadcast
   const socket = usePartySocket({
     host: "127.0.0.1:1999",
-    room: roomId || "default",
+    room: isMounted ? (roomId || "default") : null,
     query: token ? { token } : undefined,
     onMessage() {
       // handled in component

--- a/src/hooks/useSeatAvailability.ts
+++ b/src/hooks/useSeatAvailability.ts
@@ -60,6 +60,11 @@ export function useSeatAvailability() {
   // renders without needing checkedInVenueId itself as a dependency.
   const checkedInVenueRef = useRef<string | null>(null);
 
+  const [isMounted, setIsMounted] = useState(false);
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
   useEffect(() => {
     getToken()
       .then(setToken)
@@ -68,7 +73,7 @@ export function useSeatAvailability() {
 
   const socket = usePartySocket({
     host: "127.0.0.1:1999",
-    room: SEAT_ROOM,
+    room: isMounted ? SEAT_ROOM : null,
     query: token ? { token } : undefined,
     onOpen() {
       setIsConnected(true);
@@ -117,7 +122,7 @@ export function useSeatAvailability() {
         queueOfflineCheckIn(venueId).catch(console.error);
         toast("You are offline. Check-in queued for sync.", "success");
       } else {
-        socket.send(
+        socket?.send(
           JSON.stringify({ type: "seat_checkin", venueId, capacity }),
         );
       }
@@ -192,7 +197,7 @@ export function useSeatAvailability() {
   const checkOut = useCallback(() => {
     checkedInVenueRef.current = null;
     setCheckedInVenueId(null);
-    socket.send(JSON.stringify({ type: "seat_checkout" }));
+    socket?.send(JSON.stringify({ type: "seat_checkout" }));
   }, [socket]);
 
   // Best-effort checkout if the component unmounts while checked in, so we
@@ -201,14 +206,14 @@ export function useSeatAvailability() {
     return () => {
       if (checkedInVenueRef.current) {
         try {
-          socket.send(JSON.stringify({ type: "seat_checkout" }));
+          socket?.send(JSON.stringify({ type: "seat_checkout" }));
         } catch {
           // Socket may already be closed on unmount — nothing to do.
         }
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [socket]);
 
   const getAvailability = useCallback(
     (venueId: string): SeatAvailability => {


### PR DESCRIPTION
# Pull Request

## Description

This pull request resolves the Next.js 16 App Router SSG hydration mismatch that occurred on dynamic pages using PartyKit WebSocket state initialization. The mismatch was caused by the immediate binding of the WebSocket presence state upon the initial render, which varied between the server and the client state. 

By deferring the WebSocket room assignment (connection) until after the `isMounted` state is `true` (post-hydration), we ensure that the initial UI rendered on the server accurately matches the first render on the client.

### Changes
- **WebSocket**: Wrapped `usePartySocket` `room` assignments with an `isMounted` check to prevent hydration mismatches in `useSeatAvailability`, `useRealTime`, and `collections/[id]/page`.
- **WebSocket**: Added optional chaining `socket?.send` to prevent crashing before the socket is fully connected.

## Type of Change

- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #830

## Testing

Verified the WebSocket presence functionality operates correctly in a browser environment while resolving the Next.js hydration error on dynamic pages.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A - Backend changes only

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved real-time connection handling during initial page loading to prevent hydration-related issues.
  * Prevented seat availability actions from sending messages before the connection is ready.
  * Improved cleanup of seat reservations when leaving a session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->