### PR TITLE
fix: implement atomic Lua token bucket for rate limit

### DIFF
--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -27,15 +27,53 @@ function getUpstashRatelimit(limitPerMinute: number) {
       token: process.env.UPSTASH_REDIS_REST_TOKEN,
     });
 
-    return new Ratelimit({
-      redis,
-      limiter: Ratelimit.slidingWindow(limitPerMinute, "1 m"),
-      analytics: true,
-      prefix: "worksphere:ratelimit",
-    }) as {
-      limit: (
-        identifier: string,
-      ) => Promise<{ success: boolean; remaining: number; reset: number }>;
+    return {
+      limit: async (identifier: string) => {
+        const key = `worksphere:ratelimit:${identifier}`;
+        const now = Date.now();
+        // Atomic Lua script for token bucket evaluation
+        const script = `
+          local key = KEYS[1]
+          local limit = tonumber(ARGV[1])
+          local now = tonumber(ARGV[2])
+
+          local state = redis.call("HMGET", key, "tokens", "last_refill")
+          local tokens = tonumber(state[1])
+          local last_refill = tonumber(state[2])
+
+          if not tokens then
+            tokens = limit
+            last_refill = now
+          else
+            local elapsed = math.max(0, now - last_refill)
+            local new_tokens = math.floor(elapsed * (limit / 60000))
+            if new_tokens > 0 then
+              tokens = math.min(limit, tokens + new_tokens)
+              last_refill = last_refill + (new_tokens * (60000 / limit))
+            end
+          end
+
+          if tokens > 0 then
+            redis.call("HMSET", key, "tokens", tokens - 1, "last_refill", last_refill)
+            redis.call("PEXPIRE", key, 60000)
+            return { 1, tokens - 1 }
+          else
+            return { 0, tokens }
+          end
+        `;
+        try {
+          const result = await redis.eval(script, [key], [limitPerMinute, now]);
+          return {
+            success: result[0] === 1,
+            remaining: result[1],
+            reset: now + 60000,
+          };
+        } catch (e) {
+          console.error("Redis ratelimit eval error", e);
+          // Fail open
+          return { success: true, remaining: 1, reset: now + 60000 };
+        }
+      }
     };
   } catch {
     return null;


### PR DESCRIPTION
# Pull Request

## Description

This pull request resolves the token bucket exhaustion issue (Issue #832) on Upstash Redis during concurrent bursts of traffic. The underlying `@upstash/ratelimit` sliding window evaluation was struggling to accurately distinguish timestamps when bombarded with parallel requests, resulting in legitimate requests being blocked. 

To fix this, the abstraction has been replaced with a direct, atomic Lua script executing a precise token bucket algorithm inside Upstash Redis (`redis.eval()`). This ensures thread-safe, consistent updates under heavy traffic bursts without exhausting tokens improperly.

### Changes
- **Atomic Lua Rate Limiter**: Replaced `Ratelimit.slidingWindow` instantiation in `src/lib/rateLimit.ts` with a direct `redis.eval()` wrapper that runs an atomic token bucket Lua script.
- **Fail Open Error Handling**: Ensured that the implementation fails gracefully, allowing the request if the Redis `eval` fails unexpectedly.

## Type of Change

- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [x] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #832

## Testing

Verified the logic locally. High concurrency requests to the endpoints no longer inappropriately exhaust the rate limiter due to identical evaluation timestamps.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A - Backend changes only

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request rate limiting for more consistent token tracking.
  * Added graceful handling when rate-limit checks cannot be completed, allowing requests to continue instead of failing unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->