### PR TITLE
fix: webGPU canvas context loss crash

### DIFF
--- a/src/__tests__/lib/webgpuFloorPlanRenderer.test.ts
+++ b/src/__tests__/lib/webgpuFloorPlanRenderer.test.ts
@@ -1,0 +1,171 @@
+import {
+  WebGPUFloorPlanRenderer,
+  type FloorPlanData,
+} from "@/lib/webgpu/floorPlanRenderer";
+
+describe("WebGPUFloorPlanRenderer Context Loss & Recovery", () => {
+  let canvas: HTMLCanvasElement;
+  let sampleData: FloorPlanData;
+
+  beforeEach(() => {
+    canvas = document.createElement("canvas");
+    canvas.width = 800;
+    canvas.height = 450;
+
+    sampleData = {
+      width: 10,
+      depth: 10,
+      height: 3,
+      seats: [
+        {
+          x: 0,
+          z: 0,
+          type: "hot_desk",
+          hasPower: true,
+          isQuiet: false,
+        },
+      ],
+      walls: [],
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("handles fallback gracefully when WebGPU is unavailable", async () => {
+    const originalGpu = navigator.gpu;
+    Object.defineProperty(navigator, "gpu", {
+      value: undefined,
+      configurable: true,
+    });
+
+    const renderer = new WebGPUFloorPlanRenderer(canvas);
+    const success = await renderer.initialize();
+
+    expect(success).toBe(false);
+    expect(renderer.getIsDeviceLost()).toBe(false);
+
+    // Restore navigator.gpu
+    if (originalGpu) {
+      Object.defineProperty(navigator, "gpu", {
+        value: originalGpu,
+        configurable: true,
+      });
+    }
+  });
+
+  it("registers device.lost listener and recovers on visibilitychange", async () => {
+    let resolveDeviceLost: (info: { reason: string; message: string }) => void;
+    const lostPromise = new Promise<{ reason: string; message: string }>(
+      (resolve) => {
+        resolveDeviceLost = resolve;
+      },
+    );
+
+    const mockDevice = {
+      lost: lostPromise,
+      createShaderModule: jest.fn().mockReturnValue({}),
+      createRenderPipeline: jest.fn().mockReturnValue({
+        getBindGroupLayout: jest.fn().mockReturnValue({}),
+      }),
+      createBuffer: jest.fn().mockReturnValue({
+        destroy: jest.fn(),
+      }),
+      createBindGroup: jest.fn().mockReturnValue({}),
+      createTexture: jest.fn().mockReturnValue({
+        createView: jest.fn().mockReturnValue({}),
+        destroy: jest.fn(),
+      }),
+      createCommandEncoder: jest.fn().mockReturnValue({
+        beginRenderPass: jest.fn().mockReturnValue({
+          setPipeline: jest.fn(),
+          setBindGroup: jest.fn(),
+          setVertexBuffer: jest.fn(),
+          setIndexBuffer: jest.fn(),
+          drawIndexed: jest.fn(),
+          end: jest.fn(),
+        }),
+        finish: jest.fn(),
+      }),
+      queue: {
+        writeBuffer: jest.fn(),
+        submit: jest.fn(),
+      },
+      destroy: jest.fn(),
+    };
+
+    const mockContext = {
+      configure: jest.fn(),
+      getCurrentTexture: jest.fn().mockReturnValue({
+        createView: jest.fn(),
+      }),
+    };
+
+    const mockGpu = {
+      requestAdapter: jest.fn().mockResolvedValue({
+        requestDevice: jest.fn().mockResolvedValue(mockDevice),
+      }),
+      getPreferredCanvasFormat: jest.fn().mockReturnValue("rgba8unorm"),
+    };
+
+    Object.defineProperty(navigator, "gpu", {
+      value: mockGpu,
+      configurable: true,
+      writable: true,
+    });
+
+    jest.spyOn(canvas, "getContext").mockReturnValue(mockContext as any);
+
+    const renderer = new WebGPUFloorPlanRenderer(canvas);
+    const success = await renderer.initialize();
+
+    expect(success).toBe(true);
+    expect(renderer.getIsDeviceLost()).toBe(false);
+
+    renderer.loadFloorPlan(sampleData);
+
+    // Simulate device loss (e.g. system sleep)
+    resolveDeviceLost!({
+      reason: "destroyed",
+      message: "Device was lost during sleep",
+    });
+
+    await lostPromise;
+    // Allow microtasks to execute
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(renderer.getIsDeviceLost()).toBe(true);
+    expect(renderer.getDevice()).toBeNull();
+
+    // Render should safely return without throwing errors when device is lost
+    expect(() => renderer.render()).not.toThrow();
+
+    // Simulate visibility change to "visible" (e.g. system wake)
+    const reinitSpy = jest.spyOn(renderer, "reinitialize");
+
+    Object.defineProperty(document, "visibilityState", {
+      value: "visible",
+      configurable: true,
+      writable: true,
+    });
+
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(reinitSpy).toHaveBeenCalled();
+
+    renderer.destroy();
+  });
+
+  it("removes event listeners on destroy", () => {
+    const removeListenerSpy = jest.spyOn(document, "removeEventListener");
+    const renderer = new WebGPUFloorPlanRenderer(canvas);
+
+    renderer.destroy();
+
+    expect(removeListenerSpy).toHaveBeenCalledWith(
+      "visibilitychange",
+      expect.any(Function),
+    );
+  });
+});

--- a/src/lib/webgpu/floorPlanRenderer.ts
+++ b/src/lib/webgpu/floorPlanRenderer.ts
@@ -455,10 +455,31 @@ export class WebGPUFloorPlanRenderer {
   private lastMouse = { x: 0, y: 0 };
   private animationFrame = 0;
   private time = 0;
+  private isDeviceLost = false;
+  private currentData: FloorPlanData | null = null;
+  private visibilityHandler: (() => void) | null = null;
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas;
     this.setupInteraction();
+    this.setupVisibilityHandler();
+  }
+
+  private setupVisibilityHandler(): void {
+    if (typeof document === "undefined") return;
+
+    this.visibilityHandler = () => {
+      if (document.visibilityState === "visible") {
+        if (this.isDeviceLost || !this.device) {
+          console.warn(
+            "[WebGPU] Page resumed from sleep/hidden state; re-initializing render pipeline...",
+          );
+          this.reinitialize();
+        }
+      }
+    };
+
+    document.addEventListener("visibilitychange", this.visibilityHandler);
   }
 
   private setupInteraction(): void {
@@ -539,6 +560,16 @@ export class WebGPUFloorPlanRenderer {
       if (!adapter) return false;
 
       this.device = await adapter.requestDevice();
+      this.isDeviceLost = false;
+
+      this.device.lost.then((info: { reason: string; message: string }) => {
+        console.warn(
+          `[WebGPU] GPUDevice lost (${info.reason}): ${info.message}`,
+        );
+        this.isDeviceLost = true;
+        this.cleanupGPUResources();
+      });
+
       this.context = this.canvas.getContext(
         "webgpu",
       ) as unknown as GPUCanvasContext | null;
@@ -606,8 +637,17 @@ export class WebGPUFloorPlanRenderer {
     }
   }
 
+  async reinitialize(): Promise<boolean> {
+    const success = await this.initialize();
+    if (success && this.currentData) {
+      this.loadFloorPlan(this.currentData);
+    }
+    return success;
+  }
+
   loadFloorPlan(data: FloorPlanData): void {
-    if (!this.device) return;
+    this.currentData = data;
+    if (!this.device || this.isDeviceLost) return;
 
     const mesh = buildFloorPlanMesh(data);
     this.indexCount = mesh.indexCount;
@@ -630,6 +670,7 @@ export class WebGPUFloorPlanRenderer {
 
   render(): void {
     if (
+      this.isDeviceLost ||
       !this.device ||
       !this.context ||
       !this.pipeline ||
@@ -639,86 +680,91 @@ export class WebGPUFloorPlanRenderer {
     )
       return;
 
-    this.time += 0.016;
+    try {
+      this.time += 0.016;
 
-    const aspect = this.canvas.width / this.canvas.height;
-    const projection = mat4Perspective(Math.PI / 4, aspect, 0.1, 100);
+      const aspect = this.canvas.width / this.canvas.height;
+      const projection = mat4Perspective(Math.PI / 4, aspect, 0.1, 100);
 
-    const eyeX =
-      this.camera.target[0] +
-      this.camera.panX +
-      this.camera.distance *
-        Math.cos(this.camera.rotationX) *
-        Math.sin(this.camera.rotationY);
-    const eyeY =
-      this.camera.target[1] +
-      this.camera.panY +
-      this.camera.distance * Math.sin(-this.camera.rotationX);
-    const eyeZ =
-      this.camera.target[2] +
-      this.camera.distance *
-        Math.cos(this.camera.rotationX) *
-        Math.cos(this.camera.rotationY);
+      const eyeX =
+        this.camera.target[0] +
+        this.camera.panX +
+        this.camera.distance *
+          Math.cos(this.camera.rotationX) *
+          Math.sin(this.camera.rotationY);
+      const eyeY =
+        this.camera.target[1] +
+        this.camera.panY +
+        this.camera.distance * Math.sin(-this.camera.rotationX);
+      const eyeZ =
+        this.camera.target[2] +
+        this.camera.distance *
+          Math.cos(this.camera.rotationX) *
+          Math.cos(this.camera.rotationY);
 
-    const view = mat4LookAt(
-      [eyeX, eyeY, eyeZ],
-      [
-        this.camera.target[0] + this.camera.panX,
-        this.camera.target[1] + this.camera.panY,
-        this.camera.target[2],
-      ],
-      [0, 1, 0],
-    );
+      const view = mat4LookAt(
+        [eyeX, eyeY, eyeZ],
+        [
+          this.camera.target[0] + this.camera.panX,
+          this.camera.target[1] + this.camera.panY,
+          this.camera.target[2],
+        ],
+        [0, 1, 0],
+      );
 
-    const model = mat4Identity();
-    const mvp = mat4Multiply(view, model);
-    const mvpFinal = mat4Multiply(projection, mvp);
+      const model = mat4Identity();
+      const mvp = mat4Multiply(view, model);
+      const mvpFinal = mat4Multiply(projection, mvp);
 
-    // Upload uniforms
-    const uniformData = new Float32Array(32);
-    uniformData.set(mvpFinal, 0);
-    uniformData.set(model, 16);
-    uniformData[24] = 0.5;
-    uniformData[25] = 1.0;
-    uniformData[26] = 0.7;
-    uniformData[27] = this.time;
-    this.device.queue.writeBuffer(this.uniformBuffer!, 0, uniformData);
+      // Upload uniforms
+      const uniformData = new Float32Array(32);
+      uniformData.set(mvpFinal, 0);
+      uniformData.set(model, 16);
+      uniformData[24] = 0.5;
+      uniformData[25] = 1.0;
+      uniformData[26] = 0.7;
+      uniformData[27] = this.time;
+      this.device.queue.writeBuffer(this.uniformBuffer!, 0, uniformData);
 
-    const commandEncoder = this.device.createCommandEncoder();
-    const textureView = this.context.getCurrentTexture().createView();
+      const commandEncoder = this.device.createCommandEncoder();
+      const textureView = this.context.getCurrentTexture().createView();
 
-    const depthTexture = this.device.createTexture({
-      size: [this.canvas.width, this.canvas.height],
-      format: "depth24plus",
-      usage: TextureUsage.RENDER_ATTACHMENT,
-    });
+      const depthTexture = this.device.createTexture({
+        size: [this.canvas.width, this.canvas.height],
+        format: "depth24plus",
+        usage: TextureUsage.RENDER_ATTACHMENT,
+      });
 
-    const renderPass = commandEncoder.beginRenderPass({
-      colorAttachments: [
-        {
-          view: textureView,
-          clearValue: { r: 0.08, g: 0.08, b: 0.1, a: 1.0 },
-          loadOp: "clear",
-          storeOp: "store",
+      const renderPass = commandEncoder.beginRenderPass({
+        colorAttachments: [
+          {
+            view: textureView,
+            clearValue: { r: 0.08, g: 0.08, b: 0.1, a: 1.0 },
+            loadOp: "clear",
+            storeOp: "store",
+          },
+        ],
+        depthStencilAttachment: {
+          view: depthTexture.createView(),
+          depthClearValue: 1.0,
+          depthLoadOp: "clear",
+          depthStoreOp: "store",
         },
-      ],
-      depthStencilAttachment: {
-        view: depthTexture.createView(),
-        depthClearValue: 1.0,
-        depthLoadOp: "clear",
-        depthStoreOp: "store",
-      },
-    });
+      });
 
-    renderPass.setPipeline(this.pipeline);
-    renderPass.setBindGroup(0, this.bindGroup);
-    renderPass.setVertexBuffer(0, this.vertexBuffer);
-    renderPass.setIndexBuffer(this.indexBuffer, "uint16");
-    renderPass.drawIndexed(this.indexCount);
-    renderPass.end();
+      renderPass.setPipeline(this.pipeline);
+      renderPass.setBindGroup(0, this.bindGroup);
+      renderPass.setVertexBuffer(0, this.vertexBuffer);
+      renderPass.setIndexBuffer(this.indexBuffer, "uint16");
+      renderPass.drawIndexed(this.indexCount);
+      renderPass.end();
 
-    this.device.queue.submit([commandEncoder.finish()]);
-    depthTexture.destroy();
+      this.device.queue.submit([commandEncoder.finish()]);
+      depthTexture.destroy();
+    } catch (error) {
+      console.error("[WebGPU] Render pass error (device lost):", error);
+      this.isDeviceLost = true;
+    }
   }
 
   startRenderLoop(): void {
@@ -733,11 +779,32 @@ export class WebGPUFloorPlanRenderer {
     cancelAnimationFrame(this.animationFrame);
   }
 
+  private cleanupGPUResources(): void {
+    this.pipeline = null;
+    this.bindGroup = null;
+    this.vertexBuffer?.destroy();
+    this.vertexBuffer = null;
+    this.indexBuffer?.destroy();
+    this.indexBuffer = null;
+    this.uniformBuffer?.destroy();
+    this.uniformBuffer = null;
+    this.context = null;
+    this.device = null;
+  }
+
+  getIsDeviceLost(): boolean {
+    return this.isDeviceLost;
+  }
+
+  getDevice(): GPUDevice | null {
+    return this.device;
+  }
+
   destroy(): void {
     this.stopRenderLoop();
-    this.vertexBuffer?.destroy();
-    this.indexBuffer?.destroy();
-    this.uniformBuffer?.destroy();
-    this.device?.destroy();
+    if (this.visibilityHandler && typeof document !== "undefined") {
+      document.removeEventListener("visibilitychange", this.visibilityHandler);
+    }
+    this.cleanupGPUResources();
   }
 }


### PR DESCRIPTION
I have resolved the WebGPU canvas context loss crash during device sleep-resume cycles.

Summary of Changes
Context Loss & Recovery (src/lib/webgpu/floorPlanRenderer.ts):
Added asynchronous this.device.lost listener to detect GPU device loss (e.g. system sleep/wake or driver resets) and flag isDeviceLost = true.
Added visibilitychange event listener on document to detect when the browser tab becomes visible upon device wake, automatically triggering reinitialize() and reloading active floor plan data.
Guarded render() to prevent unhandled GPU errors on lost devices.
Unbound event listeners and cleaned up GPU resources on destroy().


closes #1131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved floor plan rendering stability when the graphics device becomes unavailable or is lost.
  * Rendering now avoids crashes during device failures and safely releases affected resources.
  * Rendering automatically attempts recovery when the page becomes visible again.

* **New Features**
  * Added status accessors for monitoring graphics device availability.
  * Preserves floor plan data for automatic reload after recovery.

* **Tests**
  * Added coverage for initialization fallback, device-loss recovery, visibility changes, rendering safety, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->