### PR TITLE
fix: recover WebAudio after Bluetooth device changes

### DIFF
--- a/src/__tests__/components/NoiseMeter.test.tsx
+++ b/src/__tests__/components/NoiseMeter.test.tsx
@@ -24,6 +24,8 @@ describe("NoiseMeter Component & 60fps Audio Throttling", () => {
       value: {
         mediaDevices: {
           getUserMedia: mockGetUserMedia,
+          addEventListener: jest.fn(),
+          removeEventListener: jest.fn(),
         },
       },
       configurable: true,
@@ -191,5 +193,84 @@ describe("NoiseMeter Component & 60fps Audio Throttling", () => {
     // Frame 5: 33.34ms -> Should EXECUTE
     tick(33.34);
     expect(getFloatTimeDomainDataCalls).toBe(3);
+  });
+
+  it("handles devicechange by resuming AudioContext and re-acquiring stream if ended", async () => {
+    let deviceChangeCb: EventListener | null = null;
+    const mockResume = jest.fn().mockResolvedValue(undefined);
+
+    const mockTrack = { stop: jest.fn(), readyState: "live" };
+    const mockStream = {
+      getAudioTracks: () => [mockTrack],
+      getTracks: () => [mockTrack],
+    };
+    mockGetUserMedia.mockResolvedValue(mockStream);
+
+    global.navigator.mediaDevices.addEventListener = jest.fn((evt, cb) => {
+      if (evt === "devicechange") deviceChangeCb = cb;
+    });
+
+    const mockAudioContext = {
+      createMediaStreamSource: jest
+        .fn()
+        .mockReturnValue({ connect: jest.fn(), disconnect: jest.fn() }),
+      createAnalyser: jest
+        .fn()
+        .mockReturnValue({
+          fftSize: 2048,
+          smoothingTimeConstant: 0.25,
+          disconnect: jest.fn(),
+          getFloatTimeDomainData: jest.fn(),
+        }),
+      close: jest.fn().mockResolvedValue(undefined),
+      resume: mockResume,
+      state: "suspended",
+    };
+
+    Object.defineProperty(global, "AudioContext", {
+      value: jest.fn().mockImplementation(() => mockAudioContext),
+      writable: true,
+    });
+
+    render(<NoiseMeter onMeasured={mockOnMeasured} />);
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: /Measure Ambient Noise/i }),
+      );
+      await jest.advanceTimersByTimeAsync(50);
+    });
+
+    expect(deviceChangeCb).not.toBeNull();
+
+    // Trigger devicechange (context suspended -> calls resume)
+    await act(async () => {
+      if (deviceChangeCb) {
+        await (deviceChangeCb as EventListener)(new Event("devicechange"));
+      }
+    });
+
+    expect(mockResume).toHaveBeenCalled();
+
+    // Trigger devicechange with ended track (requires re-acquiring stream)
+    mockTrack.readyState = "ended";
+    const mockTrack2 = { stop: jest.fn(), readyState: "live" };
+    const newMockStream = {
+      getAudioTracks: () => [mockTrack2],
+      getTracks: () => [mockTrack2],
+    };
+    mockGetUserMedia.mockResolvedValueOnce(newMockStream);
+
+    await act(async () => {
+      if (deviceChangeCb) {
+        await (deviceChangeCb as EventListener)(new Event("devicechange"));
+      }
+    });
+
+    expect(mockGetUserMedia).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(5000);
+    });
   });
 });

--- a/src/components/noise/NoiseMeter.tsx
+++ b/src/components/noise/NoiseMeter.tsx
@@ -84,7 +84,7 @@ export function NoiseMeter({ onMeasured }: Props) {
     setResult(null);
 
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({
+      let stream = await navigator.mediaDevices.getUserMedia({
         audio: {
           echoCancellation: false,
           noiseSuppression: false,
@@ -105,7 +105,7 @@ export function NoiseMeter({ onMeasured }: Props) {
       }
 
       const audioContext = new AudioContextClass();
-      const source = audioContext.createMediaStreamSource(stream);
+      let source = audioContext.createMediaStreamSource(stream);
       const analyser = audioContext.createAnalyser();
 
       analyser.fftSize = 2048;
@@ -122,6 +122,10 @@ export function NoiseMeter({ onMeasured }: Props) {
           "visibilitychange",
           handleVisibilityChange,
         );
+        navigator.mediaDevices.removeEventListener(
+          "devicechange",
+          handleDeviceChange,
+        );
         cancelAnimationFrame(animationFrame);
         try {
           source.disconnect();
@@ -134,6 +138,45 @@ export function NoiseMeter({ onMeasured }: Props) {
           audioContext.close().catch(() => {});
         }
       };
+
+      const handleDeviceChange = async () => {
+        if (!audioContext || audioContext.state === "closed") return;
+
+        try {
+          if (audioContext.state !== "running") {
+            await audioContext.resume();
+          }
+
+          const track = stream.getAudioTracks()[0];
+          if (track && track.readyState === "ended") {
+            const newStream = await navigator.mediaDevices.getUserMedia({
+              audio: {
+                echoCancellation: false,
+                noiseSuppression: false,
+                autoGainControl: false,
+              },
+            });
+
+            try {
+              source.disconnect();
+            } catch {}
+
+            stream = newStream;
+            source = audioContext.createMediaStreamSource(stream);
+            source.connect(analyser);
+          }
+        } catch (error) {
+          console.error(
+            "Failed to recover audio context after device change:",
+            error,
+          );
+        }
+      };
+
+      navigator.mediaDevices.addEventListener(
+        "devicechange",
+        handleDeviceChange,
+      );
 
       const handleVisibilityChange = () => {
         if (document.hidden) {


### PR DESCRIPTION
## Description

This PR fixes a WebAudio recovery issue that occurs when switching audio output devices (such as Bluetooth headsets) while the real-time noise meter is active.

### Changes
- Added a `devicechange` listener using the MediaDevices API.
- Resumed the existing `AudioContext` when it becomes suspended or interrupted.
- Reacquired the microphone stream if the active `MediaStreamTrack` ended.
- Reconnected the existing analyser without creating duplicate `AudioContext` instances.
- Added cleanup for the device change listener to prevent memory leaks.
- Added unit tests covering audio recovery after device changes.

## Related Issue

- Fixes #1134

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

N/A (No UI changes)

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved noise measurement reliability when audio devices are changed during an active session.
  * Automatically resumes audio processing and reacquires microphone access when the current input track ends.
  * Ensures device-change monitoring is properly cleaned up when measurement stops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->