### PR TITLE
fix: cap PartySocket reconnects with jittered backoff

### DIFF
--- a/src/__tests__/lib/partySocketReconnect.test.ts
+++ b/src/__tests__/lib/partySocketReconnect.test.ts
@@ -1,0 +1,61 @@
+import {
+  attachJitteredBackoff,
+  jitteredReconnectDelay,
+  PARTY_SOCKET_RECONNECT_OPTIONS,
+} from "@/lib/partySocketReconnect";
+
+describe("PARTY_SOCKET_RECONNECT_OPTIONS", () => {
+  it("caps retries instead of reconnecting forever", () => {
+    expect(PARTY_SOCKET_RECONNECT_OPTIONS.maxRetries).toBeLessThanOrEqual(10);
+    expect(
+      Number.isFinite(PARTY_SOCKET_RECONNECT_OPTIONS.maxRetries),
+    ).toBe(true);
+  });
+});
+
+describe("jitteredReconnectDelay", () => {
+  it("does not delay the initial connect", () => {
+    expect(jitteredReconnectDelay(0, undefined, () => 0.5)).toBe(0);
+    expect(jitteredReconnectDelay(-1, undefined, () => 0.5)).toBe(0);
+  });
+
+  it("applies exponential backoff with jitter on later attempts", () => {
+    const mid = jitteredReconnectDelay(1, undefined, () => 0.5);
+    expect(mid).toBe(1_000);
+
+    const second = jitteredReconnectDelay(2, undefined, () => 0.5);
+    expect(second).toBe(2_000);
+
+    const low = jitteredReconnectDelay(1, undefined, () => 0);
+    const high = jitteredReconnectDelay(1, undefined, () => 1);
+    expect(low).toBeGreaterThanOrEqual(1_000);
+    expect(high).toBeLessThanOrEqual(1_000 * 1.2);
+    expect(low).toBeLessThan(high);
+  });
+
+  it("never exceeds maxReconnectionDelay", () => {
+    const delay = jitteredReconnectDelay(20, undefined, () => 1);
+    expect(delay).toBeLessThanOrEqual(
+      PARTY_SOCKET_RECONNECT_OPTIONS.maxReconnectionDelay,
+    );
+  });
+});
+
+describe("attachJitteredBackoff", () => {
+  it("overrides _getNextDelay using the socket retry count", () => {
+    const socket = {
+      _retryCount: 2,
+      _getNextDelay: () => 0,
+    };
+
+    attachJitteredBackoff(socket);
+    // retry 2 → base 2000ms, ±20% jitter
+    const delay = socket._getNextDelay();
+    expect(delay).toBeGreaterThanOrEqual(1_600);
+    expect(delay).toBeLessThanOrEqual(2_400);
+
+    const first = socket._getNextDelay;
+    attachJitteredBackoff(socket);
+    expect(socket._getNextDelay).toBe(first);
+  });
+});

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -14,7 +14,7 @@ import {
   FileDown,
 } from "lucide-react";
 
-import usePartySocket from "partysocket/react";
+import usePartySocket from "@/hooks/usePartySocketReconnect";
 import Image from "next/image";
 import { ComparisonTool } from "@/components/collections/ComparisonTool";
 import { EmptyState } from "@/components/ui/EmptyState";

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -24,7 +24,7 @@ import {
   useSeatAvailability,
   type SeatStatus,
 } from "@/hooks/useSeatAvailability";
-import usePartySocket from "partysocket/react";
+import usePartySocket from "@/hooks/usePartySocketReconnect";
 
 function throttle<T extends (...args: any[]) => void>(
   func: T,

--- a/src/hooks/useMultiRegion.ts
+++ b/src/hooks/useMultiRegion.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import usePartySocket from "partysocket/react";
+import usePartySocket from "@/hooks/usePartySocketReconnect";
 
 export type Region =
   | "us-east"

--- a/src/hooks/usePartySocketReconnect.ts
+++ b/src/hooks/usePartySocketReconnect.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import usePartySocket from "partysocket/react";
+import {
+  attachJitteredBackoff,
+  PARTY_SOCKET_RECONNECT_OPTIONS,
+} from "@/lib/partySocketReconnect";
+
+type PartySocketOptions = Parameters<typeof usePartySocket>[0];
+
+/**
+ * PartySocket with capped retries + jittered exponential backoff.
+ * Drop-in for `partysocket/react`'s usePartySocket.
+ */
+export default function usePartySocketReconnect(options: PartySocketOptions) {
+  const socket = usePartySocket({
+    ...PARTY_SOCKET_RECONNECT_OPTIONS,
+    ...options,
+  });
+
+  return attachJitteredBackoff(socket);
+}

--- a/src/hooks/useRealTime.tsx
+++ b/src/hooks/useRealTime.tsx
@@ -8,7 +8,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { useAuth } from "@clerk/nextjs";
-import usePartySocket from "partysocket/react";
+import usePartySocket from "@/hooks/usePartySocketReconnect";
 import YProvider from "y-partykit/provider";
 import * as Y from "yjs";
 

--- a/src/hooks/useScreenShare.ts
+++ b/src/hooks/useScreenShare.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAuth } from "@clerk/nextjs";
-import usePartySocket from "partysocket/react";
+import usePartySocket from "@/hooks/usePartySocketReconnect";
 import { adaptVideoBitrate } from "@/lib/screenShareBitrate";
 
 const ICE_SERVERS: RTCIceServer[] = [{ urls: "stun:stun.l.google.com:19302" }];

