### PR TITLE
Revert "fix: implement LRU cache eviction to prevent CacheStorage quota exceeded errors"

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -285,7 +285,7 @@ self.addEventListener("fetch", (event) => {
                       await enforceImageCacheQuota(cache, true);
 
                       try {
-                        await cache.put(event.request, responseToCache);
+                        await cache.put(event.request, networkResponse.clone());
                         await updateLRURecord(event.request.url, size);
                       } catch (retryErr) {
                         console.error(
@@ -988,6 +988,7 @@ async function updateLRURecord(url, size) {
 
 /**
  * Touches an existing record to update its lastAccessed time (True LRU).
+ * Returns a promise that resolves when the IndexedDB transaction completes.
  */
 async function touchLRURecord(url) {
   try {
@@ -996,13 +997,22 @@ async function touchLRURecord(url) {
     const store = tx.objectStore("imageCacheLRU");
     const request = store.get(url);
 
-    request.onsuccess = () => {
-      const record = request.result;
-      if (record) {
-        record.lastAccessed = Date.now();
-        store.put(record);
-      }
-    };
+    await new Promise((resolve, reject) => {
+      request.onsuccess = () => {
+        const record = request.result;
+        if (record) {
+          record.lastAccessed = Date.now();
+          store.put(record);
+        }
+        resolve();
+      };
+      request.onerror = () => reject(request.error);
+    });
+
+    await new Promise((resolve, reject) => {
+      tx.oncomplete = resolve;
+      tx.onerror = () => reject(tx.error);
+    });
   } catch (err) {
     console.error("[SW] Failed to touch LRU record:", err);
   }
@@ -1040,18 +1050,29 @@ async function enforceImageCacheQuota(cache, aggressive = false) {
       // Sort by oldest first
       records.sort((a, b) => a.lastAccessed - b.lastAccessed);
 
-      let evictedCount = 0;
+      const toEvict = [];
       for (const record of records) {
         if (totalSize <= targetSize) break;
-
-        await cache.delete(record.url);
-        store.delete(record.url);
-
+        toEvict.push(record);
         totalSize -= record.size || 0;
-        evictedCount++;
       }
+
+      // Queue all IDB deletes while the transaction is still active
+      for (const record of toEvict) {
+        store.delete(record.url);
+      }
+      await new Promise((resolve, reject) => {
+        tx.oncomplete = resolve;
+        tx.onerror = () => reject(tx.error);
+      });
+
+      // Now remove from Cache Storage after IDB transaction completes
+      for (const record of toEvict) {
+        await cache.delete(record.url);
+      }
+
       console.log(
-        `[SW] True LRU: Evicted ${evictedCount} images to stay under ${targetSize / 1024 / 1024}MB quota.`,
+        `[SW] True LRU: Evicted ${toEvict.length} images to stay under ${targetSize / 1024 / 1024}MB quota.`,
       );
     }
   } catch (err) {

--- a/public/sw.js
+++ b/public/sw.js
@@ -23,8 +23,6 @@ const PERIODIC_AVAILABILITY_TAG = "workspace-availability";
 
 // Cap image cache at 20MB so iOS Safari PWA (~50MB quota) doesn't get killed.
 const MAX_IMAGE_CACHE_BYTES = 20 * 1024 * 1024;
-// Cap entry count to prevent QuotaExceededError on storage-constrained mobile devices.
-const MAX_IMAGE_CACHE_ENTRIES = 50;
 // Fallback size for opaque cross-origin responses where Content-Length is hidden (approx 400KB).
 const OPAQUE_RESPONSE_SIZE_ESTIMATE = 400 * 1024;
 
@@ -243,19 +241,26 @@ self.addEventListener("fetch", (event) => {
     event.respondWith(
       caches.open(IMAGE_CACHE_NAME).then((cache) => {
         return cache.match(event.request).then((cachedResponse) => {
+          // Agar cache mein mil gaya, toh turant return karo
           if (cachedResponse) {
-            event.waitUntil(touchLRURecord(event.request.url).catch(() => {}));
+            // Asynchronously update the LRU timestamp for this hit
+            event.waitUntil(
+              touchLRURecord(event.request.url).catch(console.error),
+            );
             return cachedResponse;
           }
 
+          // Agar cache mein nahi hai, toh network se fetch karo aur cache mein daalo
           return fetch(event.request)
             .then((networkResponse) => {
+              // Note: External requests sometimes return status 0 (opaque), we check response.status === 200 || response.status === 0
               if (
                 networkResponse.status === 200 ||
                 networkResponse.status === 0
               ) {
                 const responseToCache = networkResponse.clone();
 
+                // Calculate size for LRU tracking
                 let size = OPAQUE_RESPONSE_SIZE_ESTIMATE;
                 if (networkResponse.headers.has("content-length")) {
                   const length = parseInt(
@@ -265,13 +270,34 @@ self.addEventListener("fetch", (event) => {
                   if (!isNaN(length) && length > 0) size = length;
                 }
 
-                const cachePromise = putImageCacheWithLru(
-                  cache,
-                  event.request,
-                  responseToCache,
-                  event.request.url,
-                  size,
-                );
+                // Wrap cache.put and IDB updates in a promise chain for waitUntil
+                const cachePromise = cache
+                  .put(event.request, responseToCache)
+                  .then(async () => {
+                    await updateLRURecord(event.request.url, size);
+                    await enforceImageCacheQuota(cache);
+                  })
+                  .catch(async (err) => {
+                    if (err.name === "QuotaExceededError") {
+                      console.warn(
+                        "[SW] Quota exceeded. Evicting older images...",
+                      );
+                      await enforceImageCacheQuota(cache, true);
+
+                      try {
+                        await cache.put(event.request, responseToCache);
+                        await updateLRURecord(event.request.url, size);
+                      } catch (retryErr) {
+                        console.error(
+                          "[SW] Still out of quota after eviction:",
+                          retryErr,
+                        );
+                      }
+                    } else {
+                      console.error("[SW] Failed to cache asset:", err);
+                    }
+                  });
+
                 event.waitUntil(cachePromise);
               }
               return networkResponse;
@@ -940,50 +966,55 @@ self.addEventListener("notificationclick", (event) => {
   );
 });
 
+// Invalid import and duplicate syncFavoritesOutbox removed to fix SyntaxError
+
 /**
  * Updates or inserts a record for an image in the LRU IDB store.
  */
 async function updateLRURecord(url, size) {
-  const db = await openIndexedDB();
-  const tx = db.transaction("imageCacheLRU", "readwrite");
-  const store = tx.objectStore("imageCacheLRU");
-  store.put({ url, size, lastAccessed: Date.now() });
-  return new Promise((resolve, reject) => {
-    tx.oncomplete = resolve;
-    tx.onerror = () => reject(tx.error);
-  });
+  try {
+    const db = await openIndexedDB();
+    const tx = db.transaction("imageCacheLRU", "readwrite");
+    const store = tx.objectStore("imageCacheLRU");
+    store.put({ url, size, lastAccessed: Date.now() });
+    return new Promise((resolve, reject) => {
+      tx.oncomplete = resolve;
+      tx.onerror = () => reject(tx.error);
+    });
+  } catch (err) {
+    console.error("[SW] Failed to update LRU record:", err);
+  }
 }
 
 /**
  * Touches an existing record to update its lastAccessed time (True LRU).
  */
 async function touchLRURecord(url) {
-  const db = await openIndexedDB();
-  const tx = db.transaction("imageCacheLRU", "readwrite");
-  const store = tx.objectStore("imageCacheLRU");
-  const request = store.get(url);
+  try {
+    const db = await openIndexedDB();
+    const tx = db.transaction("imageCacheLRU", "readwrite");
+    const store = tx.objectStore("imageCacheLRU");
+    const request = store.get(url);
 
-  request.onsuccess = () => {
-    const record = request.result;
-    if (record) {
-      record.lastAccessed = Date.now();
-      store.put(record);
-    }
-  };
+    request.onsuccess = () => {
+      const record = request.result;
+      if (record) {
+        record.lastAccessed = Date.now();
+        store.put(record);
+      }
+    };
+  } catch (err) {
+    console.error("[SW] Failed to touch LRU record:", err);
+  }
 }
 
 let isEnforcingQuota = false;
 
 /**
- * Evicts oldest image cache entries until both byte-size and entry-count
- * are within budget. Uses an IndexedDB-backed LRU store for accurate
- * lastAccessed tracking across SW restarts.
- *
- * @param {Cache} cache - The Cache Storage instance for images.
- * @param {boolean} aggressive - When true, targets 60% of MAX_IMAGE_CACHE_BYTES
- *                               to recover from a QuotaExceededError.
+ * Helper to keep image cache strictly below quota (~20MB) using True LRU.
  */
 async function enforceImageCacheQuota(cache, aggressive = false) {
+  // Wait if another sweep is concurrently running to avoid redundant IDB reads/writes
   while (isEnforcingQuota) {
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
@@ -1004,18 +1035,14 @@ async function enforceImageCacheQuota(cache, aggressive = false) {
     const targetSize = aggressive
       ? MAX_IMAGE_CACHE_BYTES * 0.6
       : MAX_IMAGE_CACHE_BYTES;
-    const needsSizeEviction = totalSize > targetSize;
-    const needsCountEviction = records.length > MAX_IMAGE_CACHE_ENTRIES;
 
-    if (needsSizeEviction || needsCountEviction) {
+    if (totalSize > targetSize) {
+      // Sort by oldest first
       records.sort((a, b) => a.lastAccessed - b.lastAccessed);
 
       let evictedCount = 0;
       for (const record of records) {
-        const overSize = totalSize > targetSize;
-        const overCount =
-          records.length - evictedCount > MAX_IMAGE_CACHE_ENTRIES;
-        if (!overSize && !overCount) break;
+        if (totalSize <= targetSize) break;
 
         await cache.delete(record.url);
         store.delete(record.url);
@@ -1023,37 +1050,13 @@ async function enforceImageCacheQuota(cache, aggressive = false) {
         totalSize -= record.size || 0;
         evictedCount++;
       }
+      console.log(
+        `[SW] True LRU: Evicted ${evictedCount} images to stay under ${targetSize / 1024 / 1024}MB quota.`,
+      );
     }
-  } catch {
-    // Eviction failure is non-fatal; the next cache.put may trigger
-    // QuotaExceededError, which will retry eviction in aggressive mode.
+  } catch (err) {
+    console.error("[SW] Failed to enforce image cache LRU quota:", err);
   } finally {
     isEnforcingQuota = false;
   }
-}
-
-/**
- * Inserts an image into the cache with proactive LRU eviction.
- * Evicts by entry count before put, then by byte size after put.
- * On QuotaExceededError, runs aggressive eviction and retries once.
- */
-async function putImageCacheWithLru(cache, request, response, url, size) {
-  try {
-    const existingKeys = await cache.keys();
-    if (existingKeys.length >= MAX_IMAGE_CACHE_ENTRIES) {
-      await enforceImageCacheQuota(cache);
-    }
-
-    await cache.put(request, response);
-  } catch (err) {
-    if (err.name === "QuotaExceededError") {
-      await enforceImageCacheQuota(cache, true);
-      await cache.put(request, response);
-    } else {
-      throw err;
-    }
-  }
-
-  await updateLRURecord(url, size);
-  await enforceImageCacheQuota(cache);
 }

--- a/src/__tests__/lib/swCacheLru.test.ts
+++ b/src/__tests__/lib/swCacheLru.test.ts
@@ -1,18 +1,27 @@
 import {
   MAX_CACHE_BYTES,
-  MAX_CACHE_ENTRIES,
   cachePutWithLruLimit,
   estimateResponseSize,
   trimCacheToMaxBytes,
 } from "@/lib/swCacheLru";
 
-function makeMockCache() {
-  const store = new Map<string, Response>();
-  const order: string[] = [];
-  return {
-    store,
-    order,
-    cache: {
+describe("swCacheLru", () => {
+  it("exposes a 20MB cap", () => {
+    expect(MAX_CACHE_BYTES).toBe(20 * 1024 * 1024);
+  });
+
+  it("prefers content-length when present", async () => {
+    const response = new Response("hello", {
+      headers: { "content-length": "42" },
+    });
+    expect(await estimateResponseSize(response)).toBe(42);
+  });
+
+  it("evicts oldest entries until under the byte limit", async () => {
+    const store = new Map<string, Response>();
+    const order: string[] = [];
+
+    const cache = {
       async keys() {
         return order.map((url) => new Request(url));
       },
@@ -29,29 +38,9 @@ function makeMockCache() {
         if (!store.has(request.url)) order.push(request.url);
         store.set(request.url, response);
       },
-    },
-  };
-}
+    };
 
-describe("swCacheLru", () => {
-  it("exposes a 20MB cap", () => {
-    expect(MAX_CACHE_BYTES).toBe(20 * 1024 * 1024);
-  });
-
-  it("exposes a 50 entry cap", () => {
-    expect(MAX_CACHE_ENTRIES).toBe(50);
-  });
-
-  it("prefers content-length when present", async () => {
-    const response = new Response("hello", {
-      headers: { "content-length": "42" },
-    });
-    expect(await estimateResponseSize(response)).toBe(42);
-  });
-
-  it("evicts oldest entries until under the byte limit", async () => {
-    const { cache, order, store } = makeMockCache();
-
+    // three ~10 byte payloads, cap at 25 → must drop the oldest
     await cache.put(
       new Request("https://img/a.jpg"),
       new Response("aaaaaaaaaa", { headers: { "content-length": "10" } }),
@@ -71,29 +60,27 @@ describe("swCacheLru", () => {
     expect(store.has("https://img/a.jpg")).toBe(false);
   });
 
-  it("evicts oldest entries when count exceeds maxEntries", async () => {
-    const { cache, order, store } = makeMockCache();
-
-    for (let i = 0; i < 5; i++) {
-      await cache.put(
-        new Request(`https://img/${i}.jpg`),
-        new Response("x", { headers: { "content-length": "1" } }),
-      );
-    }
-
-    await trimCacheToMaxBytes(cache, 10 * 1024 * 1024, 3);
-
-    expect(order).toEqual([
-      "https://img/2.jpg",
-      "https://img/3.jpg",
-      "https://img/4.jpg",
-    ]);
-    expect(store.has("https://img/0.jpg")).toBe(false);
-    expect(store.has("https://img/1.jpg")).toBe(false);
-  });
-
   it("puts then trims in cachePutWithLruLimit", async () => {
-    const { cache, store } = makeMockCache();
+    const store = new Map<string, Response>();
+    const order: string[] = [];
+    const cache = {
+      async keys() {
+        return order.map((url) => new Request(url));
+      },
+      async match(request: Request) {
+        return store.get(request.url);
+      },
+      async delete(request: Request) {
+        store.delete(request.url);
+        const idx = order.indexOf(request.url);
+        if (idx >= 0) order.splice(idx, 1);
+        return true;
+      },
+      async put(request: Request, response: Response) {
+        if (!store.has(request.url)) order.push(request.url);
+        store.set(request.url, response);
+      },
+    };
 
     await cachePutWithLruLimit(
       cache,
@@ -110,46 +97,6 @@ describe("swCacheLru", () => {
 
     expect(store.has("https://img/old.jpg")).toBe(false);
     expect(store.has("https://img/new.jpg")).toBe(true);
-  });
-
-  it("cachePutWithLruLimit evicts by count when limit exceeded", async () => {
-    const { cache, order, store } = makeMockCache();
-
-    await cachePutWithLruLimit(
-      cache,
-      new Request("https://img/a.jpg"),
-      new Response("a", { headers: { "content-length": "1" } }),
-      10 * 1024 * 1024,
-      3,
-    );
-    await cachePutWithLruLimit(
-      cache,
-      new Request("https://img/b.jpg"),
-      new Response("b", { headers: { "content-length": "1" } }),
-      10 * 1024 * 1024,
-      3,
-    );
-    await cachePutWithLruLimit(
-      cache,
-      new Request("https://img/c.jpg"),
-      new Response("c", { headers: { "content-length": "1" } }),
-      10 * 1024 * 1024,
-      3,
-    );
-    await cachePutWithLruLimit(
-      cache,
-      new Request("https://img/d.jpg"),
-      new Response("d", { headers: { "content-length": "1" } }),
-      10 * 1024 * 1024,
-      3,
-    );
-
-    expect(order).toEqual([
-      "https://img/b.jpg",
-      "https://img/c.jpg",
-      "https://img/d.jpg",
-    ]);
-    expect(store.has("https://img/a.jpg")).toBe(false);
   });
 
   describe("hasSufficientStorageQuota", () => {

--- a/src/lib/swCacheLru.ts
+++ b/src/lib/swCacheLru.ts
@@ -1,10 +1,9 @@
 /**
- * Helpers mirroring the Service Worker image-cache quota (20 MB / 50 entries).
+ * Helpers mirroring the Service Worker image-cache quota (20MB LRU).
  * Unit-tested here; enforced in public/sw.js via IndexedDB LRU + Cache Storage.
  */
 
-export const MAX_CACHE_BYTES = 20 * 1024 * 1024;
-export const MAX_CACHE_ENTRIES = 50;
+export const MAX_CACHE_BYTES = 20 * 1024 * 1024; // 20MB — under iOS Safari ~50MB PWA quota
 
 export async function estimateResponseSize(
   response: Response,
@@ -29,15 +28,10 @@ type CacheLike = {
   put: (request: Request, response: Response) => Promise<void>;
 };
 
-/**
- * Drop oldest entries (insertion-ordered) until total size AND count are
- * within budget.  Cache#keys is insertion-ordered in all major browsers,
- * so the first entries are the least-recently-used.
- */
+/** Drop oldest entries until total estimated size fits under maxBytes. */
 export async function trimCacheToMaxBytes(
   cache: CacheLike,
   maxBytes: number = MAX_CACHE_BYTES,
-  maxEntries: number = MAX_CACHE_ENTRIES,
 ): Promise<void> {
   const keys = await cache.keys();
   const entries: { request: Request; size: number }[] = [];
@@ -51,12 +45,9 @@ export async function trimCacheToMaxBytes(
     total += size;
   }
 
+  // Cache#keys is insertion-ordered in major browsers; oldest first.
   let i = 0;
-  while (i < entries.length) {
-    const overSize = total > maxBytes;
-    const overCount = entries.length - i > maxEntries;
-    if (!overSize && !overCount) break;
-
+  while (total > maxBytes && i < entries.length) {
     const entry = entries[i++];
     await cache.delete(entry.request);
     total -= entry.size;
@@ -68,10 +59,9 @@ export async function cachePutWithLruLimit(
   request: Request,
   response: Response,
   maxBytes: number = MAX_CACHE_BYTES,
-  maxEntries: number = MAX_CACHE_ENTRIES,
 ): Promise<void> {
   await cache.put(request, response);
-  await trimCacheToMaxBytes(cache, maxBytes, maxEntries);
+  await trimCacheToMaxBytes(cache, maxBytes);
 }
 
 /**


### PR DESCRIPTION
Reverts SatyamPandey-07/WorkSphere#1224

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image caching reliability by enforcing a 20 MB size limit.
  * Updated cache eviction to remove the least recently used images when storage is full.
  * Improved handling of cache quota errors and retry behavior.
  * Fixed a service worker startup error affecting background functionality.

* **Tests**
  * Updated cache tests to validate size-based eviction and storage quota handling.

Also fixes 3 critical bugs found by CodeRabbit review:
- Cloned fresh response in QuotaExceededError retry path (responseToCache was consumed)
- Wrapped touchLRURecord IDB ops in promise so it resolves on tx completion
- Queued all IDB deletes before cache deletes in enforceImageCacheQuota to avoid TransactionInactiveError


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Image caching now uses a byte-size limit instead of a fixed entry count.
  * Least recently used images are removed automatically when the cache exceeds its storage budget.
  * Cache access tracking is preserved across service-worker updates for more accurate eviction.
  * Improved recovery when storage quota is exceeded, including retry handling after cleanup.
* **Tests**
  * Updated coverage to validate byte-based cache trimming and eviction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->