### PR TITLE
docs: add Upstash Redis setup instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,18 @@ GROQ_API_KEY=gsk_...
 
 # Pexels (for venue photos - free at pexels.com/api)
 PEXELS_API_KEY=your_pexels_key_here
+
+# Upstash Redis (for distributed rate limiting)
+UPSTASH_REDIS_REST_URL=https://your-upstash-redis-endpoint.upstash.io
+UPSTASH_REDIS_REST_TOKEN=your-upstash-redis-token
 ```
+
+You can obtain the Upstash Redis credentials from your Upstash Redis database dashboard.
+
+The Upstash Redis variables are optional for local development. If UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN are omitted, the application falls back to an in-memory rate limiter. This allows the application to run locally without an Upstash Redis configuration, but rate-limit state is stored only in the local application memory and is not shared across multiple instances or processes.
+
+For production or multi-instance deployments, configuring Upstash Redis is recommended to ensure consistent rate limiting across application instances.
+
 
 ### Getting API Keys
 
@@ -428,6 +439,8 @@ PEXELS_API_KEY=your_pexels_key_here
 | `POST`   | `/api/webhook`            | Clerk webhook for user sync            |
 
 ---
+
+
 
 ## 🤖 Multi-Agent System
 


### PR DESCRIPTION
## Description

Updated the local setup documentation in README.md to include the required Upstash Redis environment variables for rate limiting.

### This change:
- Adds example values for UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN.
- Explains how to obtain the Upstash Redis credentials.
- Documents the in-memory rate limiter fallback when Upstash Redis environment variables are not configured.
- Clarifies that Upstash Redis is recommended for production and multi-instance deployments.

## Related Issue

Fixes #1203 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

N/A. Documentation changes only.

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented optional Upstash Redis environment variables for distributed rate limiting.
  * Clarified that local development can use in-memory rate limiting, while production and multi-instance deployments should configure shared Redis-based state.
  * Improved spacing between API routes and multi-agent system documentation sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->