### PR TITLE
fix: use microsecond stamps in Redis rate limit Lua

### DIFF
--- a/src/__tests__/lib/rateLimit.test.ts
+++ b/src/__tests__/lib/rateLimit.test.ts
@@ -1,8 +1,28 @@
-import { rateLimit, getRateLimitInfo, resetRateLimit } from "@/lib/rateLimit";
+import {
+  rateLimit,
+  getRateLimitInfo,
+  resetRateLimit,
+  resetRedisScripts,
+  microTimestampMember,
+} from "@/lib/rateLimit";
+
+const evalMock = jest.fn();
+
+jest.mock("@upstash/redis", () => ({
+  Redis: jest.fn().mockImplementation(() => ({
+    createScript: () => ({
+      eval: (...args: unknown[]) => evalMock(...args),
+    }),
+  })),
+}));
 
 describe("Rate Limiting", () => {
   beforeEach(() => {
     resetRateLimit();
+    resetRedisScripts();
+    evalMock.mockReset();
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
   });
 
   it("should allow requests under the limit", async () => {
@@ -71,5 +91,65 @@ describe("Rate Limiting", () => {
     expect(info?.count).toBe(5);
     expect(info?.remaining).toBe(0);
     expect(info?.isLimited).toBe(true);
+  });
+});
+
+describe("microTimestampMember", () => {
+  it("stringifies sec+usec so same-ms hits stay unique", () => {
+    const a = microTimestampMember(1700000000, 12, "a");
+    const b = microTimestampMember(1700000000, 13, "a");
+    expect(a).toBe("1700000000000012:a");
+    expect(b).toBe("1700000000000013:a");
+    expect(a).not.toBe(b);
+  });
+
+  it("pads usec to 6 digits", () => {
+    expect(microTimestampMember("100", 5, "x")).toBe("100000005:x");
+  });
+});
+
+describe("Redis sliding window path", () => {
+  beforeEach(() => {
+    resetRateLimit();
+    resetRedisScripts();
+    evalMock.mockReset();
+    process.env.UPSTASH_REDIS_REST_URL = "https://example.upstash.io";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "test-token";
+  });
+
+  afterEach(() => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    resetRedisScripts();
+  });
+
+  it("blocks after the Lua script returns 0", async () => {
+    let hits = 0;
+    evalMock.mockImplementation(async () => {
+      hits += 1;
+      return hits <= 3 ? 1 : 0;
+    });
+
+    expect(await rateLimit("redis-ip", 3)).toBe(true);
+    expect(await rateLimit("redis-ip", 3)).toBe(true);
+    expect(await rateLimit("redis-ip", 3)).toBe(true);
+    expect(await rateLimit("redis-ip", 3)).toBe(false);
+    expect(evalMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("passes a unique nonce on each same-ms call", async () => {
+    evalMock.mockResolvedValue(1);
+
+    await Promise.all([
+      rateLimit("burst-ip", 10),
+      rateLimit("burst-ip", 10),
+      rateLimit("burst-ip", 10),
+    ]);
+
+    expect(evalMock).toHaveBeenCalledTimes(3);
+    const nonces = evalMock.mock.calls.map(
+      (call) => (call[1] as string[])[2],
+    );
+    expect(new Set(nonces).size).toBe(3);
   });
 });

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -5,9 +5,54 @@
  * Development: Falls back to an in-memory sliding window automatically
  */
 
-const upstashLimiters = new Map<number, any>();
+const WINDOW_MS = 60_000;
 
-function getUpstashRatelimit(limitPerMinute: number) {
+// ZSET sliding window. Member = stringified microsecond stamp so concurrent
+// hits in the same ms don't collide / get dropped under load.
+const SLIDING_WINDOW_LUA = `
+local key = KEYS[1]
+local limit = tonumber(ARGV[1])
+local windowMs = tonumber(ARGV[2])
+local nonce = ARGV[3]
+
+local t = redis.call("TIME")
+local sec = t[1]
+local usec = t[2]
+local nowMs = tonumber(sec) * 1000 + math.floor(tonumber(usec) / 1000)
+local member = sec .. string.format("%06d", tonumber(usec)) .. ":" .. nonce
+
+redis.call("ZREMRANGEBYSCORE", key, "-inf", nowMs - windowMs)
+local count = redis.call("ZCARD", key)
+if count >= limit then
+  return 0
+end
+
+redis.call("ZADD", key, nowMs, member)
+redis.call("PEXPIRE", key, windowMs)
+return 1
+`;
+
+/** ZSET member id used by the Lua script (exported for tests). */
+export function microTimestampMember(
+  sec: string | number,
+  usec: string | number,
+  nonce: string,
+): string {
+  const u = String(usec).padStart(6, "0");
+  return `${sec}${u}:${nonce}`;
+}
+
+type RedisScript = {
+  eval: (keys: string[], args: string[]) => Promise<unknown>;
+};
+
+type RedisClient = {
+  createScript: (script: string) => RedisScript;
+};
+
+const scriptByLimit = new Map<number, RedisScript>();
+
+function getRedisScript(limitPerMinute: number): RedisScript | null {
   if (
     !process.env.UPSTASH_REDIS_REST_URL ||
     !process.env.UPSTASH_REDIS_REST_TOKEN
@@ -15,67 +60,44 @@ function getUpstashRatelimit(limitPerMinute: number) {
     return null;
   }
 
+  const cached = scriptByLimit.get(limitPerMinute);
+  if (cached) return cached;
+
   try {
-    // Dynamic require so the build doesn't fail if packages aren't present yet
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { Ratelimit } = require("@upstash/ratelimit");
+    // Dynamic require so jest doesn't pull in @upstash/redis ESM
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { Redis } = require("@upstash/redis");
 
     const redis = new Redis({
       url: process.env.UPSTASH_REDIS_REST_URL,
       token: process.env.UPSTASH_REDIS_REST_TOKEN,
-    });
+    }) as RedisClient;
 
-    return {
-      limit: async (identifier: string) => {
-        const key = `worksphere:ratelimit:${identifier}`;
-        const now = Date.now();
-        // Atomic Lua script for token bucket evaluation
-        const script = `
-          local key = KEYS[1]
-          local limit = tonumber(ARGV[1])
-          local now = tonumber(ARGV[2])
-
-          local state = redis.call("HMGET", key, "tokens", "last_refill")
-          local tokens = tonumber(state[1])
-          local last_refill = tonumber(state[2])
-
-          if not tokens then
-            tokens = limit
-            last_refill = now
-          else
-            local elapsed = math.max(0, now - last_refill)
-            local new_tokens = math.floor(elapsed * (limit / 60000))
-            if new_tokens > 0 then
-              tokens = math.min(limit, tokens + new_tokens)
-              last_refill = last_refill + (new_tokens * (60000 / limit))
-            end
-          end
-
-          if tokens > 0 then
-            redis.call("HMSET", key, "tokens", tokens - 1, "last_refill", last_refill)
-            redis.call("PEXPIRE", key, 60000)
-            return { 1, tokens - 1 }
-          else
-            return { 0, tokens }
-          end
-        `;
-        try {
-          const result = await redis.eval(script, [key], [limitPerMinute, now]);
-          return {
-            success: result[0] === 1,
-            remaining: result[1],
-            reset: now + 60000,
-          };
-        } catch (e) {
-          console.error("Redis ratelimit eval error", e);
-          // Fail open
-          return { success: true, remaining: 1, reset: now + 60000 };
-        }
-      }
-    };
+    const script = redis.createScript(SLIDING_WINDOW_LUA);
+    scriptByLimit.set(limitPerMinute, script);
+    return script;
   } catch {
+    return null;
+  }
+}
+
+async function redisSlidingWindow(
+  identifier: string,
+  limit: number,
+): Promise<boolean | null> {
+  const script = getRedisScript(limit);
+  if (!script) return null;
+
+  try {
+    const key = `worksphere:ratelimit:${limit}:${identifier}`;
+    const nonce = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+    const result = await script.eval(
+      [key],
+      [String(limit), String(WINDOW_MS), nonce],
+    );
+    return Number(result) === 1;
+  } catch (err) {
+    console.error("[rateLimit] redis eval failed, falling back to memory", err);
     return null;
   }
 }
@@ -86,7 +108,6 @@ interface MemEntry {
   resetTime: number;
 }
 const memStore = new Map<string, MemEntry>();
-const WINDOW_MS = 60_000;
 
 interface RateLimitInfo {
   count: number;
@@ -96,7 +117,6 @@ interface RateLimitInfo {
 }
 const rateLimitInfoStore = new Map<string, RateLimitInfo>();
 
-// Run cleanup in the background instead of on the request path.
 const CLEANUP_INTERVAL_MS = 60_000;
 
 function cleanupExpiredEntries() {
@@ -115,7 +135,6 @@ function cleanupExpiredEntries() {
   }
 }
 
-// Start a single background cleanup task.
 const globalCleanup = globalThis as typeof globalThis & {
   __rateLimitCleanupTimer?: NodeJS.Timeout;
 };
@@ -176,17 +195,9 @@ export async function rateLimit(
   identifier: string,
   limit = 10,
 ): Promise<boolean> {
-  let rl = upstashLimiters.get(limit);
-  if (!rl) {
-    rl = getUpstashRatelimit(limit);
-    if (rl) {
-      upstashLimiters.set(limit, rl);
-    }
-  }
-
-  if (rl) {
-    const { success } = await rl.limit(identifier);
-    return success;
+  const redisResult = await redisSlidingWindow(identifier, limit);
+  if (redisResult !== null) {
+    return redisResult;
   }
 
   return memRateLimit(identifier, limit);
@@ -213,4 +224,9 @@ export function resetRateLimit(identifier?: string): void {
     memStore.clear();
     rateLimitInfoStore.clear();
   }
+}
+
+/** Clear cached Redis scripts (tests). */
+export function resetRedisScripts(): void {
+  scriptByLimit.clear();
 }


### PR DESCRIPTION
## Summary
- Replaces the Redis rate limiter with a Lua ZSET sliding window using stringified microsecond member ids so concurrent same-ms hits don't collide under load
- Keeps the in-memory fallback when Upstash env vars are missing
- Adds tests for the Redis Lua path (mock) plus microsecond member formatting

Closes #913

## Test plan
- [ ] `npm test -- --testPathPattern='rateLimit.test|api/venues.test'`
- [ ] `npx eslint src/lib/rateLimit.ts src/__tests__/lib/rateLimit.test.ts`
- [ ] With Upstash env set, burst `/api/venues` and confirm it no longer 429s prematurely
- [ ] Without Redis env, memory fallback still enforces the limit



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved distributed rate limiting with more accurate sliding-window enforcement.
  * Ensured simultaneous requests receive unique identifiers, preventing incorrect request grouping.
  * Added a reliable in-memory fallback when Redis is unavailable or encounters an error.

* **Tests**
  * Expanded coverage for Redis-based rate limiting, blocking behavior, timestamp formatting, and concurrent requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->