### PR TITLE
feat: add WebGPU heat diffusion heatmap for venue floor plans

### DIFF
--- a/src/__tests__/components/HeatDiffusionOverlay.test.tsx
+++ b/src/__tests__/components/HeatDiffusionOverlay.test.tsx
@@ -1,0 +1,91 @@
+/** @jest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { HeatDiffusionOverlay } from "@/components/venue/floorplan/HeatDiffusionOverlay";
+
+Object.defineProperty(navigator, "gpu", {
+  value: undefined,
+  configurable: true,
+});
+
+HTMLCanvasElement.prototype.getContext = jest.fn((type: string) => {
+  if (type === "webgl2") {
+    return {
+      createShader: jest.fn(() => ({})),
+      shaderSource: jest.fn(),
+      compileShader: jest.fn(),
+      getShaderParameter: jest.fn(() => true),
+      getShaderInfoLog: jest.fn(() => ""),
+      deleteShader: jest.fn(),
+      createProgram: jest.fn(() => ({})),
+      attachShader: jest.fn(),
+      linkProgram: jest.fn(),
+      getProgramParameter: jest.fn(() => true),
+      getProgramInfoLog: jest.fn(() => ""),
+      createBuffer: jest.fn(() => ({})),
+      createVertexArray: jest.fn(() => ({})),
+      bindVertexArray: jest.fn(),
+      bindBuffer: jest.fn(),
+      bufferData: jest.fn(),
+      getAttribLocation: jest.fn(() => 0),
+      enableVertexAttribArray: jest.fn(),
+      vertexAttribPointer: jest.fn(),
+      createTexture: jest.fn(() => ({})),
+      bindTexture: jest.fn(),
+      texParameteri: jest.fn(),
+      texImage2D: jest.fn(),
+      enable: jest.fn(),
+      blendFunc: jest.fn(),
+      viewport: jest.fn(),
+      clearColor: jest.fn(),
+      clear: jest.fn(),
+      useProgram: jest.fn(),
+      activeTexture: jest.fn(),
+      getUniformLocation: jest.fn(() => ({})),
+      uniform1i: jest.fn(),
+      uniform1f: jest.fn(),
+      drawArrays: jest.fn(),
+      deleteTexture: jest.fn(),
+      deleteProgram: jest.fn(),
+      deleteVertexArray: jest.fn(),
+      VERTEX_SHADER: 35633,
+      FRAGMENT_SHADER: 35632,
+      COMPILE_STATUS: 35713,
+      LINK_STATUS: 35714,
+      ARRAY_BUFFER: 34962,
+      STATIC_DRAW: 35044,
+      TEXTURE_2D: 3553,
+      TEXTURE_MIN_FILTER: 10241,
+      TEXTURE_MAG_FILTER: 10240,
+      TEXTURE_WRAP_S: 10242,
+      TEXTURE_WRAP_T: 10243,
+      LINEAR: 9729,
+      CLAMP_TO_EDGE: 33071,
+      R32F: 33326,
+      RED: 6403,
+      FLOAT: 5126,
+      TEXTURE0: 33984,
+      BLEND: 3042,
+      SRC_ALPHA: 770,
+      ONE_MINUS_SRC_ALPHA: 771,
+      COLOR_BUFFER_BIT: 16384,
+      TRIANGLES: 4,
+    };
+  }
+  return null;
+}) as typeof HTMLCanvasElement.prototype.getContext;
+
+describe("HeatDiffusionOverlay", () => {
+  it("renders the thermal overlay chrome", async () => {
+    render(<HeatDiffusionOverlay width={320} height={200} />);
+    expect(screen.getByText(/Thermal Diffusion/i)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/Venue temperature heatmap overlay/i),
+    ).toBeInTheDocument();
+  });
+
+  it("exposes pause and reset controls", () => {
+    render(<HeatDiffusionOverlay />);
+    expect(screen.getByLabelText(/Pause simulation/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Reset simulation/i)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/lib/heatDiffusion.test.ts
+++ b/src/__tests__/lib/heatDiffusion.test.ts
@@ -1,0 +1,76 @@
+import {
+  createAmbientGrid,
+  stepHeatDiffusion,
+  temperatureToRgba,
+} from "@/lib/webgpu/heatEquation";
+import {
+  HEAT_DIFFUSION_COMPUTE,
+  HEAT_HEATMAP_RENDER,
+  HEAT_FALLBACK_FRAG,
+  HEAT_FALLBACK_VERT,
+} from "@/lib/webgpu/heatShaders.wgsl";
+
+describe("heatEquation", () => {
+  it("seeds ambient grid and HVAC sensor cells", () => {
+    const grid = createAmbientGrid(4, 4, 22, [
+      { x: 1, y: 1, temperature: 30 },
+    ]);
+    expect(grid[0]).toBe(22);
+    expect(grid[1 * 4 + 1]).toBe(30);
+  });
+
+  it("diffuses heat away from a hot HVAC sensor over steps", () => {
+    const w = 8;
+    const h = 8;
+    const sensors = [{ x: 4, y: 4, temperature: 30 }];
+    let a = createAmbientGrid(w, h, 20, sensors);
+    let b = new Float32Array(a.length);
+
+    for (let i = 0; i < 40; i++) {
+      stepHeatDiffusion(a, b, {
+        width: w,
+        height: h,
+        alpha: 0.2,
+        dt: 1,
+        ambient: 20,
+        sensors,
+      });
+      [a, b] = [b, a];
+    }
+
+    // Neighbor of the sensor should warm above ambient
+    expect(a[4 * w + 5]).toBeGreaterThan(20.5);
+    // Sensor cell stays pinned
+    expect(a[4 * w + 4]).toBe(30);
+  });
+
+  it("maps temperatures onto the heatmap ramp", () => {
+    const cool = temperatureToRgba(18, 18, 32, 0.8);
+    const hot = temperatureToRgba(32, 18, 32, 0.8);
+    expect(cool[2]).toBeGreaterThan(cool[0]); // bluish
+    expect(hot[0]).toBeGreaterThan(hot[2]); // reddish
+    expect(hot[3]).toBe(0.8);
+  });
+});
+
+describe("heatShaders", () => {
+  it("exports a WGSL compute entry for the 2D heat equation", () => {
+    expect(HEAT_DIFFUSION_COMPUTE).toContain("@compute");
+    expect(HEAT_DIFFUSION_COMPUTE).toContain("cs_main");
+    expect(HEAT_DIFFUSION_COMPUTE).toContain("tempIn");
+    expect(HEAT_DIFFUSION_COMPUTE).toContain("tempOut");
+    expect(HEAT_DIFFUSION_COMPUTE).toContain("sensors");
+  });
+
+  it("exports WGSL heatmap render shaders", () => {
+    expect(HEAT_HEATMAP_RENDER).toContain("@vertex");
+    expect(HEAT_HEATMAP_RENDER).toContain("@fragment");
+    expect(HEAT_HEATMAP_RENDER).toContain("heatColor");
+  });
+
+  it("exports WebGL 2.0 fallback GLSL", () => {
+    expect(HEAT_FALLBACK_VERT).toContain("#version 300 es");
+    expect(HEAT_FALLBACK_FRAG).toContain("u_temp");
+    expect(HEAT_FALLBACK_FRAG).toContain("heatColor");
+  });
+});

--- a/src/components/venue/floorplan/HeatDiffusionOverlay.tsx
+++ b/src/components/venue/floorplan/HeatDiffusionOverlay.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Pause, Play, RotateCcw, Thermometer } from "lucide-react";
+import { HeatDiffusionEngine } from "@/lib/webgpu/heatDiffusion";
+import { HeatDiffusionFallback } from "@/lib/webgpu/heatDiffusionFallback";
+import type { HvacSensor } from "@/lib/webgpu/heatEquation";
+
+export type HeatDiffusionOverlayProps = {
+  width?: number;
+  height?: number;
+  gridWidth?: number;
+  gridHeight?: number;
+  /** HVAC / temperature sensor telemetry mapped onto the seating grid */
+  sensors?: HvacSensor[];
+};
+
+/**
+ * Real-time thermal diffusion heatmap overlaid on a venue seating grid.
+ * Prefers WebGPU WGSL compute; falls back to WebGL 2.0 + CPU Jacobi.
+ */
+export function HeatDiffusionOverlay({
+  width = 720,
+  height = 420,
+  gridWidth = 64,
+  gridHeight = 64,
+  sensors,
+}: HeatDiffusionOverlayProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const engineRef = useRef<HeatDiffusionEngine | null>(null);
+  const fallbackRef = useRef<HeatDiffusionFallback | null>(null);
+  const [mode, setMode] = useState<"detecting" | "WebGPU" | "WebGL 2.0">(
+    "detecting",
+  );
+  const [paused, setPaused] = useState(false);
+
+  const tearDown = useCallback(() => {
+    engineRef.current?.destroy();
+    fallbackRef.current?.destroy();
+    engineRef.current = null;
+    fallbackRef.current = null;
+  }, []);
+
+  const startFallback = useCallback(
+    (canvas: HTMLCanvasElement) => {
+      const fallback = new HeatDiffusionFallback(canvas, {
+        width: gridWidth,
+        height: gridHeight,
+        sensors,
+      });
+      if (!fallback.initialize()) {
+        setMode("WebGL 2.0");
+        return;
+      }
+      fallbackRef.current = fallback;
+      setMode("WebGL 2.0");
+      fallback.start();
+    },
+    [gridHeight, gridWidth, sensors],
+  );
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    canvas.width = width;
+    canvas.height = height;
+    let cancelled = false;
+
+    (async () => {
+      if (navigator.gpu) {
+        const engine = new HeatDiffusionEngine(canvas, {
+          width: gridWidth,
+          height: gridHeight,
+          sensors,
+        });
+        const ok = await engine.initialize();
+        if (cancelled) {
+          engine.destroy();
+          return;
+        }
+        if (ok) {
+          engineRef.current = engine;
+          setMode("WebGPU");
+          engine.start();
+          return;
+        }
+        engine.destroy();
+      }
+      if (!cancelled) startFallback(canvas);
+    })();
+
+    return () => {
+      cancelled = true;
+      tearDown();
+    };
+  }, [gridHeight, gridWidth, height, sensors, startFallback, tearDown, width]);
+
+  const togglePause = useCallback(() => {
+    setPaused((p) => {
+      const next = !p;
+      if (next) {
+        engineRef.current?.stop();
+        fallbackRef.current?.stop();
+      } else {
+        engineRef.current?.start();
+        fallbackRef.current?.start();
+      }
+      return next;
+    });
+  }, []);
+
+  const handleReset = useCallback(() => {
+    tearDown();
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    setPaused(false);
+    setMode("detecting");
+    (async () => {
+      if (navigator.gpu) {
+        const engine = new HeatDiffusionEngine(canvas, {
+          width: gridWidth,
+          height: gridHeight,
+          sensors,
+        });
+        if (await engine.initialize()) {
+          engineRef.current = engine;
+          setMode("WebGPU");
+          engine.start();
+          return;
+        }
+        engine.destroy();
+      }
+      startFallback(canvas);
+    })();
+  }, [gridHeight, gridWidth, sensors, startFallback, tearDown]);
+
+  return (
+    <div className="overflow-hidden rounded-2xl border border-zinc-200 bg-zinc-50 shadow-md dark:border-zinc-800 dark:bg-zinc-900/60">
+      <div className="flex items-center justify-between gap-3 border-b border-zinc-200 p-4 dark:border-zinc-800">
+        <div className="flex items-start gap-2">
+          <Thermometer className="mt-0.5 h-4 w-4 text-orange-500" />
+          <div>
+            <p className="text-sm font-bold uppercase tracking-tight text-zinc-900 dark:text-zinc-50">
+              Thermal Diffusion
+            </p>
+            <p className="mt-1 text-[11px] text-zinc-500 dark:text-zinc-400">
+              {mode === "detecting"
+                ? "Detecting GPU…"
+                : `${mode} heat equation`}{" "}
+              • HVAC seating map overlay
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={togglePause}
+            className="rounded-lg p-2 text-zinc-600 hover:bg-zinc-200 dark:text-zinc-300 dark:hover:bg-zinc-800"
+            aria-label={paused ? "Resume simulation" : "Pause simulation"}
+          >
+            {paused ? (
+              <Play className="h-4 w-4" />
+            ) : (
+              <Pause className="h-4 w-4" />
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={handleReset}
+            className="rounded-lg p-2 text-zinc-600 hover:bg-zinc-200 dark:text-zinc-300 dark:hover:bg-zinc-800"
+            aria-label="Reset simulation"
+          >
+            <RotateCcw className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+      <div className="relative bg-zinc-950">
+        <canvas
+          ref={canvasRef}
+          width={width}
+          height={height}
+          className="block h-auto w-full"
+          aria-label="Venue temperature heatmap overlay"
+        />
+        <div className="pointer-events-none absolute bottom-3 left-3 flex items-center gap-2 rounded-md bg-black/50 px-2 py-1 text-[10px] text-zinc-200">
+          <span className="h-2 w-8 rounded-sm bg-gradient-to-r from-blue-600 via-yellow-400 to-red-500" />
+          cool → warm
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/webgpu/heatDiffusion.ts
+++ b/src/lib/webgpu/heatDiffusion.ts
@@ -1,0 +1,424 @@
+/**
+ * WebGPU heat-diffusion engine: WGSL Jacobi compute + heatmap render overlay.
+ */
+
+import {
+  HEAT_DIFFUSION_COMPUTE,
+  HEAT_HEATMAP_RENDER,
+} from "./heatShaders.wgsl";
+import {
+  createAmbientGrid,
+  DEFAULT_HEAT_GRID,
+  type HeatDiffusionConfig,
+  type HvacSensor,
+} from "./heatEquation";
+
+export type { HeatDiffusionConfig, HvacSensor };
+
+const BufferUsage =
+  typeof GPUBufferUsage !== "undefined"
+    ? GPUBufferUsage
+    : {
+        COPY_DST: 0x0008,
+        UNIFORM: 0x0040,
+        STORAGE: 0x0080,
+      };
+
+const ShaderStage =
+  typeof GPUShaderStage !== "undefined"
+    ? GPUShaderStage
+    : { VERTEX: 0x1, FRAGMENT: 0x2, COMPUTE: 0x4 };
+
+export class HeatDiffusionEngine {
+  private canvas: HTMLCanvasElement;
+  private config: Required<
+    Pick<
+      HeatDiffusionConfig,
+      | "width"
+      | "height"
+      | "alpha"
+      | "dt"
+      | "ambient"
+      | "minTemp"
+      | "maxTemp"
+      | "opacity"
+    >
+  > & { sensors: HvacSensor[] };
+
+  private device: GPUDevice | null = null;
+  private context: GPUCanvasContext | null = null;
+  private format: GPUTextureFormat = "bgra8unorm";
+
+  private tempBufferA: GPUBuffer | null = null;
+  private tempBufferB: GPUBuffer | null = null;
+  private paramsBuffer: GPUBuffer | null = null;
+  private sensorBuffer: GPUBuffer | null = null;
+  private renderUniformBuffer: GPUBuffer | null = null;
+  private sizeBuffer: GPUBuffer | null = null;
+
+  private computePipeline: GPUComputePipeline | null = null;
+  private renderPipeline: GPURenderPipeline | null = null;
+  private bindGroupA: GPUBindGroup | null = null;
+  private bindGroupB: GPUBindGroup | null = null;
+  private renderBindGroupA: GPUBindGroup | null = null;
+  private renderBindGroupB: GPUBindGroup | null = null;
+
+  private ping = true;
+  private raf = 0;
+  private running = false;
+  private cpuGrid: Float32Array;
+
+  constructor(canvas: HTMLCanvasElement, config: HeatDiffusionConfig = {}) {
+    this.canvas = canvas;
+    this.config = {
+      width: config.width ?? DEFAULT_HEAT_GRID.width,
+      height: config.height ?? DEFAULT_HEAT_GRID.height,
+      alpha: config.alpha ?? DEFAULT_HEAT_GRID.alpha,
+      dt: config.dt ?? DEFAULT_HEAT_GRID.dt,
+      ambient: config.ambient ?? DEFAULT_HEAT_GRID.ambient,
+      sensors: config.sensors ?? defaultSensors(config.width ?? 64, config.height ?? 64),
+      minTemp: config.minTemp ?? 18,
+      maxTemp: config.maxTemp ?? 32,
+      opacity: config.opacity ?? 0.72,
+    };
+    this.cpuGrid = createAmbientGrid(
+      this.config.width,
+      this.config.height,
+      this.config.ambient,
+      this.config.sensors,
+    );
+  }
+
+  async initialize(): Promise<boolean> {
+    if (!navigator.gpu) return false;
+
+    try {
+      const adapter = await navigator.gpu.requestAdapter();
+      if (!adapter) return false;
+
+      this.device = await adapter.requestDevice();
+      this.context = this.canvas.getContext("webgpu") as GPUCanvasContext | null;
+      if (!this.context) return false;
+
+      this.format = navigator.gpu.getPreferredCanvasFormat();
+      this.context.configure({
+        device: this.device,
+        format: this.format,
+        alphaMode: "premultiplied",
+      });
+
+      await this.createBuffers();
+      await this.createPipelines();
+      return true;
+    } catch (err) {
+      console.warn("[HeatDiffusion] WebGPU init failed:", err);
+      this.destroy();
+      return false;
+    }
+  }
+
+  private async createBuffers(): Promise<void> {
+    if (!this.device) return;
+    const cells = this.config.width * this.config.height;
+    const tempBytes = cells * 4;
+
+    this.tempBufferA = this.device.createBuffer({
+      size: tempBytes,
+      usage: BufferUsage.STORAGE | BufferUsage.COPY_DST,
+    });
+    this.tempBufferB = this.device.createBuffer({
+      size: tempBytes,
+      usage: BufferUsage.STORAGE | BufferUsage.COPY_DST,
+    });
+    this.device.queue.writeBuffer(this.tempBufferA, 0, this.cpuGrid);
+    this.device.queue.writeBuffer(this.tempBufferB, 0, this.cpuGrid);
+
+    // HeatParams: 8 x f32/u32 = 32 bytes
+    this.paramsBuffer = this.device.createBuffer({
+      size: 32,
+      usage: BufferUsage.UNIFORM | BufferUsage.COPY_DST,
+    });
+    this.writeParams();
+
+    const sensorCount = Math.max(this.config.sensors.length, 1);
+    const sensorBytes = sensorCount * 16;
+    this.sensorBuffer = this.device.createBuffer({
+      size: sensorBytes,
+      usage: BufferUsage.STORAGE | BufferUsage.COPY_DST,
+    });
+    this.writeSensors();
+
+    this.renderUniformBuffer = this.device.createBuffer({
+      size: 16,
+      usage: BufferUsage.UNIFORM | BufferUsage.COPY_DST,
+    });
+    this.device.queue.writeBuffer(
+      this.renderUniformBuffer,
+      0,
+      new Float32Array([
+        this.config.minTemp,
+        this.config.maxTemp,
+        this.config.opacity,
+        0,
+      ]),
+    );
+
+    this.sizeBuffer = this.device.createBuffer({
+      size: 16,
+      usage: BufferUsage.UNIFORM | BufferUsage.COPY_DST,
+    });
+    this.device.queue.writeBuffer(
+      this.sizeBuffer,
+      0,
+      new Uint32Array([this.config.width, this.config.height, 0, 0]),
+    );
+  }
+
+  private writeParams(): void {
+    if (!this.device || !this.paramsBuffer) return;
+    const u32 = new Uint32Array(8);
+    const f32 = new Float32Array(u32.buffer);
+    u32[0] = this.config.width;
+    u32[1] = this.config.height;
+    f32[2] = this.config.alpha;
+    f32[3] = this.config.dt;
+    f32[4] = this.config.ambient;
+    u32[5] = this.config.sensors.length;
+    this.device.queue.writeBuffer(this.paramsBuffer, 0, u32);
+  }
+
+  private writeSensors(): void {
+    if (!this.device || !this.sensorBuffer) return;
+    const list =
+      this.config.sensors.length > 0
+        ? this.config.sensors
+        : [{ x: 0, y: 0, temperature: this.config.ambient }];
+    const data = new ArrayBuffer(list.length * 16);
+    const view = new DataView(data);
+    list.forEach((s, i) => {
+      const o = i * 16;
+      view.setUint32(o, s.x, true);
+      view.setUint32(o + 4, s.y, true);
+      view.setFloat32(o + 8, s.temperature, true);
+      view.setFloat32(o + 12, 0, true);
+    });
+    this.device.queue.writeBuffer(this.sensorBuffer, 0, data);
+  }
+
+  private async createPipelines(): Promise<void> {
+    if (!this.device) return;
+
+    const computeModule = this.device.createShaderModule({
+      code: HEAT_DIFFUSION_COMPUTE,
+    });
+    const renderModule = this.device.createShaderModule({
+      code: HEAT_HEATMAP_RENDER,
+    });
+
+    const computeLayout = this.device.createBindGroupLayout({
+      entries: [
+        {
+          binding: 0,
+          visibility: ShaderStage.COMPUTE,
+          buffer: { type: "uniform" },
+        },
+        {
+          binding: 1,
+          visibility: ShaderStage.COMPUTE,
+          buffer: { type: "read-only-storage" },
+        },
+        {
+          binding: 2,
+          visibility: ShaderStage.COMPUTE,
+          buffer: { type: "storage" },
+        },
+        {
+          binding: 3,
+          visibility: ShaderStage.COMPUTE,
+          buffer: { type: "read-only-storage" },
+        },
+      ],
+    });
+
+    this.computePipeline = this.device.createComputePipeline({
+      layout: this.device.createPipelineLayout({
+        bindGroupLayouts: [computeLayout],
+      }),
+      compute: { module: computeModule, entryPoint: "cs_main" },
+    });
+
+    this.bindGroupA = this.device.createBindGroup({
+      layout: computeLayout,
+      entries: [
+        { binding: 0, resource: { buffer: this.paramsBuffer! } },
+        { binding: 1, resource: { buffer: this.tempBufferA! } },
+        { binding: 2, resource: { buffer: this.tempBufferB! } },
+        { binding: 3, resource: { buffer: this.sensorBuffer! } },
+      ],
+    });
+    this.bindGroupB = this.device.createBindGroup({
+      layout: computeLayout,
+      entries: [
+        { binding: 0, resource: { buffer: this.paramsBuffer! } },
+        { binding: 1, resource: { buffer: this.tempBufferB! } },
+        { binding: 2, resource: { buffer: this.tempBufferA! } },
+        { binding: 3, resource: { buffer: this.sensorBuffer! } },
+      ],
+    });
+
+    const renderLayout = this.device.createBindGroupLayout({
+      entries: [
+        {
+          binding: 0,
+          visibility: ShaderStage.FRAGMENT,
+          buffer: { type: "uniform" },
+        },
+        {
+          binding: 1,
+          visibility: ShaderStage.FRAGMENT,
+          buffer: { type: "read-only-storage" },
+        },
+        {
+          binding: 2,
+          visibility: ShaderStage.FRAGMENT,
+          buffer: { type: "uniform" },
+        },
+      ],
+    });
+
+    this.renderPipeline = this.device.createRenderPipeline({
+      layout: this.device.createPipelineLayout({
+        bindGroupLayouts: [renderLayout],
+      }),
+      vertex: { module: renderModule, entryPoint: "vs_main" },
+      fragment: {
+        module: renderModule,
+        entryPoint: "fs_main",
+        targets: [
+          {
+            format: this.format,
+            blend: {
+              color: {
+                srcFactor: "src-alpha",
+                dstFactor: "one-minus-src-alpha",
+                operation: "add",
+              },
+              alpha: {
+                srcFactor: "one",
+                dstFactor: "one-minus-src-alpha",
+                operation: "add",
+              },
+            },
+          },
+        ],
+      },
+      primitive: { topology: "triangle-list" },
+    });
+
+    this.renderBindGroupA = this.device.createBindGroup({
+      layout: renderLayout,
+      entries: [
+        { binding: 0, resource: { buffer: this.renderUniformBuffer! } },
+        { binding: 1, resource: { buffer: this.tempBufferA! } },
+        { binding: 2, resource: { buffer: this.sizeBuffer! } },
+      ],
+    });
+    this.renderBindGroupB = this.device.createBindGroup({
+      layout: renderLayout,
+      entries: [
+        { binding: 0, resource: { buffer: this.renderUniformBuffer! } },
+        { binding: 1, resource: { buffer: this.tempBufferB! } },
+        { binding: 2, resource: { buffer: this.sizeBuffer! } },
+      ],
+    });
+  }
+
+  setSensors(sensors: HvacSensor[]): void {
+    this.config.sensors = sensors;
+    this.writeParams();
+    this.writeSensors();
+  }
+
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    const tick = () => {
+      if (!this.running) return;
+      this.step();
+      this.raf = requestAnimationFrame(tick);
+    };
+    this.raf = requestAnimationFrame(tick);
+  }
+
+  stop(): void {
+    this.running = false;
+    if (this.raf) cancelAnimationFrame(this.raf);
+    this.raf = 0;
+  }
+
+  step(): void {
+    if (
+      !this.device ||
+      !this.context ||
+      !this.computePipeline ||
+      !this.renderPipeline
+    ) {
+      return;
+    }
+
+    const encoder = this.device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(this.computePipeline);
+    pass.setBindGroup(0, this.ping ? this.bindGroupA! : this.bindGroupB!);
+    pass.dispatchWorkgroups(
+      Math.ceil(this.config.width / 16),
+      Math.ceil(this.config.height / 16),
+    );
+    pass.end();
+
+    const view = this.context.getCurrentTexture().createView();
+    const render = encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view,
+          clearValue: { r: 0.08, g: 0.09, b: 0.11, a: 1 },
+          loadOp: "clear",
+          storeOp: "store",
+        },
+      ],
+    });
+    render.setPipeline(this.renderPipeline);
+    // After compute, output lives in B when ping=true (A→B)
+    render.setBindGroup(
+      0,
+      this.ping ? this.renderBindGroupB! : this.renderBindGroupA!,
+    );
+    render.draw(3);
+    render.end();
+
+    this.device.queue.submit([encoder.finish()]);
+    this.ping = !this.ping;
+  }
+
+  destroy(): void {
+    this.stop();
+    this.tempBufferA?.destroy();
+    this.tempBufferB?.destroy();
+    this.paramsBuffer?.destroy();
+    this.sensorBuffer?.destroy();
+    this.renderUniformBuffer?.destroy();
+    this.sizeBuffer?.destroy();
+    this.device?.destroy?.();
+    this.device = null;
+    this.context = null;
+  }
+}
+
+function defaultSensors(width: number, height: number): HvacSensor[] {
+  return [
+    { x: Math.floor(width * 0.2), y: Math.floor(height * 0.2), temperature: 28 },
+    { x: Math.floor(width * 0.75), y: Math.floor(height * 0.3), temperature: 19 },
+    { x: Math.floor(width * 0.5), y: Math.floor(height * 0.7), temperature: 26 },
+    { x: Math.floor(width * 0.15), y: Math.floor(height * 0.8), temperature: 21 },
+  ];
+}

