### PR TITLE
fix: webAuthn passkey assertion failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -174,6 +174,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -923,6 +924,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -946,6 +948,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -961,7 +964,8 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.1.tgz",
       "integrity": "sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.1.1",
@@ -982,28 +986,6 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "@electric-sql/pglite": "0.4.1"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -3382,6 +3364,7 @@
       "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.61.1"
       },
@@ -9151,6 +9134,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -9565,6 +9549,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -9575,6 +9560,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -9706,6 +9692,7 @@
       "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.64.0",
         "@typescript-eslint/types": "8.64.0",
@@ -10296,6 +10283,7 @@
       "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.0.tgz",
       "integrity": "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "uncrypto": "^0.1.3"
       }
@@ -10330,6 +10318,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -11044,6 +11033,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001803",
@@ -12604,6 +12594,7 @@
       "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -12735,6 +12726,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -14038,6 +14030,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
       "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -14176,6 +14169,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "typescript": "^5 || ^6 || ^7"
       },
@@ -15021,6 +15015,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -16204,6 +16199,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -16430,7 +16426,8 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/leaflet.heat": {
       "version": "0.2.0",
@@ -17300,6 +17297,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
       "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.2.10",
         "@swc/helpers": "0.5.15",
@@ -17988,6 +17986,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
       "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
@@ -18415,6 +18414,7 @@
       "integrity": "sha512-yfN4yrw7HV9kEJhoy1+jgah0jafEIQsf7uWouSsM8MvJtlubsk+kM7AIBWZ8+GJl74Yj3c+nbYqBkMOxtsZ3Lw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "7.8.0",
         "@prisma/dev": "0.24.3",
@@ -18874,6 +18874,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18883,6 +18884,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -18944,7 +18946,8 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
       "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-is-18": {
       "name": "react-is",
@@ -19003,6 +19006,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -19151,7 +19155,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -20315,6 +20320,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -20718,6 +20724,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21367,6 +21374,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
       "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -21443,6 +21451,7 @@
       "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
       "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lib0": "^0.2.85"
       },
@@ -21558,6 +21567,7 @@
       "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.31.tgz",
       "integrity": "sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lib0": "^0.2.99"
       },
@@ -21624,6 +21634,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/__tests__/lib/webauthn.test.ts
+++ b/src/__tests__/lib/webauthn.test.ts
@@ -1,17 +1,48 @@
 import {
+  isMobileWebview,
   isOriginAllowedForRpId,
   normalizeRpId,
   parseClientDataJSON,
   verifyWebAuthnChallenge,
 } from "@/lib/webauthn";
+import { getExpectedOrigin } from "@/lib/passkey";
 
 function toClientDataJSON(data: object): string {
   const json = JSON.stringify(data);
   const bytes = new TextEncoder().encode(json);
   let binary = "";
   for (const b of bytes) binary += String.fromCharCode(b);
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
 }
