### PR TITLE
Feature/webrtc screen share

### DIFF
--- a/party/server.ts
+++ b/party/server.ts
@@ -35,12 +35,14 @@ export default class WorkspaceServer implements Party.Server {
     const token = url.searchParams.get("token");
 
     let isViewer = false;
+    let verifiedUserId: string | undefined;
 
     if (token) {
       try {
         const secretKey = process.env.CLERK_SECRET_KEY;
         const verifiedToken = await verifyToken(token, { secretKey });
         const userId = verifiedToken.sub;
+        verifiedUserId = userId;
 
         // Canvas whiteboard rooms: any authenticated user can edit
         if (this.room.id.startsWith("canvas-")) {
@@ -76,7 +78,10 @@ export default class WorkspaceServer implements Party.Server {
       isViewer = true;
     }
 
-    conn.setState({ role: isViewer ? "VIEWER" : "EDITOR" });
+    conn.setState({
+      role: isViewer ? "VIEWER" : "EDITOR",
+      userId: verifiedUserId,
+    });
 
     // Bring newly connected clients up to speed on current seat availability
     // (#703) so rings render correctly before any new check-in event fires.
@@ -108,13 +113,20 @@ export default class WorkspaceServer implements Party.Server {
   }
 
   onMessage(message: string, sender: Party.Connection) {
-    const state = sender.state as { role?: string };
+    const state = sender.state as { role?: string; userId?: string };
 
     try {
       const parsed = JSON.parse(message);
 
-      // If it's a typing indicator, broadcast it safely
       if (parsed.type === "typing") {
+        this.room.broadcast(message, [sender.id]);
+        return;
+      }
+
+      // WebRTC signaling is allowed for VIEWERS, but `from` must match the
+      // Clerk userId we verified on connect — never trust the client field alone.
+      if (parsed.type === "webrtc-signal") {
+        if (!state.userId || parsed.from !== state.userId) return;
         this.room.broadcast(message, [sender.id]);
         return;
       }

--- a/src/__tests__/hooks/useScreenShare.test.tsx
+++ b/src/__tests__/hooks/useScreenShare.test.tsx
@@ -1,0 +1,173 @@
+import { act, renderHook } from "@testing-library/react";
+import { useScreenShare } from "@/hooks/useScreenShare";
+
+jest.mock("@clerk/nextjs", () => ({
+  useAuth: () => ({
+    getToken: jest.fn().mockResolvedValue(null),
+  }),
+}));
+
+const send = jest.fn();
+let socketOpts: {
+  onOpen?: () => void;
+  onMessage?: (event: { data: string }) => void;
+} = {};
+
+jest.mock("partysocket/react", () => ({
+  __esModule: true,
+  default: jest.fn((opts: typeof socketOpts) => {
+    socketOpts = opts;
+    return { send };
+  }),
+}));
+
+describe("useScreenShare", () => {
+  const stop = jest.fn();
+  let videoTrack: {
+    kind: string;
+    stop: jest.Mock;
+    onended: ((ev?: Event) => void) | null;
+  };
+
+  beforeEach(() => {
+    stop.mockClear();
+    send.mockClear();
+    socketOpts = {};
+
+    videoTrack = { kind: "video", stop, onended: null };
+
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getDisplayMedia: jest.fn().mockResolvedValue({
+          getTracks: () => [videoTrack],
+          getVideoTracks: () => [videoTrack],
+        }),
+      },
+    });
+
+    Object.defineProperty(document, "pictureInPictureEnabled", {
+      configurable: true,
+      value: true,
+    });
+  });
+
+  it("asks for display media when the host starts sharing", async () => {
+    const { result } = renderHook(() =>
+      useScreenShare({
+        roomId: "session-demo",
+        userId: "host-1",
+        isHost: true,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.startShare();
+    });
+
+    expect(navigator.mediaDevices.getDisplayMedia).toHaveBeenCalled();
+    expect(result.current.sharing).toBe(true);
+    expect(send).toHaveBeenCalledWith(
+      expect.stringContaining('"kind":"share-start"'),
+    );
+  });
+
+  it("stops tracks when share ends", async () => {
+    const { result } = renderHook(() =>
+      useScreenShare({
+        roomId: "session-demo",
+        userId: "host-1",
+        isHost: true,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.startShare();
+    });
+
+    act(() => {
+      result.current.stopShare();
+    });
+
+    expect(stop).toHaveBeenCalled();
+    expect(result.current.sharing).toBe(false);
+  });
+
+  it("cleans up when the browser ends the display track", async () => {
+    const { result } = renderHook(() =>
+      useScreenShare({
+        roomId: "session-demo",
+        userId: "host-1",
+        isHost: true,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.startShare();
+    });
+
+    expect(typeof videoTrack.onended).toBe("function");
+
+    act(() => {
+      videoTrack.onended?.();
+    });
+
+    expect(send).toHaveBeenCalledWith(
+      expect.stringContaining('"kind":"share-stop"'),
+    );
+    expect(stop).toHaveBeenCalled();
+    expect(result.current.sharing).toBe(false);
+  });
+
+  it("viewers reply viewer-ready when the host starts sharing", async () => {
+    renderHook(() =>
+      useScreenShare({
+        roomId: "session-demo",
+        userId: "viewer-1",
+        isHost: false,
+      }),
+    );
+
+    await act(async () => {
+      socketOpts.onMessage?.({
+        data: JSON.stringify({
+          type: "webrtc-signal",
+          kind: "share-start",
+          from: "host-1",
+        }),
+      });
+    });
+
+    expect(send).toHaveBeenCalledWith(
+      expect.stringContaining('"kind":"viewer-ready"'),
+    );
+  });
+
+  it("toggles picture-in-picture on the video element", async () => {
+    const requestPictureInPicture = jest.fn().mockResolvedValue(undefined);
+    const video = {
+      requestPictureInPicture,
+    } as unknown as HTMLVideoElement;
+
+    Object.defineProperty(document, "pictureInPictureElement", {
+      configurable: true,
+      value: null,
+    });
+
+    const { result } = renderHook(() =>
+      useScreenShare({
+        roomId: "session-demo",
+        userId: "host-1",
+        isHost: true,
+      }),
+    );
+
+    let pip = false;
+    await act(async () => {
+      pip = await result.current.requestPip(video);
+    });
+
+    expect(requestPictureInPicture).toHaveBeenCalled();
+    expect(pip).toBe(true);
+  });
+});

--- a/src/__tests__/lib/screenShareBitrate.test.ts
+++ b/src/__tests__/lib/screenShareBitrate.test.ts
@@ -1,0 +1,55 @@
+import {
+  pickBitrateTier,
+  readNetworkHints,
+} from "@/lib/screenShareBitrate";
+
+describe("pickBitrateTier", () => {
+  it("stays high on a healthy link", () => {
+    expect(pickBitrateTier({ rttMs: 40, packetsLost: 0, packetsSent: 100 })).toEqual({
+      maxBitrate: 2_500_000,
+      label: "high",
+    });
+  });
+
+  it("drops to medium when rtt climbs", () => {
+    expect(pickBitrateTier({ rttMs: 150, packetsLost: 0, packetsSent: 100 }).label).toBe(
+      "medium",
+    );
+  });
+
+  it("drops to low on packet loss", () => {
+    expect(
+      pickBitrateTier({ rttMs: 50, packetsLost: 20, packetsSent: 100 }).label,
+    ).toBe("low");
+  });
+});
+
+describe("readNetworkHints", () => {
+  it("pulls rtt and outbound video counters from stats", () => {
+    const rows = [
+      {
+        type: "candidate-pair",
+        state: "succeeded",
+        currentRoundTripTime: 0.08,
+      },
+      {
+        type: "outbound-rtp",
+        kind: "video",
+        packetsLost: 2,
+        packetsSent: 200,
+      },
+    ];
+
+    const report = {
+      forEach(cb: (stat: (typeof rows)[number]) => void) {
+        rows.forEach(cb);
+      },
+    } as unknown as RTCStatsReport;
+
+    expect(readNetworkHints(report)).toEqual({
+      rttMs: 80,
+      packetsLost: 2,
+      packetsSent: 200,
+    });
+  });
+});

--- a/src/app/sessions/[slug]/page.tsx
+++ b/src/app/sessions/[slug]/page.tsx
@@ -44,6 +44,7 @@ export default async function SessionPage({
       venue: true,
       host: {
         select: {
+          id: true,
           firstName: true,
           lastName: true,
         },
@@ -55,6 +56,7 @@ export default async function SessionPage({
               id: true,
               firstName: true,
               lastName: true,
+              imageUrl: true,
             },
           },
         },

--- a/src/app/sessions/[slug]/session-detail-client.tsx
+++ b/src/app/sessions/[slug]/session-detail-client.tsx
@@ -1,16 +1,17 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useUser } from "@clerk/nextjs";
 import {
   CalendarDays,
   Check,
   Clock3,
-  
   MapPin,
   Navigation,
   Share2,
   UsersRound,
 } from "lucide-react";
+import ScreenSharePanel from "@/components/sessions/ScreenSharePanel";
 
 type Props = {
   session: {
@@ -21,6 +22,7 @@ type Props = {
     endsAt: string;
     maxGuests: number | null;
     host: {
+      id: string;
       firstName: string | null;
       lastName: string | null;
     };
@@ -44,6 +46,7 @@ type Props = {
 };
 
 export default function SessionDetailClient({ session }: Props) {
+  const { user } = useUser();
   const [rsvps, setRsvps] = useState(session.rsvps);
   const [message, setMessage] = useState("");
   const going = useMemo(
@@ -138,6 +141,12 @@ export default function SessionDetailClient({ session }: Props) {
             </div>
 
             {message && <p className="mt-4 text-sm text-violet-200">{message}</p>}
+
+            <ScreenSharePanel
+              sessionSlug={session.slug}
+              hostId={session.host.id}
+              currentUserId={user?.id}
+            />
           </section>
 
           <aside className="space-y-6">

--- a/src/components/sessions/ScreenSharePanel.tsx
+++ b/src/components/sessions/ScreenSharePanel.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { MonitorUp, PictureInPicture2, Square } from "lucide-react";
+import { useScreenShare } from "@/hooks/useScreenShare";
+
+type Props = {
+  sessionSlug: string;
+  hostId: string;
+  currentUserId: string | null | undefined;
+};
+
+export default function ScreenSharePanel({
+  sessionSlug,
+  hostId,
+  currentUserId,
+}: Props) {
+  const isHost = !!currentUserId && currentUserId === hostId;
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [pipOn, setPipOn] = useState(false);
+
+  const {
+    sharing,
+    localStream,
+    remoteStream,
+    error,
+    pipSupported,
+    startShare,
+    stopShare,
+    requestPip,
+  } = useScreenShare({
+    roomId: `session-${sessionSlug}`,
+    userId: currentUserId,
+    isHost,
+  });
+
+  const activeStream = isHost ? localStream : remoteStream;
+  const showStage = !!activeStream;
+
+  useEffect(() => {
+    const el = videoRef.current;
+    if (!el) return;
+    el.srcObject = activeStream;
+  }, [activeStream]);
+
+  useEffect(() => {
+    function onLeave() {
+      setPipOn(false);
+    }
+    document.addEventListener("leavepictureinpicture", onLeave);
+    return () => document.removeEventListener("leavepictureinpicture", onLeave);
+  }, []);
+
+  if (!currentUserId) {
+    return null;
+  }
+
+  return (
+    <div className="mt-8 rounded-2xl border border-white/10 bg-black/25 p-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-medium text-zinc-200">Live presentation</h2>
+          <p className="mt-1 text-xs text-zinc-500">
+            {isHost
+              ? "Share your screen with everyone in this session."
+              : sharing || remoteStream
+                ? "Host is presenting — open PiP to keep watching while you work."
+                : "Waiting for the host to share their screen."}
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {isHost && !sharing && (
+            <button
+              type="button"
+              onClick={() => void startShare()}
+              className="inline-flex items-center gap-2 rounded-xl bg-cyan-600 px-4 py-2 text-sm font-medium hover:bg-cyan-500"
+            >
+              <MonitorUp className="h-4 w-4" />
+              Share screen
+            </button>
+          )}
+          {isHost && sharing && (
+            <button
+              type="button"
+              onClick={stopShare}
+              className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium hover:bg-white/10"
+            >
+              <Square className="h-4 w-4" />
+              Stop sharing
+            </button>
+          )}
+          {showStage && pipSupported && (
+            <button
+              type="button"
+              onClick={async () => {
+                const on = await requestPip(videoRef.current);
+                setPipOn(on);
+              }}
+              className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium hover:bg-white/10"
+            >
+              <PictureInPicture2 className="h-4 w-4" />
+              {pipOn ? "Exit PiP" : "Pop out"}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {error && <p className="mt-3 text-sm text-rose-300">{error}</p>}
+
+      {showStage && (
+        <video
+          ref={videoRef}
+          autoPlay
+          playsInline
+          muted={isHost}
+          className="mt-4 aspect-video w-full rounded-xl bg-black object-contain"
+        />
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useScreenShare.ts
+++ b/src/hooks/useScreenShare.ts
@@ -1,0 +1,322 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useAuth } from "@clerk/nextjs";
+import usePartySocket from "partysocket/react";
+import { adaptVideoBitrate } from "@/lib/screenShareBitrate";
+
+const ICE_SERVERS: RTCIceServer[] = [
+  { urls: "stun:stun.l.google.com:19302" },
+];
+
+type SignalKind =
+  | "share-start"
+  | "share-stop"
+  | "viewer-ready"
+  | "offer"
+  | "answer"
+  | "ice";
+
+type SignalMessage = {
+  type: "webrtc-signal";
+  kind: SignalKind;
+  from: string;
+  to?: string;
+  sdp?: RTCSessionDescriptionInit;
+  candidate?: RTCIceCandidateInit | null;
+};
+
+type Options = {
+  roomId: string;
+  userId: string | null | undefined;
+  isHost: boolean;
+};
+
+function partyHost() {
+  if (typeof window === "undefined") return "127.0.0.1:1999";
+  return process.env.NEXT_PUBLIC_PARTYKIT_HOST || "127.0.0.1:1999";
+}
+
+export function useScreenShare({ roomId, userId, isHost }: Options) {
+  const { getToken } = useAuth();
+  const [token, setToken] = useState<string | null>(null);
+  const [sharing, setSharing] = useState(false);
+  const [remoteStream, setRemoteStream] = useState<MediaStream | null>(null);
+  const [localStream, setLocalStream] = useState<MediaStream | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pipSupported, setPipSupported] = useState(false);
+
+  const localStreamRef = useRef<MediaStream | null>(null);
+  const peersRef = useRef<Map<string, RTCPeerConnection>>(new Map());
+  const bitrateTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const socketRef = useRef<{ send: (data: string) => void } | null>(null);
+
+  useEffect(() => {
+    getToken()
+      .then(setToken)
+      .catch(() => setToken(null));
+  }, [getToken]);
+
+  useEffect(() => {
+    setPipSupported(
+      typeof document !== "undefined" &&
+        "pictureInPictureEnabled" in document &&
+        !!document.pictureInPictureEnabled,
+    );
+  }, []);
+
+  const sendSignal = useCallback((msg: Omit<SignalMessage, "type" | "from">) => {
+    if (!userId || !socketRef.current) return;
+    const payload: SignalMessage = {
+      type: "webrtc-signal",
+      from: userId,
+      ...msg,
+    };
+    socketRef.current.send(JSON.stringify(payload));
+  }, [userId]);
+
+  const cleanupPeer = useCallback((peerId: string) => {
+    const pc = peersRef.current.get(peerId);
+    if (!pc) return;
+    pc.onicecandidate = null;
+    pc.ontrack = null;
+    pc.close();
+    peersRef.current.delete(peerId);
+  }, []);
+
+  const cleanupAll = useCallback(() => {
+    if (bitrateTimerRef.current) {
+      clearInterval(bitrateTimerRef.current);
+      bitrateTimerRef.current = null;
+    }
+    for (const id of [...peersRef.current.keys()]) {
+      cleanupPeer(id);
+    }
+    localStreamRef.current?.getTracks().forEach((t) => t.stop());
+    localStreamRef.current = null;
+    setLocalStream(null);
+    setRemoteStream(null);
+    setSharing(false);
+  }, [cleanupPeer]);
+
+  const ensurePeer = useCallback(
+    (peerId: string, asOfferer: boolean) => {
+      let pc = peersRef.current.get(peerId);
+      if (pc) return pc;
+
+      pc = new RTCPeerConnection({ iceServers: ICE_SERVERS });
+      peersRef.current.set(peerId, pc);
+
+      pc.onicecandidate = (ev) => {
+        sendSignal({
+          kind: "ice",
+          to: peerId,
+          candidate: ev.candidate ? ev.candidate.toJSON() : null,
+        });
+      };
+
+      pc.ontrack = (ev) => {
+        const stream = ev.streams[0] ?? new MediaStream([ev.track]);
+        setRemoteStream(stream);
+      };
+
+      const local = localStreamRef.current;
+      if (local && asOfferer) {
+        for (const track of local.getTracks()) {
+          pc.addTrack(track, local);
+        }
+      }
+
+      return pc;
+    },
+    [sendSignal],
+  );
+
+  const startBitrateLoop = useCallback(() => {
+    if (bitrateTimerRef.current) clearInterval(bitrateTimerRef.current);
+    bitrateTimerRef.current = setInterval(() => {
+      for (const pc of peersRef.current.values()) {
+        void adaptVideoBitrate(pc);
+      }
+    }, 4000);
+  }, []);
+
+  const handleSignal = useCallback(
+    async (msg: SignalMessage) => {
+      if (!userId || msg.from === userId) return;
+
+      if (msg.kind === "share-start" && !isHost) {
+        sendSignal({ kind: "viewer-ready", to: msg.from });
+        return;
+      }
+
+      if (msg.kind === "share-stop") {
+        cleanupPeer(msg.from);
+        setRemoteStream(null);
+        return;
+      }
+
+      if (msg.kind === "viewer-ready" && isHost && localStreamRef.current) {
+        if (msg.to && msg.to !== userId) return;
+        const pc = ensurePeer(msg.from, true);
+        try {
+          const offer = await pc.createOffer();
+          await pc.setLocalDescription(offer);
+          sendSignal({
+            kind: "offer",
+            to: msg.from,
+            sdp: pc.localDescription ?? offer,
+          });
+        } catch {
+          cleanupPeer(msg.from);
+        }
+        return;
+      }
+
+      if (msg.kind === "offer" && msg.to === userId) {
+        const pc = ensurePeer(msg.from, false);
+        try {
+          await pc.setRemoteDescription(msg.sdp!);
+          const answer = await pc.createAnswer();
+          await pc.setLocalDescription(answer);
+          sendSignal({
+            kind: "answer",
+            to: msg.from,
+            sdp: pc.localDescription ?? answer,
+          });
+        } catch {
+          cleanupPeer(msg.from);
+        }
+        return;
+      }
+
+      if (msg.kind === "answer" && msg.to === userId) {
+        const pc = peersRef.current.get(msg.from);
+        if (!pc) return;
+        try {
+          await pc.setRemoteDescription(msg.sdp!);
+        } catch {
+          cleanupPeer(msg.from);
+        }
+        return;
+      }
+
+      if (msg.kind === "ice" && msg.to === userId && msg.candidate) {
+        const pc = peersRef.current.get(msg.from);
+        if (!pc) return;
+        try {
+          await pc.addIceCandidate(msg.candidate);
+        } catch {
+          // Candidate can arrive early; fine to drop.
+        }
+      }
+    },
+    [userId, isHost, sendSignal, ensurePeer, cleanupPeer],
+  );
+
+  const socket = usePartySocket({
+    host: partyHost(),
+    room: roomId,
+    query: token ? { token } : undefined,
+    onOpen() {
+      // Late joiners: poke the host in case a share is already running.
+      if (userId && !isHost) {
+        sendSignal({ kind: "viewer-ready" });
+      }
+    },
+    onMessage(event) {
+      try {
+        const data = JSON.parse(event.data) as SignalMessage;
+        if (data.type !== "webrtc-signal") return;
+        void handleSignal(data);
+      } catch {
+        // ignore non-json
+      }
+    },
+  });
+
+  useEffect(() => {
+    socketRef.current = socket;
+  }, [socket]);
+
+  useEffect(() => {
+    return () => {
+      cleanupAll();
+    };
+  }, [cleanupAll]);
+
+  const startShare = useCallback(async () => {
+    if (!isHost || !userId) {
+      setError("Only the session host can share their screen.");
+      return;
+    }
+    if (!navigator.mediaDevices?.getDisplayMedia) {
+      setError("Screen sharing is not supported in this browser.");
+      return;
+    }
+
+    setError(null);
+
+    try {
+      const stream = await navigator.mediaDevices.getDisplayMedia({
+        video: { frameRate: 15 },
+        audio: true,
+      });
+
+      localStreamRef.current = stream;
+      setLocalStream(stream);
+      setSharing(true);
+
+      const [videoTrack] = stream.getVideoTracks();
+      if (videoTrack) {
+        videoTrack.onended = () => {
+          sendSignal({ kind: "share-stop" });
+          cleanupAll();
+        };
+      }
+
+      sendSignal({ kind: "share-start" });
+      startBitrateLoop();
+    } catch (err) {
+      const name = err instanceof Error ? err.name : "";
+      if (name === "NotAllowedError") {
+        setError("Screen capture permission was denied.");
+      } else {
+        setError("Could not start screen share.");
+      }
+      cleanupAll();
+    }
+  }, [isHost, userId, sendSignal, cleanupAll, startBitrateLoop]);
+
+  const stopShare = useCallback(() => {
+    sendSignal({ kind: "share-stop" });
+    cleanupAll();
+  }, [sendSignal, cleanupAll]);
+
+  const requestPip = useCallback(async (video: HTMLVideoElement | null) => {
+    if (!video) return false;
+    if (!document.pictureInPictureEnabled) return false;
+    try {
+      if (document.pictureInPictureElement === video) {
+        await document.exitPictureInPicture();
+        return false;
+      }
+      await video.requestPictureInPicture();
+      return true;
+    } catch {
+      setError("Picture-in-picture failed.");
+      return false;
+    }
+  }, []);
+
+  return {
+    sharing,
+    localStream,
+    remoteStream,
+    error,
+    pipSupported,
+    startShare,
+    stopShare,
+    requestPip,
+  };
+}

--- a/src/lib/screenShareBitrate.ts
+++ b/src/lib/screenShareBitrate.ts
@@ -1,0 +1,75 @@
+/**
+ * Pick a max video bitrate from outbound/candidate-pair stats.
+ * Used while screen sharing so we don't blow up slow peers.
+ */
+
+export type BitrateTier = {
+  maxBitrate: number;
+  label: "high" | "medium" | "low";
+};
+
+const HIGH: BitrateTier = { maxBitrate: 2_500_000, label: "high" };
+const MEDIUM: BitrateTier = { maxBitrate: 1_000_000, label: "medium" };
+const LOW: BitrateTier = { maxBitrate: 400_000, label: "low" };
+
+export function pickBitrateTier(input: {
+  rttMs?: number;
+  packetsLost?: number;
+  packetsSent?: number;
+}): BitrateTier {
+  const rtt = input.rttMs ?? 0;
+  const sent = input.packetsSent ?? 0;
+  const lost = input.packetsLost ?? 0;
+  const lossRatio = sent > 0 ? lost / sent : 0;
+
+  if (rtt > 250 || lossRatio > 0.08) return LOW;
+  if (rtt > 120 || lossRatio > 0.03) return MEDIUM;
+  return HIGH;
+}
+
+/** Read rough RTT / loss from an RTCPeerConnection stats report. */
+export function readNetworkHints(
+  report: RTCStatsReport,
+): { rttMs?: number; packetsLost?: number; packetsSent?: number } {
+  let rttMs: number | undefined;
+  let packetsLost: number | undefined;
+  let packetsSent: number | undefined;
+
+  report.forEach((stat) => {
+    if (stat.type === "candidate-pair" && stat.state === "succeeded") {
+      if (typeof stat.currentRoundTripTime === "number") {
+        rttMs = stat.currentRoundTripTime * 1000;
+      }
+    }
+    if (stat.type === "outbound-rtp" && stat.kind === "video") {
+      if (typeof stat.packetsLost === "number") packetsLost = stat.packetsLost;
+      if (typeof stat.packetsSent === "number") packetsSent = stat.packetsSent;
+    }
+  });
+
+  return { rttMs, packetsLost, packetsSent };
+}
+
+export async function adaptVideoBitrate(
+  pc: RTCPeerConnection,
+): Promise<BitrateTier | null> {
+  const sender = pc.getSenders().find((s) => s.track?.kind === "video");
+  if (!sender) return null;
+
+  const hints = readNetworkHints(await pc.getStats());
+  const tier = pickBitrateTier(hints);
+  const params = sender.getParameters();
+
+  if (!params.encodings?.length) {
+    params.encodings = [{}];
+  }
+  params.encodings[0].maxBitrate = tier.maxBitrate;
+
+  try {
+    await sender.setParameters(params);
+  } catch {
+    // Some browsers reject mid-flight tweaks; ignore and keep going.
+  }
+
+  return tier;
+}


### PR DESCRIPTION
## Summary
- Lets session hosts capture their screen with `getDisplayMedia` and stream it to members over WebRTC
- Signals SDP/ICE through PartyKit and adapts outbound video bitrate from peer network stats
- Adds a pop-out picture-in-picture control on the live presentation player
- Hardens signaling by verifying authenticated identity before broadcasting `webrtc-signal` messages

Closes #907

## Test plan
- [ ] `npm test -- --testPathPattern='screenShareBitrate|useScreenShare'`
- [ ] Host on `/sessions/[slug]` → Share screen → permission prompt works
- [ ] Second signed-in member sees the stream; Pop out opens PiP
- [ ] Stop sharing / browser stop-share clears the remote video

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added screen sharing to session pages, with host controls and viewer playback.
  * Added Picture-in-Picture support for screen-sharing video.
  * Improved screen-sharing quality by adapting video bitrate to network conditions.
* **Bug Fixes**
  * Strengthened signaling validation to prevent unauthorized WebRTC messages.
* **Tests**
  * Added coverage for screen sharing, Picture-in-Picture, signaling behavior, and adaptive bitrate selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->