--- a/src/lib/webgpu/heatDiffusionFallback.ts
+++ b/src/lib/webgpu/heatDiffusionFallback.ts
@@ -1,0 +1,219 @@
+/**
+ * WebGL 2.0 fallback for heat diffusion: CPU Jacobi + R32F temperature texture.
+ */
+
+import {
+  createAmbientGrid,
+  DEFAULT_HEAT_GRID,
+  stepHeatDiffusion,
+  type HeatDiffusionConfig,
+  type HvacSensor,
+} from "./heatEquation";
+import { HEAT_FALLBACK_FRAG, HEAT_FALLBACK_VERT } from "./heatShaders.wgsl";
+
+export class HeatDiffusionFallback {
+  private canvas: HTMLCanvasElement;
+  private gl: WebGL2RenderingContext | null = null;
+  private program: WebGLProgram | null = null;
+  private texture: WebGLTexture | null = null;
+  private vao: WebGLVertexArrayObject | null = null;
+
+  private config: Required<
+    Pick<
+      HeatDiffusionConfig,
+      | "width"
+      | "height"
+      | "alpha"
+      | "dt"
+      | "ambient"
+      | "minTemp"
+      | "maxTemp"
+      | "opacity"
+    >
+  > & { sensors: HvacSensor[] };
+
+  private gridA: Float32Array;
+  private gridB: Float32Array;
+  private ping = true;
+  private raf = 0;
+  private running = false;
+
+  constructor(canvas: HTMLCanvasElement, config: HeatDiffusionConfig = {}) {
+    this.canvas = canvas;
+    this.config = {
+      width: config.width ?? DEFAULT_HEAT_GRID.width,
+      height: config.height ?? DEFAULT_HEAT_GRID.height,
+      alpha: config.alpha ?? DEFAULT_HEAT_GRID.alpha,
+      dt: config.dt ?? DEFAULT_HEAT_GRID.dt,
+      ambient: config.ambient ?? DEFAULT_HEAT_GRID.ambient,
+      sensors:
+        config.sensors ??
+        defaultSensors(config.width ?? 64, config.height ?? 64),
+      minTemp: config.minTemp ?? 18,
+      maxTemp: config.maxTemp ?? 32,
+      opacity: config.opacity ?? 0.72,
+    };
+    this.gridA = createAmbientGrid(
+      this.config.width,
+      this.config.height,
+      this.config.ambient,
+      this.config.sensors,
+    );
+    this.gridB = new Float32Array(this.gridA);
+  }
+
+  initialize(): boolean {
+    const gl = this.canvas.getContext("webgl2", {
+      alpha: true,
+      premultipliedAlpha: true,
+    });
+    if (!gl) return false;
+    this.gl = gl;
+
+    const vs = compile(gl, gl.VERTEX_SHADER, HEAT_FALLBACK_VERT);
+    const fs = compile(gl, gl.FRAGMENT_SHADER, HEAT_FALLBACK_FRAG);
+    if (!vs || !fs) return false;
+
+    const program = gl.createProgram();
+    if (!program) return false;
+    gl.attachShader(program, vs);
+    gl.attachShader(program, fs);
+    gl.linkProgram(program);
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      console.warn("[HeatDiffusionFallback] link failed", gl.getProgramInfoLog(program));
+      return false;
+    }
+    this.program = program;
+
+    const verts = new Float32Array([-1, -1, 3, -1, -1, 3]);
+    const vbo = gl.createBuffer();
+    this.vao = gl.createVertexArray();
+    gl.bindVertexArray(this.vao);
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, verts, gl.STATIC_DRAW);
+    const loc = gl.getAttribLocation(program, "a_pos");
+    gl.enableVertexAttribArray(loc);
+    gl.vertexAttribPointer(loc, 2, gl.FLOAT, false, 0, 0);
+
+    this.texture = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, this.texture);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    this.uploadTexture(this.gridA);
+
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+    return true;
+  }
+
+  setSensors(sensors: HvacSensor[]): void {
+    this.config.sensors = sensors;
+  }
+
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    const tick = () => {
+      if (!this.running) return;
+      this.step();
+      this.raf = requestAnimationFrame(tick);
+    };
+    this.raf = requestAnimationFrame(tick);
+  }
+
+  stop(): void {
+    this.running = false;
+    if (this.raf) cancelAnimationFrame(this.raf);
+    this.raf = 0;
+  }
+
+  step(): void {
+    const input = this.ping ? this.gridA : this.gridB;
+    const output = this.ping ? this.gridB : this.gridA;
+    stepHeatDiffusion(input, output, this.config);
+    this.uploadTexture(output);
+    this.draw();
+    this.ping = !this.ping;
+  }
+
+  private uploadTexture(grid: Float32Array): void {
+    const gl = this.gl;
+    if (!gl || !this.texture) return;
+    gl.bindTexture(gl.TEXTURE_2D, this.texture);
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      gl.R32F,
+      this.config.width,
+      this.config.height,
+      0,
+      gl.RED,
+      gl.FLOAT,
+      grid,
+    );
+  }
+
+  private draw(): void {
+    const gl = this.gl;
+    if (!gl || !this.program || !this.vao || !this.texture) return;
+
+    gl.viewport(0, 0, this.canvas.width, this.canvas.height);
+    gl.clearColor(0.08, 0.09, 0.11, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    gl.useProgram(this.program);
+    gl.bindVertexArray(this.vao);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, this.texture);
+    gl.uniform1i(gl.getUniformLocation(this.program, "u_temp"), 0);
+    gl.uniform1f(
+      gl.getUniformLocation(this.program, "u_minTemp"),
+      this.config.minTemp,
+    );
+    gl.uniform1f(
+      gl.getUniformLocation(this.program, "u_maxTemp"),
+      this.config.maxTemp,
+    );
+    gl.uniform1f(
+      gl.getUniformLocation(this.program, "u_opacity"),
+      this.config.opacity,
+    );
+    gl.drawArrays(gl.TRIANGLES, 0, 3);
+  }
+
+  destroy(): void {
+    this.stop();
+    const gl = this.gl;
+    if (gl && this.texture) gl.deleteTexture(this.texture);
+    if (gl && this.program) gl.deleteProgram(this.program);
+    if (gl && this.vao) gl.deleteVertexArray(this.vao);
+    this.gl = null;
+  }
+}
+
+function compile(
+  gl: WebGL2RenderingContext,
+  type: number,
+  source: string,
+): WebGLShader | null {
+  const shader = gl.createShader(type);
+  if (!shader) return null;
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    console.warn("[HeatDiffusionFallback] shader error", gl.getShaderInfoLog(shader));
+    gl.deleteShader(shader);
+    return null;
+  }
+  return shader;
+}
+
+function defaultSensors(width: number, height: number): HvacSensor[] {
+  return [
+    { x: Math.floor(width * 0.2), y: Math.floor(height * 0.2), temperature: 28 },
+    { x: Math.floor(width * 0.75), y: Math.floor(height * 0.3), temperature: 19 },
+    { x: Math.floor(width * 0.5), y: Math.floor(height * 0.7), temperature: 26 },
+    { x: Math.floor(width * 0.15), y: Math.floor(height * 0.8), temperature: 21 },
+  ];
+}

