### PR TITLE
fix: order tag IDs before bulk FavoriteTag sync transactions

### DIFF
--- a/src/__tests__/lib/favoriteTagSync.test.ts
+++ b/src/__tests__/lib/favoriteTagSync.test.ts
@@ -1,0 +1,81 @@
+import {
+  sortTagIdsDeterministically,
+  syncFavoriteTagsBulk,
+} from "@/lib/favoriteTagSync";
+import { prisma } from "@/lib/prisma";
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    $transaction: jest.fn(),
+    favoriteTag: {
+      update: jest.fn((args: unknown) => ({ __op: "update", args })),
+    },
+  },
+}));
+
+describe("sortTagIdsDeterministically", () => {
+  it("returns tag ids in lexicographic order", () => {
+    expect(
+      sortTagIdsDeterministically(["tag-c", "tag-a", "tag-b"]),
+    ).toEqual(["tag-a", "tag-b", "tag-c"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = ["z", "a"];
+    sortTagIdsDeterministically(input);
+    expect(input).toEqual(["z", "a"]);
+  });
+});
+
+describe("syncFavoriteTagsBulk", () => {
+  const mockTransaction = prisma.$transaction as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTransaction.mockImplementation(async (ops: unknown[]) => ops);
+  });
+
+  it("returns an empty array without opening a transaction", async () => {
+    await expect(syncFavoriteTagsBulk([])).resolves.toEqual([]);
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("passes FavoriteTag updates to $transaction in sorted id order", async () => {
+    await syncFavoriteTagsBulk([
+      { id: "tag-c", name: "C" },
+      { id: "tag-a", color: "#111111" },
+      { id: "tag-b", name: "B", color: "#222222" },
+    ]);
+
+    expect(mockTransaction).toHaveBeenCalledTimes(1);
+    const ops = mockTransaction.mock.calls[0][0] as Array<{
+      args: { where: { id: string }; data: Record<string, string> };
+    }>;
+
+    expect(ops.map((op) => op.args.where.id)).toEqual([
+      "tag-a",
+      "tag-b",
+      "tag-c",
+    ]);
+    expect(ops[0].args.data).toEqual({ color: "#111111" });
+    expect(ops[1].args.data).toEqual({ name: "B", color: "#222222" });
+    expect(ops[2].args.data).toEqual({ name: "C" });
+  });
+
+  it("dedupes duplicate tag ids keeping the last payload", async () => {
+    await syncFavoriteTagsBulk([
+      { id: "tag-a", name: "First" },
+      { id: "tag-a", name: "Second", color: "#abcdef" },
+    ]);
+
+    const ops = mockTransaction.mock.calls[0][0] as Array<{
+      args: { where: { id: string }; data: Record<string, string> };
+    }>;
+
+    expect(ops).toHaveLength(1);
+    expect(ops[0].args).toEqual({
+      where: { id: "tag-a" },
+      data: { name: "Second", color: "#abcdef" },
+    });
+  });
+});

--- a/src/__tests__/lib/savedVenueValidations.test.ts
+++ b/src/__tests__/lib/savedVenueValidations.test.ts
@@ -2,6 +2,7 @@ import {
   favoriteNotesSchema,
   createFavoriteTagSchema,
   updateFavoriteTagSchema,
+  syncFavoriteTagsSchema,
   validateRequest,
 } from "@/lib/validations";
 
@@ -119,6 +120,30 @@ describe("Validations - updateFavoriteTagSchema", () => {
 
   it("should reject invalid color format", () => {
     const result = updateFavoriteTagSchema.safeParse({ color: "blue" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("Validations - syncFavoriteTagsSchema", () => {
+  it("should accept a batch of tag updates", () => {
+    const result = syncFavoriteTagsSchema.safeParse({
+      updates: [
+        { id: "tag-1", name: "Quiet" },
+        { id: "tag-2", color: "#22c55e" },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject an update with neither name nor color", () => {
+    const result = syncFavoriteTagsSchema.safeParse({
+      updates: [{ id: "tag-1" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject an empty updates array", () => {
+    const result = syncFavoriteTagsSchema.safeParse({ updates: [] });
     expect(result.success).toBe(false);
   });
 });

--- a/src/app/api/favorites/tags/sync/route.ts
+++ b/src/app/api/favorites/tags/sync/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/prisma";
+import { ensureUserExists } from "@/lib/auth";
+import { syncFavoriteTagsSchema, validateRequest } from "@/lib/validations";
+import { syncFavoriteTagsBulk } from "@/lib/favoriteTagSync";
+
+// POST /api/favorites/tags/sync - Bulk-update tags across saved venues
+export async function POST(req: NextRequest) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    await ensureUserExists(userId);
+
+    const body = await req.json();
+    const validation = validateRequest(syncFavoriteTagsSchema, body);
+    if (!validation.success) {
+      return NextResponse.json({ error: validation.error }, { status: 400 });
+    }
+
+    const { updates } = validation.data;
+    const tagIds = updates.map((u) => u.id);
+
+    const ownedTags = await prisma.favoriteTag.findMany({
+      where: {
+        id: { in: tagIds },
+        favorite: { userId },
+      },
+      select: { id: true },
+    });
+
+    if (ownedTags.length !== new Set(tagIds).size) {
+      return NextResponse.json(
+        { error: "One or more tags were not found" },
+        { status: 404 },
+      );
+    }
+
+    const tags = await syncFavoriteTagsBulk(updates);
+
+    return NextResponse.json({ tags });
+  } catch (error: unknown) {
+    console.error("POST /api/favorites/tags/sync error:", error);
+
+    const code =
+      error && typeof error === "object" && "code" in error
+        ? (error as { code?: string }).code
+        : undefined;
+
+    if (code === "P2002") {
+      return NextResponse.json(
+        { error: "Tag with this name already exists" },
+        { status: 409 },
+      );
+    }
+
+    return NextResponse.json(
+      { error: "Failed to sync tags" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/favoriteTagSync.ts
+++ b/src/lib/favoriteTagSync.ts
@@ -1,0 +1,48 @@
+import { prisma } from "@/lib/prisma";
+
+export type FavoriteTagBulkUpdate = {
+  id: string;
+  name?: string;
+  color?: string;
+};
+
+/**
+ * Sort tag IDs so every concurrent bulk sync locks FavoriteTag rows in the
+ * same order. Unordered locking across overlapping sets is what produces
+ * PostgreSQL deadlocks (Prisma P2034) when syncing 50+ venue tags at once.
+ */
+export function sortTagIdsDeterministically(ids: string[]): string[] {
+  return [...ids].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+/**
+ * Apply bulk FavoriteTag field updates inside a single Prisma transaction.
+ * Writes always run in deterministic tag-id order to avoid row-lock deadlocks.
+ */
+export async function syncFavoriteTagsBulk(updates: FavoriteTagBulkUpdate[]) {
+  if (updates.length === 0) {
+    return [];
+  }
+
+  // Last write wins if the same id appears twice in the payload.
+  const byId = new Map<string, FavoriteTagBulkUpdate>();
+  for (const update of updates) {
+    byId.set(update.id, update);
+  }
+
+  const orderedIds = sortTagIdsDeterministically([...byId.keys()]);
+
+  return prisma.$transaction(
+    orderedIds.map((id) => {
+      const update = byId.get(id)!;
+      const data: { name?: string; color?: string } = {};
+      if (update.name !== undefined) data.name = update.name;
+      if (update.color !== undefined) data.color = update.color;
+
+      return prisma.favoriteTag.update({
+        where: { id },
+        data,
+      });
+    }),
+  );
+}

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -163,6 +163,26 @@ export const updateFavoriteTagSchema = z.object({
     .optional(),
 });
 
+export const syncFavoriteTagsSchema = z.object({
+  updates: z
+    .array(
+      z
+        .object({
+          id: z.string().min(1),
+          name: z.string().min(1).max(50).trim().optional(),
+          color: z
+            .string()
+            .regex(/^#[0-9a-fA-F]{6}$/, "Must be a valid hex color")
+            .optional(),
+        })
+        .refine((u) => u.name !== undefined || u.color !== undefined, {
+          message: "Each update must include name and/or color",
+        }),
+    )
+    .min(1)
+    .max(200),
+});
+
 // Location schema
 export const locationSchema = z.object({
   latitude: z.number().min(-90).max(90),
@@ -213,6 +233,7 @@ export type Favorite = z.infer<typeof favoriteSchema>;
 export type FavoriteNotes = z.infer<typeof favoriteNotesSchema>;
 export type CreateFavoriteTag = z.infer<typeof createFavoriteTagSchema>;
 export type UpdateFavoriteTag = z.infer<typeof updateFavoriteTagSchema>;
+export type SyncFavoriteTags = z.infer<typeof syncFavoriteTagsSchema>;
 export type Location = z.infer<typeof locationSchema>;
 export type CreateFolder = z.infer<typeof createFolderSchema>;
 export type UpdateFolder = z.infer<typeof updateFolderSchema>;


### PR DESCRIPTION
## Summary
- Adds bulk FavoriteTag sync that sorts tag IDs deterministically before `prisma.$transaction` writes, avoiding PostgreSQL row-lock deadlocks (P2034) when updating 50+ saved venues.
- Exposes `POST /api/favorites/tags/sync` with ownership checks and validation.
Closes #1036
## Test plan
- [ ] `npx jest src/__tests__/lib/favoriteTagSync.test.ts src/__tests__/lib/savedVenueValidations.test.ts --no-coverage`
- [ ] Call `POST /api/favorites/tags/sync` with 50+ tag updates and confirm no 500 / P2034
- [ ] Confirm unauthorized / foreign tag IDs return 401 / 404


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk synchronization for favorite tags, allowing names and colors to be updated in one request.
  * Added validation for tag update batches, including required fields and batch size limits.
  * Added clear responses for unauthorized access, invalid requests, missing tags, naming conflicts, and unexpected errors.

* **Tests**
  * Added coverage for bulk updates, duplicate handling, deterministic processing, validation, and empty requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->