### PR TITLE
[Feature]: display real-time open/closed status badges on venue cards

### DIFF
--- a/src/components/VenueCard.tsx
+++ b/src/components/VenueCard.tsx
@@ -549,10 +549,49 @@ export function VenueCard({
         )}
 
         {/* Hours */}
-        {enrichData?.opening_hours && (
+        {(enrichData?.opening_hours || venue.openingHours) && (
           <div className="flex items-center gap-2 mb-3 text-xs text-zinc-600 dark:text-zinc-400">
             <Clock className="w-3 h-3 shrink-0" />
-            <span>{enrichData.opening_hours}</span>
+            <span>{enrichData?.opening_hours || venue.openingHours}</span>
+            {(() => {
+              const hoursStr = enrichData?.opening_hours || venue.openingHours;
+              if (!hoursStr) return null;
+              const match = hoursStr.match(
+                /(\d{1,2}:\d{2})\s*-\s*(\d{1,2}:\d{2})/,
+              );
+              if (!match) return null;
+
+              const now = new Date();
+              const currentMinutes = now.getHours() * 60 + now.getMinutes();
+              const [openH, openM] = match[1].split(":").map(Number);
+              const [closeH, closeM] = match[2].split(":").map(Number);
+
+              const openMinutes = openH * 60 + openM;
+              const closeMinutes = closeH * 60 + closeM;
+
+              let isOpen = false;
+              if (closeMinutes < openMinutes) {
+                isOpen =
+                  currentMinutes >= openMinutes ||
+                  currentMinutes <= closeMinutes;
+              } else {
+                isOpen =
+                  currentMinutes >= openMinutes &&
+                  currentMinutes < closeMinutes;
+              }
+
+              return (
+                <span
+                  className={`px-2 py-0.5 rounded-full font-semibold ${
+                    isOpen
+                      ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                      : "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400"
+                  }`}
+                >
+                  {isOpen ? "Open Now" : "Closed"}
+                </span>
+              );
+            })()}
           </div>
         )}
 

--- a/src/components/chat/ChatMessages.tsx
+++ b/src/components/chat/ChatMessages.tsx
@@ -68,6 +68,7 @@ export interface Venue {
   hasQuietZone?: boolean;
   hasAncHeadsetRental?: boolean;
   outletLocations?: string[];
+  openingHours?: string;
 }
 
 export interface Message {
@@ -255,6 +256,47 @@ export function VenueChatCard({
             </div>
 
             <div className="flex items-center gap-2 shrink-0">
+              {venue.openingHours &&
+                (() => {
+                  const match = venue.openingHours.match(
+                    /(\d{1,2}:\d{2})\s*-\s*(\d{1,2}:\d{2})/,
+                  );
+                  if (!match) return null;
+                  const now = new Date();
+                  const currentMinutes = now.getHours() * 60 + now.getMinutes();
+                  const [openH, openM] = match[1].split(":").map(Number);
+                  const [closeH, closeM] = match[2].split(":").map(Number);
+                  const openMinutes = openH * 60 + openM;
+                  const closeMinutes = closeH * 60 + closeM;
+                  let isOpen = false;
+                  if (closeMinutes < openMinutes) {
+                    isOpen =
+                      currentMinutes >= openMinutes ||
+                      currentMinutes <= closeMinutes;
+                  } else {
+                    isOpen =
+                      currentMinutes >= openMinutes &&
+                      currentMinutes < closeMinutes;
+                  }
+                  return (
+                    <div
+                      className={`flex items-center gap-1 px-1.5 py-0.5 rounded border ${
+                        isOpen
+                          ? "bg-green-500/10 border-green-500/20"
+                          : "bg-red-500/10 border-red-500/20"
+                      }`}
+                    >
+                      <Clock
+                        className={`w-3 h-3 ${isOpen ? "text-green-600" : "text-red-600"}`}
+                      />
+                      <span
+                        className={`text-[9px] font-bold uppercase ${isOpen ? "text-green-600" : "text-red-600"}`}
+                      >
+                        {isOpen ? "Open Now" : "Closed"}
+                      </span>
+                    </div>
+                  );
+                })()}
               {venue.wifi && (
                 <div className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-green-500/10 border border-green-500/20">
                   <Wifi className="w-3 h-3 text-green-600" />
@@ -441,6 +483,48 @@ export function VenueChatCard({
               )}
 
               <div className="flex flex-wrap items-center gap-2 mt-2">
+                {venue.openingHours &&
+                  (() => {
+                    const match = venue.openingHours.match(
+                      /(\d{1,2}:\d{2})\s*-\s*(\d{1,2}:\d{2})/,
+                    );
+                    if (!match) return null;
+                    const now = new Date();
+                    const currentMinutes =
+                      now.getHours() * 60 + now.getMinutes();
+                    const [openH, openM] = match[1].split(":").map(Number);
+                    const [closeH, closeM] = match[2].split(":").map(Number);
+                    const openMinutes = openH * 60 + openM;
+                    const closeMinutes = closeH * 60 + closeM;
+                    let isOpen = false;
+                    if (closeMinutes < openMinutes) {
+                      isOpen =
+                        currentMinutes >= openMinutes ||
+                        currentMinutes <= closeMinutes;
+                    } else {
+                      isOpen =
+                        currentMinutes >= openMinutes &&
+                        currentMinutes < closeMinutes;
+                    }
+                    return (
+                      <div
+                        className={`flex items-center gap-1 px-1.5 py-0.5 rounded-md border ${
+                          isOpen
+                            ? "bg-green-500/10 border-green-500/20"
+                            : "bg-red-500/10 border-red-500/20"
+                        }`}
+                      >
+                        <Clock
+                          className={`w-3 h-3 ${isOpen ? "text-green-600" : "text-red-600"}`}
+                        />
+                        <span
+                          className={`text-[10px] font-bold uppercase ${isOpen ? "text-green-600" : "text-red-600"}`}
+                        >
+                          {isOpen ? "Open Now" : "Closed"}
+                        </span>
+                      </div>
+                    );
+                  })()}
                 {venue.wifi && (
                   <div className="flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-green-500/10 border border-green-500/20">
                     <Wifi className="w-3 h-3 text-green-600" />

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -9,6 +9,7 @@ export interface MapMarker {
   rating?: number;
   score?: number;
   wifiQuality?: number;
+  openingHours?: string;
   hasOutlets?: boolean;
   powerTypes?: string[];
   petsAllowedIndoors?: boolean;


### PR DESCRIPTION
- closes #667

### Description
This PR implements real-time open/closed status badges across all venue card components, allowing users to immediately identify if a workspace is currently open based on their local time.

### Changes Made
- **MapMarker Types**: Added the `openingHours` optional property to the core `MapMarker` and chat `Venue` interfaces (`src/types/map.ts`, `ChatMessages.tsx`) to support storing operational hours.
- **VenueCard Component**: Implemented a localized parsing utility to evaluate the `openingHours` string against the user's current local time, rendering an inline "Open Now" (green) or "Closed" (red) status badge.
- **ChatMessages Component**: Extended the same real-time hours evaluation logic to the AI assistant's inline venue grid cards for a cohesive user experience.

###
 
<img width="2878" height="1482" alt="image" src="https://github.com/user-attachments/assets/695d8a72-3326-48fd-a2ab-c30192764847" />

### Testing Instructions
1. Run the app locally (`npm run dev`).
2. Search for venues on the map or ask the AI assistant for recommendations.
3. Observe the "Open Now" / "Closed" badges alongside the venue hours in the venue cards. 
4. The logic accurately accounts for edge cases where a venue's closing time extends past midnight.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Open Now” and “Closed” status indicators to venue cards and chat results.
  * Venue hours now display from available venue data, with support for overnight hours.
  * Opening hours are now available across venue map markers and listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->