--- a/src/lib/webgpu/heatEquation.ts
+++ b/src/lib/webgpu/heatEquation.ts
@@ -1,0 +1,126 @@
+/**
+ * Pure 2D heat-equation helpers (shared by WebGPU path + WebGL fallback + tests).
+ */
+
+export type HvacSensor = {
+  /** Grid column */
+  x: number;
+  /** Grid row */
+  y: number;
+  /** Celsius */
+  temperature: number;
+};
+
+export type HeatGridConfig = {
+  width: number;
+  height: number;
+  /** Thermal diffusivity coefficient */
+  alpha?: number;
+  dt?: number;
+  ambient?: number;
+  sensors?: HvacSensor[];
+};
+
+export type HeatDiffusionConfig = HeatGridConfig & {
+  minTemp?: number;
+  maxTemp?: number;
+  opacity?: number;
+};
+
+export const DEFAULT_HEAT_GRID = {
+  width: 64,
+  height: 64,
+  alpha: 0.15,
+  dt: 1,
+  ambient: 22,
+} as const;
+
+/**
+ * One explicit Jacobi / finite-difference step of the 2D heat equation,
+ * then re-inject HVAC sensor temperatures.
+ */
+export function stepHeatDiffusion(
+  input: Float32Array,
+  output: Float32Array,
+  config: Required<
+    Pick<HeatGridConfig, "width" | "height" | "alpha" | "dt" | "ambient">
+  > & { sensors: HvacSensor[] },
+): void {
+  const { width: w, height: h, alpha, dt, ambient, sensors } = config;
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const idx = y * w + x;
+      const xl = x === 0 ? x : x - 1;
+      const xr = x + 1 >= w ? x : x + 1;
+      const yd = y === 0 ? y : y - 1;
+      const yu = y + 1 >= h ? y : y + 1;
+
+      const c = input[idx];
+      const lap =
+        input[y * w + xl] +
+        input[y * w + xr] +
+        input[yd * w + x] +
+        input[yu * w + x] -
+        4 * c;
+
+      let next = c + alpha * dt * lap;
+      next = next + (ambient - next) * 0.002;
+      output[idx] = next;
+    }
+  }
+
+  for (const s of sensors) {
+    if (s.x < 0 || s.y < 0 || s.x >= w || s.y >= h) continue;
+    output[s.y * w + s.x] = s.temperature;
+  }
+}
+
+export function createAmbientGrid(
+  width: number,
+  height: number,
+  ambient: number,
+  sensors: HvacSensor[] = [],
+): Float32Array {
+  const grid = new Float32Array(width * height).fill(ambient);
+  for (const s of sensors) {
+    if (s.x < 0 || s.y < 0 || s.x >= width || s.y >= height) continue;
+    grid[s.y * width + s.x] = s.temperature;
+  }
+  return grid;
+}
+
+/** Map Celsius → RGBA heatmap (matches WGSL/GLSL ramp). */
+export function temperatureToRgba(
+  temp: number,
+  minTemp: number,
+  maxTemp: number,
+  opacity = 0.75,
+): [number, number, number, number] {
+  const span = Math.max(maxTemp - minTemp, 0.001);
+  const t = Math.min(1, Math.max(0, (temp - minTemp) / span));
+  let r: number;
+  let g: number;
+  let b: number;
+  if (t < 0.25) {
+    const k = t / 0.25;
+    r = 0.05 + (0.0 - 0.05) * k;
+    g = 0.15 + (0.75 - 0.15) * k;
+    b = 0.55 + (1.0 - 0.55) * k;
+  } else if (t < 0.5) {
+    const k = (t - 0.25) / 0.25;
+    r = 0.0 + (0.15 - 0.0) * k;
+    g = 0.75 + (0.9 - 0.75) * k;
+    b = 1.0 + (0.35 - 1.0) * k;
+  } else if (t < 0.75) {
+    const k = (t - 0.5) / 0.25;
+    r = 0.15 + (1.0 - 0.15) * k;
+    g = 0.9 + (0.85 - 0.9) * k;
+    b = 0.35 + (0.1 - 0.35) * k;
+  } else {
+    const k = (t - 0.75) / 0.25;
+    r = 1.0 + (0.95 - 1.0) * k;
+    g = 0.85 + (0.1 - 0.85) * k;
+    b = 0.1 + (0.12 - 0.1) * k;
+  }
+  return [r, g, b, opacity];
+}