--- a/src/hooks/useSeatAvailability.ts
+++ b/src/hooks/useSeatAvailability.ts
@@ -11,7 +11,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAuth } from "@clerk/nextjs";
-import usePartySocket from "partysocket/react";
+import usePartySocket from "@/hooks/usePartySocketReconnect";
 import { useToast } from "@/components/ui/Toast";
 import {
   queueOfflineCheckIn,

--- a/src/lib/partySocketReconnect.ts
+++ b/src/lib/partySocketReconnect.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared PartySocket reconnect tuning.
+ *
+ * Default partysocket uses infinite retries and a 0ms delay on the first
+ * reconnect, which storms the server when the network interface flaps
+ * (Wi‑Fi → cellular). Cap attempts and back off with jitter instead.
+ */
+
+export const PARTY_SOCKET_RECONNECT_OPTIONS = {
+  maxRetries: 10,
+  minReconnectionDelay: 1_000,
+  maxReconnectionDelay: 30_000,
+  reconnectionDelayGrowFactor: 2,
+} as const;
+
+export type PartyReconnectOptions = {
+  maxRetries: number;
+  minReconnectionDelay: number;
+  maxReconnectionDelay: number;
+  reconnectionDelayGrowFactor: number;
+};
+
+/**
+ * Delay before reconnect attempt `retryCount`.
+ * PartySocket increments retryCount before waiting; 0 is the initial connect.
+ */
+export function jitteredReconnectDelay(
+  retryCount: number,
+  opts: PartyReconnectOptions = PARTY_SOCKET_RECONNECT_OPTIONS,
+  random: () => number = Math.random,
+): number {
+  if (retryCount <= 0) return 0;
+
+  const { minReconnectionDelay: min, maxReconnectionDelay: max } = opts;
+  const grow = opts.reconnectionDelayGrowFactor;
+  const base = Math.min(max, min * grow ** (retryCount - 1));
+  // ±20% jitter so clients don't retry in lockstep after a mass disconnect
+  const jitter = base * (random() * 0.4 - 0.2);
+  return Math.round(Math.min(max, Math.max(min, base + jitter)));
+}
+
+type DelaySocket = {
+  _retryCount: number;
+  _getNextDelay: () => number;
+  __worksphereJitter?: boolean;
+};
+
+/** Swap in jittered backoff on a live PartySocket instance (idempotent). */
+export function attachJitteredBackoff<T extends object>(socket: T): T {
+  const s = socket as T & DelaySocket;
+  if (s.__worksphereJitter) return socket;
+
+  s._getNextDelay = function (this: DelaySocket) {
+    return jitteredReconnectDelay(this._retryCount);
+  };
+  s.__worksphereJitter = true;
+  return socket;
+}


### PR DESCRIPTION
## Summary
- Caps PartyKit socket reconnect attempts instead of retrying forever
- Applies jittered exponential backoff (1s → 30s) so interface switches don’t storm the server
- Routes existing PartySocket call sites through a shared reconnect helper

Closes #1038

## Test plan
- [ ] `npm test -- --testPathPattern='partySocketReconnect|useScreenShare|Map.test'`
- [ ] Connect to a PartyKit room, switch Wi‑Fi → cellular, confirm reconnects back off and stop after the cap
- [ ] Confirm rooms still connect normally on a stable network



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic reconnection for real-time connections using capped, jittered exponential backoff.
  * Improved resilience for collections, maps, screen sharing, seat availability, and other real-time features when connections are interrupted.

* **Tests**
  * Added coverage for retry limits, backoff timing, jitter bounds, and reconnection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->