### PR TITLE
fix: implement rate limiting on auth, chat, and venues endpoints

### DIFF
--- a/src/__tests__/api/partykit-auth.test.ts
+++ b/src/__tests__/api/partykit-auth.test.ts
@@ -1,0 +1,53 @@
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/partykit/auth/route";
+import { prisma } from "@/lib/prisma";
+import { resetRateLimit } from "@/lib/rateLimit";
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    folderMember: {
+      findUnique: jest.fn(),
+    },
+    folder: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+describe("GET /api/partykit/auth - Rate Limiting", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetRateLimit();
+  });
+
+  it("should allow requests under the limit (30 req/min)", async () => {
+    (prisma.folderMember.findUnique as jest.Mock).mockResolvedValue(null);
+    (prisma.folder.findUnique as jest.Mock).mockResolvedValue(null);
+
+    for (let i = 0; i < 30; i++) {
+      const req = new NextRequest(
+        "http://localhost/api/partykit/auth?userId=u1&folderId=f1",
+      );
+      const res = await GET(req);
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("should return 429 when exceeding the limit (30 req/min)", async () => {
+    (prisma.folderMember.findUnique as jest.Mock).mockResolvedValue(null);
+    (prisma.folder.findUnique as jest.Mock).mockResolvedValue(null);
+
+    let lastRes;
+    for (let i = 0; i < 31; i++) {
+      const req = new NextRequest(
+        "http://localhost/api/partykit/auth?userId=u1&folderId=f1",
+      );
+      lastRes = await GET(req);
+    }
+
+    expect(lastRes!.status).toBe(429);
+    const data = await lastRes!.json();
+    expect(data.error).toMatch(/too many/i);
+    expect(data.retryAfter).toBeDefined();
+  });
+});

--- a/src/__tests__/api/venues.test.ts
+++ b/src/__tests__/api/venues.test.ts
@@ -159,7 +159,7 @@ describe("GET /api/venues - Rate limiting (#717)", () => {
 
   it("returns 429 with a retryAfter once the caller exceeds the limit", async () => {
     let lastRes;
-    for (let i = 0; i < 121; i++) {
+    for (let i = 0; i < 61; i++) {
       const req = new NextRequest(`http://localhost/api/venues?limit=5`);
       lastRes = await GET(req);
     }
@@ -172,7 +172,7 @@ describe("GET /api/venues - Rate limiting (#717)", () => {
   });
 
   it("does not touch the database once a request is rate limited", async () => {
-    for (let i = 0; i < 121; i++) {
+    for (let i = 0; i < 61; i++) {
       const req = new NextRequest(`http://localhost/api/venues?limit=5`);
       await GET(req);
     }

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -943,8 +943,8 @@ export async function POST(req: Request) {
     const identifier = userId || forwarded?.split(",")[0] || "anonymous";
 
     // Rate limiting (now async)
-    if (!(await rateLimit(identifier, 20))) {
-      const info = await getRateLimitInfo(identifier);
+    if (!(await rateLimit(identifier, 10))) {
+      const info = await getRateLimitInfo(identifier, 10);
       return Response.json(
         {
           error:

--- a/src/app/api/partykit/auth/route.ts
+++ b/src/app/api/partykit/auth/route.ts
@@ -1,9 +1,32 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { rateLimit, getRateLimitInfo } from "@/lib/rateLimit";
 
 // Internal endpoint for PartyKit to verify user roles.
 // In production, you should secure this with a shared secret to prevent abuse.
 export async function GET(req: NextRequest) {
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0].trim() ??
+    req.headers.get("x-real-ip") ??
+    "anonymous";
+  const identifier = `partykit-auth:${ip}`;
+
+  const allowed = await rateLimit(identifier, 30);
+  if (!allowed) {
+    const info = await getRateLimitInfo(identifier, 30);
+    const retryAfter = info?.resetTime
+      ? Math.ceil((info.resetTime - Date.now()) / 1000)
+      : 60;
+
+    return NextResponse.json(
+      {
+        error: "Too many authentication requests. Please try again later.",
+        retryAfter,
+      },
+      { status: 429, headers: { "Retry-After": String(retryAfter) } },
+    );
+  }
+
   const { searchParams } = new URL(req.url);
   const userId = searchParams.get("userId");
   const folderId = searchParams.get("folderId");

--- a/src/app/api/venues/route.ts
+++ b/src/app/api/venues/route.ts
@@ -15,7 +15,7 @@ import { rateLimit, getRateLimitInfo } from "@/lib/rateLimit";
 // that legitimate traffic almost immediately, so this endpoint uses a much higher,
 // burst-tolerant ceiling — generous enough for fast typing, still low enough to stop
 // scripted abuse. See #717.
-const VENUE_SEARCH_RATE_LIMIT = 120;
+const VENUE_SEARCH_RATE_LIMIT = 60;
 
 // GET /api/venues - Search venues
 export async function GET(req: NextRequest) {


### PR DESCRIPTION
## Description

This PR implements rate limiting using the existing Upstash/in-memory rate limit infrastructure to prevent brute-forcing, resource exhaustion, and high LLM cost abuse on public endpoints:

- **PartyKit Auth (`/api/partykit/auth`)**: Applied a rate limit of 30 req/min per IP.
- **Chat Assistant (`/api/chat`)**: Adjusted the rate limit from 20 to 10 req/min per user/IP. Added correct parameterization to `getRateLimitInfo` to prevent returning information for the default limit of 10 instead of the actual route limit.
- **Venue Search (`/api/venues`)**: Adjusted the rate limit from 120 to 60 req/min per user/IP.

## Related Issue

Fixes #982

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

N/A

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rate limiting to PartyKit authentication and role-verification requests.
  * Rate-limit responses include a retry interval and `Retry-After` header.

* **Bug Fixes**
  * Tightened request limits for chat and venue searches.
  * Prevented further database access after venue-search requests are rate limited.

* **Tests**
  * Added coverage confirming authentication requests are allowed within limits and rejected with HTTP 429 when exceeded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->