### PR TITLE
fix(webgl-heatmap): stop recreating GL context on data updates (#828)

### DIFF
--- a/src/components/WebGLHeatmapLayer.tsx
+++ b/src/components/WebGLHeatmapLayer.tsx
@@ -3,7 +3,7 @@
 /**
  * Distributed WebGL Leaflet Heatmap Layer Component (#818)
  *
- * Integrates WebGLHeatmapRenderer with React-Leaflet map viewports. Converts geographical 
+ * Integrates WebGLHeatmapRenderer with React-Leaflet map viewports. Converts geographical
  * coordinates to screen space and renders continuous GPU spatial density clustering at 60 FPS.
  */
 
@@ -19,7 +19,7 @@ export interface GeoTelemetryPoint {
   lat: number;
   lng: number;
   intensity: number; // 0.0 to 1.0
-  radius?: number;   // Influence radius in pixels
+  radius?: number; // Influence radius in pixels
 }
 
 interface WebGLHeatmapLayerProps {
@@ -40,11 +40,88 @@ export function WebGLHeatmapLayer({
   const rendererRef = useRef<WebGLHeatmapRenderer | null>(null);
   const animFrameRef = useRef<number | null>(null);
 
+  // Refs so event handlers (attached once) always see the latest props
+  // without forcing the whole setup effect to re-run.
+  const pointsRef = useRef(points);
+  const visibleRef = useRef(visible);
   useEffect(() => {
-    if (!map || typeof window === "undefined" || !L || !L.DomUtil || typeof L.DomUtil.create !== "function") return;
+    pointsRef.current = points;
+    visibleRef.current = visible;
+  }, [points, visible]);
 
-    // Create canvas container overlay inside Leaflet overlayPane
-    const canvas = L.DomUtil.create("canvas", "leaflet-webgl-heatmap-layer") as HTMLCanvasElement;
+  const renderFrame = () => {
+    const canvas = canvasRef.current;
+    const renderer = rendererRef.current;
+    if (!canvas || !renderer || !map) return;
+
+    const size = map.getSize();
+    const pixelRatio = window.devicePixelRatio || 1;
+    const width = size.x;
+    const height = size.y;
+
+    if (
+      canvas.width !== width * pixelRatio ||
+      canvas.height !== height * pixelRatio
+    ) {
+      canvas.width = width * pixelRatio;
+      canvas.height = height * pixelRatio;
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+    }
+
+    const topLeft = map.containerPointToLayerPoint([0, 0]);
+    L.DomUtil.setPosition(canvas, topLeft);
+
+    const heatmapPoints: HeatmapPoint[] = [];
+    const currentZoom = map.getZoom();
+
+    for (let i = 0; i < pointsRef.current.length; i++) {
+      const pt = pointsRef.current[i];
+      const containerPt = map.latLngToContainerPoint([pt.lat, pt.lng]);
+
+      if (
+        containerPt.x < -100 ||
+        containerPt.x > width + 100 ||
+        containerPt.y < -100 ||
+        containerPt.y > height + 100
+      ) {
+        continue;
+      }
+
+      heatmapPoints.push({
+        x: containerPt.x * pixelRatio,
+        y: containerPt.y * pixelRatio,
+        intensity: pt.intensity,
+        radius: (pt.radius ?? 25) * pixelRatio,
+      });
+    }
+
+    renderer.updatePoints(heatmapPoints);
+
+    if (animFrameRef.current) {
+      cancelAnimationFrame(animFrameRef.current);
+    }
+
+    animFrameRef.current = requestAnimationFrame(() => {
+      if (rendererRef.current && visibleRef.current) {
+        rendererRef.current.render(
+          width * pixelRatio,
+          height * pixelRatio,
+          currentZoom,
+        );
+      }
+    });
+  };
+
+  // Mount-only setup: create the canvas + GL context ONCE per map instance.
+  // Notice `points` is NOT in this dependency array — that was the leak.
+  useEffect(() => {
+    if (!map || typeof window === "undefined" || !L?.DomUtil?.create) return;
+
+    const canvas = L.DomUtil.create(
+      "canvas",
+      "leaflet-webgl-heatmap-layer",
+    ) as HTMLCanvasElement;
     canvas.style.position = "absolute";
     canvas.style.top = "0";
     canvas.style.left = "0";
@@ -57,98 +134,44 @@ export function WebGLHeatmapLayer({
     overlayPane.appendChild(canvas);
     canvasRef.current = canvas;
 
-    // Initialize WebGL Heatmap Renderer
     const renderer = new WebGLHeatmapRenderer(canvas, { opacity, blur });
     rendererRef.current = renderer;
 
-    const updateCanvasPositionAndRender = () => {
-      if (!canvas || !rendererRef.current || !map) return;
+    map.on("move", renderFrame);
+    map.on("zoom", renderFrame);
+    map.on("resize", renderFrame);
 
-      const size = map.getSize();
-      const pixelRatio = window.devicePixelRatio || 1;
-
-      // Match canvas dimensions to viewport
-      const width = size.x;
-      const height = size.y;
-
-      if (canvas.width !== width * pixelRatio || canvas.height !== height * pixelRatio) {
-        canvas.width = width * pixelRatio;
-        canvas.height = height * pixelRatio;
-        canvas.style.width = `${width}px`;
-        canvas.style.height = `${height}px`;
-      }
-
-      // Reposition canvas overlay to map top-left
-      const topLeft = map.containerPointToLayerPoint([0, 0]);
-      L.DomUtil.setPosition(canvas, topLeft);
-
-      // Convert geographical points to viewport pixel coordinates
-      const heatmapPoints: HeatmapPoint[] = [];
-      const currentZoom = map.getZoom();
-
-      for (let i = 0; i < points.length; i++) {
-        const pt = points[i];
-        const containerPt = map.latLngToContainerPoint([pt.lat, pt.lng]);
-        
-        // Skip points far outside viewport bounds for optimization
-        if (
-          containerPt.x < -100 ||
-          containerPt.x > width + 100 ||
-          containerPt.y < -100 ||
-          containerPt.y > height + 100
-        ) {
-          continue;
-        }
-
-        heatmapPoints.push({
-          x: containerPt.x * pixelRatio,
-          y: containerPt.y * pixelRatio,
-          intensity: pt.intensity,
-          radius: (pt.radius ?? 25) * pixelRatio,
-        });
-      }
-
-      // Upload VBO buffer data to GPU
-      rendererRef.current.updatePoints(heatmapPoints);
-
-      // Request 60 FPS hardware frame render
-      if (animFrameRef.current) {
-        cancelAnimationFrame(animFrameRef.current);
-      }
-
-      animFrameRef.current = requestAnimationFrame(() => {
-        if (rendererRef.current && visible) {
-          rendererRef.current.render(width * pixelRatio, height * pixelRatio, currentZoom);
-        }
-      });
-    };
-
-    // Attach Leaflet map event listeners
-    map.on("move", updateCanvasPositionAndRender);
-    map.on("zoom", updateCanvasPositionAndRender);
-    map.on("resize", updateCanvasPositionAndRender);
-
-    // Initial render
-    updateCanvasPositionAndRender();
+    renderFrame();
 
     return () => {
       if (animFrameRef.current) {
         cancelAnimationFrame(animFrameRef.current);
+        animFrameRef.current = null;
       }
-      map.off("move", updateCanvasPositionAndRender);
-      map.off("zoom", updateCanvasPositionAndRender);
-      map.off("resize", updateCanvasPositionAndRender);
+      map.off("move", renderFrame);
+      map.off("zoom", renderFrame);
+      map.off("resize", renderFrame);
 
-      if (rendererRef.current) {
-        rendererRef.current.destroy();
-        rendererRef.current = null;
-      }
-      if (canvas && canvas.parentNode) {
+      rendererRef.current?.destroy();
+      rendererRef.current = null;
+
+      if (canvas.parentNode) {
         canvas.parentNode.removeChild(canvas);
       }
       canvasRef.current = null;
     };
-  }, [map, points, opacity, blur, visible]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [map]);
+
+  // Data/style updates: just re-upload + re-draw. Never touches the GL context.
+  useEffect(() => {
+    if (rendererRef.current) {
+      rendererRef.current.setOpacity(opacity);
+      rendererRef.current.setBlur(blur);
+    }
+    renderFrame();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [points, opacity, blur, visible]);
 
   return null;
 }

--- a/src/components/WebGLHeatmapLayer.tsx
+++ b/src/components/WebGLHeatmapLayer.tsx
@@ -53,6 +53,8 @@ export function WebGLHeatmapLayer({
     const canvas = canvasRef.current;
     const renderer = rendererRef.current;
     if (!canvas || !renderer || !map) return;
+    canvas.style.display = visibleRef.current ? "" : "none";
+    if (!visibleRef.current) return;
 
     const size = map.getSize();
     const pixelRatio = window.devicePixelRatio || 1;

--- a/src/lib/webgl/webglHeatmapRenderer.ts
+++ b/src/lib/webgl/webglHeatmapRenderer.ts
@@ -62,12 +62,24 @@ export class WebGLHeatmapRenderer {
 
   private initGL() {
     try {
+      // Defensive cleanup: if initGL() ever runs more than once (e.g. the
+      // context-recovery callback fires without a true context loss), free
+      // the previous program/buffer first so we never leak GPU resources.
+      if (this.gl) {
+        if (this.program) this.gl.deleteProgram(this.program);
+        if (this.vbo) this.gl.deleteBuffer(this.vbo);
+        this.program = null;
+        this.vbo = null;
+      }
+
       this.gl =
         (this.canvas.getContext("webgl2") as WebGL2RenderingContext | null) ||
         (this.canvas.getContext("webgl") as WebGLRenderingContext | null);
 
       if (!this.gl) {
-        console.warn("[WebGLHeatmap] WebGL context not supported by client environment.");
+        console.warn(
+          "[WebGLHeatmap] WebGL context not supported by client environment.",
+        );
         return;
       }
 
@@ -78,8 +90,14 @@ export class WebGLHeatmapRenderer {
       gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
 
       // Compile Shader Program
-      const vertShader = this.compileShader(gl.VERTEX_SHADER, HEATMAP_VERTEX_SHADER);
-      const fragShader = this.compileShader(gl.FRAGMENT_SHADER, HEATMAP_FRAGMENT_SHADER);
+      const vertShader = this.compileShader(
+        gl.VERTEX_SHADER,
+        HEATMAP_VERTEX_SHADER,
+      );
+      const fragShader = this.compileShader(
+        gl.FRAGMENT_SHADER,
+        HEATMAP_FRAGMENT_SHADER,
+      );
 
       if (!vertShader || !fragShader) return;
 
@@ -91,7 +109,10 @@ export class WebGLHeatmapRenderer {
       gl.linkProgram(program);
 
       if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
-        console.error("[WebGLHeatmap] Program link error:", gl.getProgramInfoLog(program));
+        console.error(
+          "[WebGLHeatmap] Program link error:",
+          gl.getProgramInfoLog(program),
+        );
         return;
       }
 
@@ -114,7 +135,7 @@ export class WebGLHeatmapRenderer {
       gl.bufferData(
         gl.ARRAY_BUFFER,
         this.maxPoints * 4 * Float32Array.BYTES_PER_ELEMENT,
-        gl.DYNAMIC_DRAW
+        gl.DYNAMIC_DRAW,
       );
     } catch (err) {
       console.error("[WebGLHeatmap] Context initialization error:", err);
@@ -130,7 +151,10 @@ export class WebGLHeatmapRenderer {
     this.gl.compileShader(shader);
 
     if (!this.gl.getShaderParameter(shader, this.gl.COMPILE_STATUS)) {
-      console.error("[WebGLHeatmap] Shader compile failed:", this.gl.getShaderInfoLog(shader));
+      console.error(
+        "[WebGLHeatmap] Shader compile failed:",
+        this.gl.getShaderInfoLog(shader),
+      );
       this.gl.deleteShader(shader);
       return null;
     }
@@ -164,7 +188,13 @@ export class WebGLHeatmapRenderer {
    * Render frame to canvas with hardware spatial clustering
    */
   public render(width: number, height: number, zoom: number = 1.0) {
-    if (!this.gl || !this.program || !this.vbo || this.pointsCount === 0 || this.isDestroyed) {
+    if (
+      !this.gl ||
+      !this.program ||
+      !this.vbo ||
+      this.pointsCount === 0 ||
+      this.isDestroyed
+    ) {
       return;
     }
 
@@ -191,11 +221,25 @@ export class WebGLHeatmapRenderer {
     }
     if (this.aIntensityLoc !== -1) {
       gl.enableVertexAttribArray(this.aIntensityLoc);
-      gl.vertexAttribPointer(this.aIntensityLoc, 1, gl.FLOAT, false, stride, 2 * Float32Array.BYTES_PER_ELEMENT);
+      gl.vertexAttribPointer(
+        this.aIntensityLoc,
+        1,
+        gl.FLOAT,
+        false,
+        stride,
+        2 * Float32Array.BYTES_PER_ELEMENT,
+      );
     }
     if (this.aRadiusLoc !== -1) {
       gl.enableVertexAttribArray(this.aRadiusLoc);
-      gl.vertexAttribPointer(this.aRadiusLoc, 1, gl.FLOAT, false, stride, 3 * Float32Array.BYTES_PER_ELEMENT);
+      gl.vertexAttribPointer(
+        this.aRadiusLoc,
+        1,
+        gl.FLOAT,
+        false,
+        stride,
+        3 * Float32Array.BYTES_PER_ELEMENT,
+      );
     }
 
     // Draw telemetry points


### PR DESCRIPTION
## Description
Fixes a memory leak in the WebGL heatmap layer where continuous pan/zoom on 4K
displays caused GPU VRAM to grow until the tab crashed .

<!-- Provide a clear and concise description of what this PR does and why it is needed. -->

## Related Issue

<!-- 
Please link to the issue here using the standard keywords. 
Example: Fixes #123 or Closes #123
-->
Fixes #828 

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

<!-- Add visual evidence if this PR changes UI/UX. -->

## Breaking Changes

- [ ] Yes (please describe below)
- [X] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved heatmap stability while moving, zooming, or resizing the map.
  - Ensured the latest heatmap points, visibility, opacity, and blur updates reliably apply without flicker.
  - Improved cleanup of graphics resources to help prevent leaks and stale visuals.
- **Performance**
  - Heatmap updates no longer recreate the WebGL layer during routine data or style changes.
  - Rendering now schedules efficiently via the next animation frame and avoids work when the layer is hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->