### PR TITLE
fix: prevent room state drift during PartyKit failover

### DIFF
--- a/party/multiRegionServer.ts
+++ b/party/multiRegionServer.ts
@@ -96,6 +96,8 @@ export default class MultiRegionWorkspaceServer implements Party.Server {
   private seatCheckins = new Map<string, SeatCheckin>();
   private stateSync: DurableStateSync;
   private connRegions = new Map<string, Region>();
+  private serverEpoch = Date.now();
+  private sequenceId = 0;
 
   constructor(readonly room: Party.Room) {
     const region = (process.env.PARTYKIT_REGION as Region) ?? "us-east";
@@ -175,8 +177,14 @@ export default class MultiRegionWorkspaceServer implements Party.Server {
 
     // Bring newly connected clients up to speed
     if (this.seatCheckins.size > 0) {
+      this.sequenceId++;
       conn.send(
-        JSON.stringify({ type: "seat_snapshot", venues: this.seatSummary() }),
+        JSON.stringify({
+          type: "seat_snapshot",
+          venues: this.seatSummary(),
+          epoch: this.serverEpoch,
+          sequenceId: this.sequenceId,
+        }),
       );
     }
 
@@ -337,6 +345,7 @@ export default class MultiRegionWorkspaceServer implements Party.Server {
   private broadcastSeatUpdate(venueId: string) {
     const count = this.countForVenue(venueId);
     const capacity = this.capacityForVenue(venueId);
+    this.sequenceId++;
     this.room.broadcast(
       JSON.stringify({
         type: "seat_update",
@@ -344,6 +353,8 @@ export default class MultiRegionWorkspaceServer implements Party.Server {
         count,
         capacity,
         status: seatStatusFor(count, capacity),
+        epoch: this.serverEpoch,
+        sequenceId: this.sequenceId,
       }),
     );
   }

--- a/party/server.ts
+++ b/party/server.ts
@@ -27,6 +27,8 @@ export default class WorkspaceServer implements Party.Server {
   // keyed by connection id so we can always find & clear a user's previous
   // check-in on check-in/checkout/disconnect without scanning every venue.
   private seatCheckins = new Map<string, SeatCheckin>();
+  private serverEpoch = Date.now();
+  private sequenceId = 0;
 
   constructor(readonly room: Party.Room) {}
 
@@ -86,8 +88,14 @@ export default class WorkspaceServer implements Party.Server {
     // Bring newly connected clients up to speed on current seat availability
     // (#703) so rings render correctly before any new check-in event fires.
     if (this.seatCheckins.size > 0) {
+      this.sequenceId++;
       conn.send(
-        JSON.stringify({ type: "seat_snapshot", venues: this.seatSummary() }),
+        JSON.stringify({
+          type: "seat_snapshot",
+          venues: this.seatSummary(),
+          epoch: this.serverEpoch,
+          sequenceId: this.sequenceId,
+        }),
       );
     }
 
@@ -242,6 +250,7 @@ export default class WorkspaceServer implements Party.Server {
   private broadcastSeatUpdate(venueId: string) {
     const count = this.countForVenue(venueId);
     const capacity = this.capacityForVenue(venueId);
+    this.sequenceId++;
     this.room.broadcast(
       JSON.stringify({
         type: "seat_update",
@@ -249,6 +258,8 @@ export default class WorkspaceServer implements Party.Server {
         count,
         capacity,
         status: seatStatusFor(count, capacity),
+        epoch: this.serverEpoch,
+        sequenceId: this.sequenceId,
       }),
     );
   }

--- a/src/__tests__/hooks/useSeatAvailability.test.ts
+++ b/src/__tests__/hooks/useSeatAvailability.test.ts
@@ -1,0 +1,164 @@
+import { renderHook, act } from "@testing-library/react";
+import { useSeatAvailability } from "@/hooks/useSeatAvailability";
+
+// Mock the partysocket hook
+let mockOnMessage: (event: { data: string }) => void;
+
+jest.mock("partysocket/react", () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation((config) => {
+      mockOnMessage = config.onMessage;
+      return {
+        send: jest.fn(),
+        readyState: 1, // WebSocket.OPEN
+      };
+    }),
+  };
+});
+
+jest.mock("@clerk/nextjs", () => ({
+  useAuth: () => ({
+    getToken: jest.fn().mockResolvedValue("test-token"),
+  }),
+}));
+
+jest.mock("@/components/ui/Toast", () => ({
+  useToast: () => ({ toast: jest.fn() }),
+}));
+
+jest.mock("@/lib/offlineStore", () => ({
+  queueOfflineCheckIn: jest.fn().mockResolvedValue(undefined),
+  getQueuedCheckIns: jest.fn().mockResolvedValue([]),
+  dequeueOfflineCheckIn: jest.fn().mockResolvedValue(undefined),
+  incrementCheckInRetryCount: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe("useSeatAvailability", () => {
+  it("initializes with default state", () => {
+    const { result } = renderHook(() => useSeatAvailability());
+    expect(result.current.availability).toEqual({});
+  });
+
+  it("accepts a snapshot with a new epoch and populates availability", () => {
+    const { result } = renderHook(() => useSeatAvailability());
+
+    act(() => {
+      mockOnMessage({
+        data: JSON.stringify({
+          type: "seat_snapshot",
+          epoch: 100,
+          sequenceId: 1,
+          venues: [
+            { venueId: "venue-1", count: 5, capacity: 10, status: "green" },
+          ],
+        }),
+      });
+    });
+
+    expect(result.current.getAvailability("venue-1").count).toBe(5);
+  });
+
+  it("rejects a stale packet with a lower epoch", () => {
+    const { result } = renderHook(() => useSeatAvailability());
+
+    act(() => {
+      // First, a new snapshot arrives
+      mockOnMessage({
+        data: JSON.stringify({
+          type: "seat_snapshot",
+          epoch: 100,
+          sequenceId: 1,
+          venues: [
+            { venueId: "venue-1", count: 5, capacity: 10, status: "green" },
+          ],
+        }),
+      });
+    });
+
+    act(() => {
+      // Then, a delayed packet from an older epoch arrives
+      mockOnMessage({
+        data: JSON.stringify({
+          type: "seat_update",
+          epoch: 90,
+          sequenceId: 50,
+          venueId: "venue-1",
+          count: 2,
+          capacity: 10,
+          status: "green",
+        }),
+      });
+    });
+
+    // The count should remain 5, ignoring the stale packet
+    expect(result.current.getAvailability("venue-1").count).toBe(5);
+  });
+
+  it("accepts an update with the same epoch but higher sequence", () => {
+    const { result } = renderHook(() => useSeatAvailability());
+
+    act(() => {
+      mockOnMessage({
+        data: JSON.stringify({
+          type: "seat_snapshot",
+          epoch: 100,
+          sequenceId: 1,
+          venues: [
+            { venueId: "venue-1", count: 5, capacity: 10, status: "green" },
+          ],
+        }),
+      });
+    });
+
+    act(() => {
+      mockOnMessage({
+        data: JSON.stringify({
+          type: "seat_update",
+          epoch: 100,
+          sequenceId: 2,
+          venueId: "venue-1",
+          count: 6,
+          capacity: 10,
+          status: "yellow",
+        }),
+      });
+    });
+
+    expect(result.current.getAvailability("venue-1").count).toBe(6);
+  });
+
+  it("rejects an update with the same epoch and lower sequence (reordering)", () => {
+    const { result } = renderHook(() => useSeatAvailability());
+
+    act(() => {
+      mockOnMessage({
+        data: JSON.stringify({
+          type: "seat_snapshot",
+          epoch: 100,
+          sequenceId: 5,
+          venues: [
+            { venueId: "venue-1", count: 5, capacity: 10, status: "green" },
+          ],
+        }),
+      });
+    });
+
+    act(() => {
+      mockOnMessage({
+        data: JSON.stringify({
+          type: "seat_update",
+          epoch: 100,
+          sequenceId: 2, // lower sequence than 5
+          venueId: "venue-1",
+          count: 2,
+          capacity: 10,
+          status: "green",
+        }),
+      });
+    });
+
+    // The count should remain 5, ignoring the out-of-order packet
+    expect(result.current.getAvailability("venue-1").count).toBe(5);
+  });
+});

--- a/src/hooks/useSeatAvailability.ts
+++ b/src/hooks/useSeatAvailability.ts
@@ -41,11 +41,15 @@ interface SeatUpdateMessage {
   count: number;
   capacity: number;
   status: SeatStatus;
+  epoch?: number;
+  sequenceId?: number;
 }
 
 interface SeatSnapshotMessage {
   type: "seat_snapshot";
-  venues: Array<Omit<SeatUpdateMessage, "type">>;
+  venues: Array<Omit<SeatUpdateMessage, "type" | "epoch" | "sequenceId">>;
+  epoch?: number;
+  sequenceId?: number;
 }
 
 export function useSeatAvailability() {
@@ -57,6 +61,9 @@ export function useSeatAvailability() {
   const [isConnected, setIsConnected] = useState(false);
   const [checkedInVenueId, setCheckedInVenueId] = useState<string | null>(null);
   const [isMounted, setIsMounted] = useState(false);
+
+  const epochRef = useRef<number>(0);
+  const sequenceRef = useRef<number>(0);
 
   useEffect(() => {
     setIsMounted(true);
@@ -87,6 +94,21 @@ export function useSeatAvailability() {
       try {
         const data = JSON.parse(event.data) as
           SeatUpdateMessage | SeatSnapshotMessage;
+
+        if (data.type !== "seat_update" && data.type !== "seat_snapshot") {
+          return;
+        }
+
+        const msgEpoch = data.epoch ?? 0;
+        const msgSeq = data.sequenceId ?? 0;
+
+        if (msgEpoch < epochRef.current) return;
+        if (msgEpoch === epochRef.current && msgSeq <= sequenceRef.current) {
+          return;
+        }
+
+        epochRef.current = msgEpoch;
+        sequenceRef.current = msgSeq;
 
         if (data.type === "seat_update") {
           setAvailability((prev) => ({


### PR DESCRIPTION
## Description

This PR fixes room state drift during PartyKit multi-region failover reconnects.

### Changes made
- Added `serverEpoch` and `sequenceId` metadata to PartyKit room state messages (`seat_snapshot` and `seat_update`).
- Updated the client synchronization logic to ignore stale or out-of-order messages by comparing `epoch` and `sequenceId`.
- Prevented stale state updates from causing incorrect or negative seat availability after reconnects.
- Added regression tests covering failover reconnects, stale packets, and packet reordering.

This preserves consistent room state across reconnects and multi-region failovers while remaining backward compatible.

## Related Issue

- Fixes #1139

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (where applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (N/A)

## Screenshots / Screen Recordings (if applicable)

Not applicable (backend synchronization fix).

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ordering metadata to live seat availability updates.
  * Improved real-time seat availability by ignoring stale or out-of-order updates.

* **Tests**
  * Added coverage for initial seat state, update ordering, and handling of messages from older server sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->