--- a/src/lib/webgpu/heatShaders.wgsl.ts
+++ b/src/lib/webgpu/heatShaders.wgsl.ts
@@ -1,0 +1,192 @@
+/**
+ * WGSL shaders for 2D heat-equation diffusion (Jacobi) + heatmap overlay.
+ *
+ * Compute: explicit finite-difference step on a ping-pong temperature grid,
+ * with HVAC sensor cells re-injected each iteration.
+ * Render: fullscreen quad mapping temperature → blue→red heatmap colors.
+ */
+
+export const HEAT_DIFFUSION_COMPUTE = /* wgsl */ `
+struct HeatParams {
+  width: u32,
+  height: u32,
+  alpha: f32,
+  dt: f32,
+  ambient: f32,
+  sensorCount: u32,
+  _pad0: f32,
+  _pad1: f32,
+};
+
+struct Sensor {
+  x: u32,
+  y: u32,
+  temperature: f32,
+  _pad: f32,
+};
+
+@group(0) @binding(0) var<uniform> params: HeatParams;
+@group(0) @binding(1) var<storage, read> tempIn: array<f32>;
+@group(0) @binding(2) var<storage, read_write> tempOut: array<f32>;
+@group(0) @binding(3) var<storage, read> sensors: array<Sensor>;
+
+@compute @workgroup_size(16, 16)
+fn cs_main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let x = gid.x;
+  let y = gid.y;
+  if (x >= params.width || y >= params.height) {
+    return;
+  }
+
+  let idx = y * params.width + x;
+  let w = params.width;
+  let h = params.height;
+
+  // Neumann edges: clamp neighbor samples
+  let xl = select(x - 1u, x, x == 0u);
+  let xr = select(x + 1u, x, x + 1u >= w);
+  let yd = select(y - 1u, y, y == 0u);
+  let yu = select(y + 1u, y, y + 1u >= h);
+
+  let c = tempIn[idx];
+  let l = tempIn[y * w + xl];
+  let r = tempIn[y * w + xr];
+  let d = tempIn[yd * w + x];
+  let u = tempIn[yu * w + x];
+
+  let lap = l + r + d + u - 4.0 * c;
+  var next = c + params.alpha * params.dt * lap;
+
+  // Soft pull toward ambient so the field stays bounded
+  next = next + (params.ambient - next) * 0.002;
+
+  tempOut[idx] = next;
+
+  // Re-assert HVAC sensor sources after diffusion
+  for (var i = 0u; i < params.sensorCount; i = i + 1u) {
+    let s = sensors[i];
+    if (s.x == x && s.y == y) {
+      tempOut[idx] = s.temperature;
+    }
+  }
+}
+`;
+
+export const HEAT_HEATMAP_RENDER = /* wgsl */ `
+struct HeatUniforms {
+  minTemp: f32,
+  maxTemp: f32,
+  opacity: f32,
+  _pad: f32,
+};
+
+struct GridSize {
+  width: u32,
+  height: u32,
+};
+
+@group(0) @binding(0) var<uniform> u: HeatUniforms;
+@group(0) @binding(1) var<storage, read> temps: array<f32>;
+@group(0) @binding(2) var<uniform> size: GridSize;
+
+struct VSOut {
+  @builtin(position) pos: vec4<f32>,
+  @location(0) uv: vec2<f32>,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) vi: u32) -> VSOut {
+  // Fullscreen triangle
+  var positions = array<vec2<f32>, 3>(
+    vec2<f32>(-1.0, -1.0),
+    vec2<f32>( 3.0, -1.0),
+    vec2<f32>(-1.0,  3.0),
+  );
+  var uvs = array<vec2<f32>, 3>(
+    vec2<f32>(0.0, 1.0),
+    vec2<f32>(2.0, 1.0),
+    vec2<f32>(0.0, -1.0),
+  );
+  var out: VSOut;
+  out.pos = vec4<f32>(positions[vi], 0.0, 1.0);
+  out.uv = uvs[vi];
+  return out;
+}
+
+fn heatColor(t: f32) -> vec3<f32> {
+  // blue → cyan → yellow → red
+  if (t < 0.25) {
+    let k = t / 0.25;
+    return mix(vec3<f32>(0.05, 0.15, 0.55), vec3<f32>(0.0, 0.75, 1.0), k);
+  }
+  if (t < 0.5) {
+    let k = (t - 0.25) / 0.25;
+    return mix(vec3<f32>(0.0, 0.75, 1.0), vec3<f32>(0.15, 0.9, 0.35), k);
+  }
+  if (t < 0.75) {
+    let k = (t - 0.5) / 0.25;
+    return mix(vec3<f32>(0.15, 0.9, 0.35), vec3<f32>(1.0, 0.85, 0.1), k);
+  }
+  let k = (t - 0.75) / 0.25;
+  return mix(vec3<f32>(1.0, 0.85, 0.1), vec3<f32>(0.95, 0.1, 0.12), k);
+}
+
+@fragment
+fn fs_main(input: VSOut) -> @location(0) vec4<f32> {
+  let w = size.width;
+  let h = size.height;
+  let gx = u32(clamp(input.uv.x, 0.0, 0.999) * f32(w));
+  let gy = u32(clamp(input.uv.y, 0.0, 0.999) * f32(h));
+  let idx = gy * w + gx;
+  let raw = temps[idx];
+  let span = max(u.maxTemp - u.minTemp, 0.001);
+  let t = clamp((raw - u.minTemp) / span, 0.0, 1.0);
+  let rgb = heatColor(t);
+  return vec4<f32>(rgb, u.opacity);
+}
+`;
+
+/** Shared GLSL ES 3.0 heatmap for the WebGL 2.0 fallback path. */
+export const HEAT_FALLBACK_VERT = `#version 300 es
+in vec2 a_pos;
+out vec2 v_uv;
+void main() {
+  v_uv = a_pos * 0.5 + 0.5;
+  v_uv.y = 1.0 - v_uv.y;
+  gl_Position = vec4(a_pos, 0.0, 1.0);
+}
+`;
+
+export const HEAT_FALLBACK_FRAG = `#version 300 es
+precision highp float;
+uniform sampler2D u_temp;
+uniform float u_minTemp;
+uniform float u_maxTemp;
+uniform float u_opacity;
+in vec2 v_uv;
+out vec4 outColor;
+
+vec3 heatColor(float t) {
+  if (t < 0.25) {
+    float k = t / 0.25;
+    return mix(vec3(0.05, 0.15, 0.55), vec3(0.0, 0.75, 1.0), k);
+  }
+  if (t < 0.5) {
+    float k = (t - 0.25) / 0.25;
+    return mix(vec3(0.0, 0.75, 1.0), vec3(0.15, 0.9, 0.35), k);
+  }
+  if (t < 0.75) {
+    float k = (t - 0.5) / 0.25;
+    return mix(vec3(0.15, 0.9, 0.35), vec3(1.0, 0.85, 0.1), k);
+  }
+  float k = (t - 0.75) / 0.25;
+  return mix(vec3(1.0, 0.85, 0.1), vec3(0.95, 0.1, 0.12), k);
+}
+
+void main() {
+  float raw = texture(u_temp, v_uv).r;
+  float span = max(u_maxTemp - u_minTemp, 0.001);
+  float t = clamp((raw - u_minTemp) / span, 0.0, 1.0);
+  outColor = vec4(heatColor(t), u_opacity);
+}
+`;


### PR DESCRIPTION
## Summary
- Adds a WGSL compute pipeline for 2D heat-equation diffusion driven by HVAC sensor telemetry.
- Renders a temperature heatmap overlay for venue seating maps, with a WebGL 2.0 fallback when WebGPU is unavailable.
Closes #1020
## Test plan
- [ ] `npx jest src/__tests__/lib/heatDiffusion.test.ts src/__tests__/components/HeatDiffusionOverlay.test.tsx --no-coverage`
- [ ] Render `<HeatDiffusionOverlay />` in a browser with WebGPU and confirm the heatmap animates
- [ ] Disable WebGPU / use unsupported browser and confirm WebGL 2.0 fallback runs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a venue thermal diffusion heatmap showing temperature patterns across the seating grid.
  * Displays HVAC sensor temperatures with real-time heat visualization.
  * Added controls to pause, resume, and reset the simulation.
  * Automatically uses WebGPU when available, with WebGL 2.0 fallback support for broader browser compatibility.
  * Includes a color scale that distinguishes cooler and warmer areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->