+
+describe("isMobileWebview", () => {
+  const ios175WKWebViewUA =
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148";
+  const iosCustomAppUA =
+    "Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 WorkSphereApp/1.0";
+  const iosSafariUA =
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1";
+  const desktopChromeUA =
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+  const androidWebviewUA =
+    "Mozilla/5.0 (Linux; U; Android 14; en-us; Pixel 8 Build/UD1A.230803.022) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/120.0.6099.144 Mobile Safari/537.36 wv";
+
+  it("identifies iOS 17.5 WKWebView embeds as mobile webview", () => {
+    expect(isMobileWebview(ios175WKWebViewUA)).toBe(true);
+    expect(isMobileWebview(iosCustomAppUA)).toBe(true);
+    expect(isMobileWebview(androidWebviewUA)).toBe(true);
+  });
+
+  it("returns false for standard desktop and mobile browsers", () => {
+    expect(isMobileWebview(iosSafariUA)).toBe(false);
+    expect(isMobileWebview(desktopChromeUA)).toBe(false);
+    expect(isMobileWebview(null)).toBe(false);
+    expect(isMobileWebview(undefined)).toBe(false);
+  });
+});
 
 describe("normalizeRpId", () => {
   const prev = process.env.WEBAUTHN_RP_ID;
@@ -33,7 +64,9 @@ describe("normalizeRpId", () => {
     expect(normalizeRpId("https://staging.worksphere.app")).toBe(
       "worksphere.app",
     );
-    expect(normalizeRpId("https://embed.worksphere.app")).toBe("worksphere.app");
+    expect(normalizeRpId("https://embed.worksphere.app")).toBe(
+      "worksphere.app",
+    );
   });
 
   it("keeps localhost as-is", () => {
@@ -43,30 +76,61 @@ describe("normalizeRpId", () => {
 });
 
 describe("isOriginAllowedForRpId", () => {
+  const ios175WKWebViewUA =
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148";
+
   it("allows the apex and its subdomains", () => {
     expect(
       isOriginAllowedForRpId("https://worksphere.app", "worksphere.app"),
     ).toBe(true);
     expect(
-      isOriginAllowedForRpId("https://staging.worksphere.app", "worksphere.app"),
+      isOriginAllowedForRpId(
+        "https://staging.worksphere.app",
+        "worksphere.app",
+      ),
     ).toBe(true);
     expect(
-      isOriginAllowedForRpId("https://foo.bar.worksphere.app", "worksphere.app"),
+      isOriginAllowedForRpId(
+        "https://foo.bar.worksphere.app",
+        "worksphere.app",
+      ),
     ).toBe(true);
   });
 
-  it("rejects unrelated hosts", () => {
+  it("rejects unrelated hosts for standard user agent", () => {
     expect(
       isOriginAllowedForRpId("https://evil.example.com", "worksphere.app"),
     ).toBe(false);
     expect(
-      isOriginAllowedForRpId("https://worksphere.app.evil.com", "worksphere.app"),
+      isOriginAllowedForRpId(
+        "https://worksphere.app.evil.com",
+        "worksphere.app",
+      ),
     ).toBe(false);
+  });
+
+  it("relaxes exact match origin check for recognized mobile webview user agents", () => {
+    expect(
+      isOriginAllowedForRpId(
+        "ios-app://custom-wrapper",
+        "worksphere.app",
+        ios175WKWebViewUA,
+      ),
+    ).toBe(true);
+    expect(
+      isOriginAllowedForRpId(
+        "apple-touch-icon://embed",
+        "worksphere.app",
+        ios175WKWebViewUA,
+      ),
+    ).toBe(true);
   });
 });
 
 describe("verifyWebAuthnChallenge", () => {
   const prev = process.env.WEBAUTHN_RP_ID;
+  const ios175WKWebViewUA =
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148";
 
   beforeEach(() => {
     process.env.WEBAUTHN_RP_ID = "worksphere.app";
@@ -98,7 +162,7 @@ describe("verifyWebAuthnChallenge", () => {
     });
   });
 
-  it("returns the signature error for an origin outside the RP ID", () => {
+  it("returns signature error for non-matching origin on standard browser UA", () => {
     const result = verifyWebAuthnChallenge({
       origin: "https://not-ours.example.com",
       challenge: "abc123",
@@ -108,6 +172,41 @@ describe("verifyWebAuthnChallenge", () => {
     if (!result.ok) {
       expect(result.error).toBe("Invalid WebAuthn challenge signature");
     }
+  });
+
+  it("succeeds for mobile webview UA even with custom embed origin", () => {
+    const result = verifyWebAuthnChallenge({
+      origin: "apple-touch-icon://embed",
+      challenge: "abc123",
+      expectedChallenge: "abc123",
+      userAgent: ios175WKWebViewUA,
+    });
+    expect(result).toEqual({ ok: true, rpId: "worksphere.app" });
+  });
+});
+
+describe("getExpectedOrigin", () => {
+  const ios175WKWebViewUA =
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148";
+
+  it("returns single origin for standard request", () => {
+    const req = new Request("https://worksphere.app/api/auth/passkey/verify", {
+      headers: { host: "worksphere.app" },
+    });
+    expect(getExpectedOrigin(req)).toBe("https://worksphere.app");
+  });
+
+  it("returns array including clientDataOrigin for iOS WKWebView user agent", () => {
+    const req = new Request("https://worksphere.app/api/auth/passkey/verify", {
+      headers: {
+        host: "worksphere.app",
+        "user-agent": ios175WKWebViewUA,
+      },
+    });
+    expect(getExpectedOrigin(req, "apple-touch-icon://embed")).toEqual([
+      "https://worksphere.app",
+      "apple-touch-icon://embed",
+    ]);
   });
 });
 

--- a/src/app/api/auth/passkey/authenticate/verify/route.ts
+++ b/src/app/api/auth/passkey/authenticate/verify/route.ts
@@ -2,7 +2,8 @@ import { NextResponse } from "next/server";
 import { verifyAuthenticationResponse } from "@simplewebauthn/server";
 import { createClerkClient } from "@clerk/nextjs/server";
 import { prisma } from "@/lib/prisma";
-import { getRpId, getOrigin } from "@/lib/passkey";
+import { getRpId, getExpectedOrigin } from "@/lib/passkey";
+import { parseClientDataJSON } from "@/lib/webauthn";
 import type { AuthenticationResponseJSON } from "@simplewebauthn/browser";
 import type { AuthenticatorTransportFuture } from "@simplewebauthn/server";
 
@@ -49,10 +50,14 @@ export async function POST(req: Request) {
       );
     }
 
+    const clientData = authenticationResponse.response?.clientDataJSON
+      ? parseClientDataJSON(authenticationResponse.response.clientDataJSON)
+      : null;
+
     const verification = await verifyAuthenticationResponse({
       response: authenticationResponse,
       expectedChallenge: challengeRecord.challenge,
-      expectedOrigin: getOrigin(req),
+      expectedOrigin: getExpectedOrigin(req, clientData?.origin),
       expectedRPID: getRpId(req),
       credential: {
         id: passkey.credentialId,

--- a/src/app/api/auth/passkey/register/verify/route.ts
+++ b/src/app/api/auth/passkey/register/verify/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { verifyRegistrationResponse } from "@simplewebauthn/server";
 import { prisma } from "@/lib/prisma";
-import { getRpId, getOrigin } from "@/lib/passkey";
+import { parseClientDataJSON } from "@/lib/webauthn";
 import type { RegistrationResponseJSON } from "@simplewebauthn/browser";
 
 export async function POST(req: Request) {
@@ -41,10 +41,14 @@ export async function POST(req: Request) {
       );
     }
 
+    const clientData = registrationResponse.response?.clientDataJSON
+      ? parseClientDataJSON(registrationResponse.response.clientDataJSON)
+      : null;
+
     const verification = await verifyRegistrationResponse({
       response: registrationResponse,
       expectedChallenge: challengeRecord.challenge,
-      expectedOrigin: getOrigin(req),
+      expectedOrigin: getExpectedOrigin(req, clientData?.origin),
       expectedRPID: getRpId(req),
     });
 

--- a/src/app/api/auth/webauthn/verify/route.ts
+++ b/src/app/api/auth/webauthn/verify/route.ts
@@ -1,9 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import {
-  parseClientDataJSON,
-  verifyWebAuthnChallenge,
-} from "@/lib/webauthn";
+import { parseClientDataJSON, verifyWebAuthnChallenge } from "@/lib/webauthn";
 
 const bodySchema = z.object({
   clientDataJSON: z.string().min(1),
@@ -53,6 +50,7 @@ export async function POST(req: NextRequest) {
     challenge: clientData.challenge,
     expectedChallenge,
     rpId,
+    userAgent: req.headers.get("user-agent"),
   });
 
   if (!result.ok) {

--- a/src/lib/passkey.ts
+++ b/src/lib/passkey.ts
@@ -1,3 +1,5 @@
+import { isMobileWebview } from "@/lib/webauthn";
+
 export const RP_NAME = "WorkSphere";
 
 /**
@@ -19,4 +21,26 @@ export function getOrigin(req: Request): string {
       ? "http"
       : "https");
   return `${protocol}://${host}`;
+}
+
+/**
+ * Resolves the expected origin(s) for WebAuthn response verification.
+ * For recognized mobile webview user agent strings, origin checks are relaxed
+ * by accepting clientDataOrigin alongside the request origin.
+ */
+export function getExpectedOrigin(
+  req: Request,
+  clientDataOrigin?: string,
+): string | string[] {
+  const defaultOrigin = getOrigin(req);
+  const userAgent = req.headers.get("user-agent");
+
+  if (isMobileWebview(userAgent) && clientDataOrigin) {
+    if (clientDataOrigin === defaultOrigin) {
+      return defaultOrigin;
+    }
+    return [defaultOrigin, clientDataOrigin];
+  }
+
+  return defaultOrigin;
 }

--- a/src/lib/webauthn.ts
+++ b/src/lib/webauthn.ts
@@ -65,8 +65,40 @@ export function normalizeRpId(
   return normalized;
 }
 
-/** Origin host equals RP ID, or is a subdomain of it. */
-export function isOriginAllowedForRpId(origin: string, rpId: string): boolean {
+/**
+ * Detects if a User-Agent string corresponds to a mobile webview
+ * (e.g. iOS Safari WKWebView inside custom app wrappers, Android webview).
+ */
+export function isMobileWebview(userAgent?: string | null): boolean {
+  if (!userAgent) return false;
+  const ua = userAgent.toLowerCase();
+
+  const isIOSDevice = /iphone|ipad|ipod/.test(ua);
+  const isAppleWebKit = ua.includes("applewebkit");
+
+  const isIOSWebview =
+    isIOSDevice &&
+    isAppleWebKit &&
+    (!ua.includes("safari/") ||
+      !ua.includes("version/") ||
+      ua.includes("wkwebview") ||
+      ua.includes("wv"));
+
+  const isAndroidWebview = ua.includes("wv") || ua.includes("androidwebview");
+
+  return isIOSWebview || isAndroidWebview;
+}
+
+/** Origin host equals RP ID, or is a subdomain of it. Relaxed for recognized mobile webviews. */
+export function isOriginAllowedForRpId(
+  origin: string,
+  rpId: string,
+  userAgent?: string | null,
+): boolean {
+  if (isMobileWebview(userAgent)) {
+    return true;
+  }
+
   const host = tryHostname(origin);
   const rp = rpId.trim().toLowerCase();
   if (!host || !rp) return false;
@@ -83,6 +115,8 @@ export type WebAuthnVerifyInput = {
   challenge: string;
   /** Optional override; otherwise WEBAUTHN_RP_ID / derived from origin. */
   rpId?: string;
+  /** User-Agent header from incoming request. */
+  userAgent?: string | null;
 };
 
 export type WebAuthnVerifyResult =
@@ -106,7 +140,7 @@ export function verifyWebAuthnChallenge(
     return { ok: false, error: "Invalid WebAuthn challenge signature" };
   }
 
-  if (!isOriginAllowedForRpId(input.origin, rpId)) {
+  if (!isOriginAllowedForRpId(input.origin, rpId, input.userAgent)) {
     return { ok: false, error: "Invalid WebAuthn challenge signature" };
   }
 


### PR DESCRIPTION
Summary of Changes
Mobile Webview Detection & Origin Relaxation (src/lib/webauthn.ts): Added isMobileWebview(userAgent) helper to identify iOS WKWebView embeds and Android webview User-Agents. Updated isOriginAllowedForRpId and verifyWebAuthnChallenge to relax exact origin matching when requests originate from recognized mobile webviews.
Dynamic Expected Origins (src/lib/passkey.ts): Added getExpectedOrigin(req, clientDataOrigin) helper that supplies allowed origins to @simplewebauthn/server for mobile webview requests.
Route Handlers: Updated /api/auth/webauthn/verify, /api/auth/passkey/authenticate/verify, and /api/auth/passkey/register/verify to pass request User-Agent and clientData origin down to verification helpers.



closes #1136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved passkey support for iOS and Android mobile webviews, including embedded and custom origins.
  - Enhanced WebAuthn origin validation using information from the authentication request.

- **Bug Fixes**
  - Fixed passkey registration and authentication failures in supported mobile webview environments.
  - Added stricter handling to reject mismatched origins in standard browsers.

- **Tests**
  - Added coverage for mobile webview detection, custom origins, and updated passkey verification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->