### PR TITLE
feat: add real-time WebAudio FFT spectrum and waterfall spectrogram

### DIFF
--- a/src/__tests__/components/NoiseSpectrogram.test.tsx
+++ b/src/__tests__/components/NoiseSpectrogram.test.tsx
@@ -1,0 +1,109 @@
+/** @jest-environment jsdom */
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { NoiseSpectrogram } from "@/components/noise/NoiseSpectrogram";
+
+describe("NoiseSpectrogram", () => {
+  const mockGetUserMedia = jest.fn();
+  const mockGetFloatFrequencyData = jest.fn((arr: Float32Array) => {
+    arr.fill(-60);
+    arr[10] = -35;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    Object.defineProperty(global.navigator, "mediaDevices", {
+      value: {
+        getUserMedia: mockGetUserMedia,
+      },
+      configurable: true,
+    });
+
+    const mockAnalyser = {
+      fftSize: 0,
+      smoothingTimeConstant: 0,
+      minDecibels: 0,
+      maxDecibels: 0,
+      frequencyBinCount: 1024,
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+      getFloatFrequencyData: mockGetFloatFrequencyData,
+    };
+
+    const mockSource = {
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+    };
+
+    const mockAudioContext = {
+      state: "running",
+      resume: jest.fn().mockResolvedValue(undefined),
+      close: jest.fn().mockResolvedValue(undefined),
+      createMediaStreamSource: jest.fn(() => mockSource),
+      createAnalyser: jest.fn(() => mockAnalyser),
+    };
+
+    Object.defineProperty(global, "AudioContext", {
+      value: jest.fn(() => mockAudioContext),
+      configurable: true,
+    });
+
+    mockGetUserMedia.mockResolvedValue({
+      getTracks: () => [{ stop: jest.fn() }],
+    });
+
+    HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
+      fillRect: jest.fn(),
+      fillStyle: "",
+      getImageData: jest.fn(() => ({
+        data: new Uint8ClampedArray(4),
+        width: 1,
+        height: 1,
+      })),
+      putImageData: jest.fn(),
+      createImageData: jest.fn(() => ({
+        data: new Uint8ClampedArray(640),
+        width: 1,
+        height: 160,
+      })),
+    })) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+
+    let rafId = 0;
+    global.requestAnimationFrame = jest.fn((cb: FrameRequestCallback) => {
+      rafId += 1;
+      // don't auto-loop forever
+      setTimeout(() => cb(performance.now()), 0);
+      return rafId;
+    });
+    global.cancelAnimationFrame = jest.fn();
+  });
+
+  it("renders the spectrogram chrome", () => {
+    render(<NoiseSpectrogram />);
+    expect(screen.getByText(/FFT Noise Spectrogram/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Start spectrogram/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("wires the mic to AnalyserNode with fftSize 2048", async () => {
+    render(<NoiseSpectrogram />);
+    fireEvent.click(screen.getByRole("button", { name: /Start spectrogram/i }));
+
+    await waitFor(() => {
+      expect(mockGetUserMedia).toHaveBeenCalled();
+    });
+
+    const ctxInstance = (global.AudioContext as jest.Mock).mock.results[0]
+      .value;
+    const analyser = ctxInstance.createAnalyser.mock.results[0].value;
+    expect(analyser.fftSize).toBe(2048);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Frequency spectrum bar chart/i)).toBeInTheDocument();
+      expect(
+        screen.getByLabelText(/Rolling spectrogram waterfall/i),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/__tests__/lib/fftSpectrogram.test.ts
+++ b/src/__tests__/lib/fftSpectrogram.test.ts
@@ -1,0 +1,49 @@
+import {
+  FFT_SIZE,
+  averageDbFromFrequencyBins,
+  classifyNoise,
+  normalizeBinDb,
+  peakDbFromFrequencyBins,
+  spectrogramColor,
+} from "@/lib/noise/fftSpectrogram";
+
+describe("fftSpectrogram helpers", () => {
+  it("uses AnalyserNode fftSize 2048", () => {
+    expect(FFT_SIZE).toBe(2048);
+  });
+
+  it("classifies Quiet / Moderate / Loud by decibel thresholds", () => {
+    expect(classifyNoise(30)).toBe("Quiet");
+    expect(classifyNoise(44.9)).toBe("Quiet");
+    expect(classifyNoise(45)).toBe("Moderate");
+    expect(classifyNoise(65)).toBe("Moderate");
+    expect(classifyNoise(65.1)).toBe("Loud");
+    expect(classifyNoise(90)).toBe("Loud");
+  });
+
+  it("computes peak dB from frequency bins", () => {
+    const bins = new Float32Array([-80, -40, -60]);
+    // (-40 + 100) = 60
+    expect(peakDbFromFrequencyBins(bins)).toBe(60);
+  });
+
+  it("averages the loudest bins for a live level", () => {
+    const bins = new Float32Array([-90, -30, -35, -100]);
+    const avg = averageDbFromFrequencyBins(bins, 2);
+    // avg of -30 and -35 → -32.5 → 67.5
+    expect(avg).toBe(67.5);
+  });
+
+  it("normalizes dBFS bins into 0–1", () => {
+    expect(normalizeBinDb(-100)).toBe(0);
+    expect(normalizeBinDb(-10)).toBe(1);
+    expect(normalizeBinDb(-55)).toBeCloseTo(0.5, 2);
+  });
+
+  it("returns RGB triples for spectrogram intensity", () => {
+    const cold = spectrogramColor(0);
+    const hot = spectrogramColor(1);
+    expect(cold[2]).toBeGreaterThan(cold[0]);
+    expect(hot[0]).toBeGreaterThan(hot[2]);
+  });
+});

--- a/src/components/noise/NoiseSpectrogram.tsx
+++ b/src/components/noise/NoiseSpectrogram.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Mic, Square, Activity } from "lucide-react";
+import {
+  FFT_SIZE,
+  FRAME_INTERVAL_MS,
+  averageDbFromFrequencyBins,
+  classifyNoise,
+  normalizeBinDb,
+  peakDbFromFrequencyBins,
+  spectrogramColor,
+  type NoiseClass,
+} from "@/lib/noise/fftSpectrogram";
+
+type Status = "idle" | "requesting" | "running" | "error";
+
+/**
+ * Real-time 60fps FFT spectrum bars + rolling waterfall spectrogram
+ * via WebAudio AnalyserNode (fftSize 2048).
+ */
+export function NoiseSpectrogram() {
+  const [status, setStatus] = useState<Status>("idle");
+  const [liveDb, setLiveDb] = useState(0);
+  const [peakDb, setPeakDb] = useState(0);
+  const [noiseClass, setNoiseClass] = useState<NoiseClass>("Quiet");
+
+  const spectrumRef = useRef<HTMLCanvasElement | null>(null);
+  const waterfallRef = useRef<HTMLCanvasElement | null>(null);
+  const cleanupRef = useRef<(() => void) | null>(null);
+  const sessionPeakRef = useRef(20);
+
+  useEffect(() => {
+    return () => cleanupRef.current?.();
+  }, []);
+
+  const stop = useCallback(() => {
+    cleanupRef.current?.();
+    cleanupRef.current = null;
+    setStatus("idle");
+  }, []);
+
+  const start = useCallback(async () => {
+    setStatus("requesting");
+    sessionPeakRef.current = 20;
+    setPeakDb(20);
+    setLiveDb(20);
+    setNoiseClass("Quiet");
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          echoCancellation: false,
+          noiseSuppression: false,
+          autoGainControl: false,
+        },
+      });
+
+      const AudioContextClass =
+        window.AudioContext ||
+        (
+          window as typeof window & {
+            webkitAudioContext?: typeof AudioContext;
+          }
+        ).webkitAudioContext;
+
+      if (!AudioContextClass) {
+        throw new Error("Web Audio API is not supported");
+      }
+
+      const audioContext = new AudioContextClass();
+      if (audioContext.state === "suspended") {
+        await audioContext.resume();
+      }
+
+      const source = audioContext.createMediaStreamSource(stream);
+      const analyser = audioContext.createAnalyser();
+      analyser.fftSize = FFT_SIZE;
+      analyser.smoothingTimeConstant = 0.7;
+      analyser.minDecibels = -100;
+      analyser.maxDecibels = -10;
+      source.connect(analyser);
+
+      const bins = new Float32Array(analyser.frequencyBinCount);
+      let raf = 0;
+      let lastTick: number | null = null;
+
+      const cleanup = () => {
+        cancelAnimationFrame(raf);
+        try {
+          source.disconnect();
+        } catch {
+          /* already disconnected */
+        }
+        try {
+          analyser.disconnect();
+        } catch {
+          /* already disconnected */
+        }
+        stream.getTracks().forEach((t) => t.stop());
+        if (audioContext.state !== "closed") {
+          audioContext.close().catch(() => {});
+        }
+      };
+
+      cleanupRef.current = cleanup;
+      setStatus("running");
+
+      const tick = (timestamp: number) => {
+        if (lastTick !== null) {
+          const delta = timestamp - lastTick;
+          if (delta < FRAME_INTERVAL_MS) {
+            raf = requestAnimationFrame(tick);
+            return;
+          }
+          lastTick = timestamp - (delta % FRAME_INTERVAL_MS);
+        } else {
+          lastTick = timestamp;
+        }
+
+        analyser.getFloatFrequencyData(bins);
+
+        const peak = peakDbFromFrequencyBins(bins);
+        const avg = averageDbFromFrequencyBins(bins);
+        if (peak > sessionPeakRef.current) {
+          sessionPeakRef.current = peak;
+        }
+
+        setLiveDb(avg);
+        setPeakDb(sessionPeakRef.current);
+        setNoiseClass(classifyNoise(avg));
+
+        drawSpectrumBars(spectrumRef.current, bins);
+        drawWaterfallColumn(waterfallRef.current, bins);
+
+        raf = requestAnimationFrame(tick);
+      };
+
+      raf = requestAnimationFrame(tick);
+    } catch (err) {
+      console.error("[NoiseSpectrogram] mic/analyser failed:", err);
+      setStatus("error");
+    }
+  }, []);
+
+  const classStyles = classBadge(noiseClass);
+
+  return (
+    <div className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4 shadow-md dark:border-zinc-800 dark:bg-zinc-900/60">
+      <div className="flex items-center justify-between gap-3 border-b border-zinc-200 pb-3 dark:border-zinc-800">
+        <div>
+          <p className="text-sm font-bold uppercase tracking-tight text-zinc-900 dark:text-zinc-50">
+            FFT Noise Spectrogram
+          </p>
+          <p className="mt-1 text-[11px] text-zinc-500 dark:text-zinc-400">
+            WebAudio AnalyserNode · fftSize {FFT_SIZE} · 60fps spectrum +
+            waterfall
+          </p>
+        </div>
+        <Activity className="h-5 w-5 shrink-0 text-sky-500" />
+      </div>
+
+      {status === "running" && (
+        <div className="mt-4 space-y-3">
+          <div className="flex flex-wrap items-end justify-between gap-3">
+            <div>
+              <p className="text-[10px] font-bold uppercase tracking-widest text-zinc-400">
+                Live level
+              </p>
+              <p className="text-3xl font-black tracking-tighter text-zinc-900 dark:text-white">
+                {liveDb.toFixed(1)}
+                <span className="ml-1 text-xs font-bold text-zinc-400">dB</span>
+              </p>
+            </div>
+            <div className="text-right">
+              <p className="text-[10px] font-bold uppercase tracking-widest text-zinc-400">
+                Peak
+              </p>
+              <p className="text-xl font-black text-zinc-900 dark:text-zinc-50">
+                {peakDb.toFixed(1)}{" "}
+                <span className="text-xs font-bold text-zinc-400">dB</span>
+              </p>
+            </div>
+            <span
+              className={`rounded-lg border px-2.5 py-1 text-xs font-black uppercase tracking-wider ${classStyles}`}
+            >
+              {noiseClass}
+            </span>
+          </div>
+
+          <div className="overflow-hidden rounded-xl border border-zinc-800 bg-zinc-950">
+            <p className="px-3 pt-2 text-[9px] font-bold uppercase tracking-widest text-zinc-500">
+              Frequency spectrum
+            </p>
+            <canvas
+              ref={spectrumRef}
+              width={640}
+              height={120}
+              className="block h-28 w-full"
+              aria-label="Frequency spectrum bar chart"
+            />
+          </div>
+
+          <div className="overflow-hidden rounded-xl border border-zinc-800 bg-zinc-950">
+            <p className="px-3 pt-2 text-[9px] font-bold uppercase tracking-widest text-zinc-500">
+              Waterfall history
+            </p>
+            <canvas
+              ref={waterfallRef}
+              width={640}
+              height={160}
+              className="block h-40 w-full"
+              aria-label="Rolling spectrogram waterfall"
+            />
+          </div>
+        </div>
+      )}
+
+      <div className="mt-4 flex gap-2">
+        {status === "running" ? (
+          <button
+            type="button"
+            onClick={stop}
+            className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-zinc-800 px-4 py-2.5 text-sm font-bold text-white hover:bg-zinc-700"
+          >
+            <Square className="h-4 w-4 fill-current" />
+            Stop
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={start}
+            disabled={status === "requesting"}
+            className="inline-flex w-full items-center justify-center gap-2 rounded-xl accent-bg px-4 py-2.5 text-sm font-bold uppercase tracking-tight text-white accent-bg-hover disabled:opacity-50"
+          >
+            <Mic className="h-4 w-4" />
+            {status === "requesting" ? "Requesting mic…" : "Start spectrogram"}
+          </button>
+        )}
+      </div>
+
+      {status === "error" && (
+        <p className="mt-3 rounded-lg border border-red-500/20 bg-red-500/10 p-3 text-xs font-bold text-red-600 dark:text-red-400">
+          Microphone access failed. Check permissions and try again.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function classBadge(noiseClass: NoiseClass): string {
+  if (noiseClass === "Quiet") {
+    return "border-emerald-500/30 bg-emerald-500/10 text-emerald-500";
+  }
+  if (noiseClass === "Moderate") {
+    return "border-amber-500/30 bg-amber-500/10 text-amber-500";
+  }
+  return "border-rose-500/30 bg-rose-500/10 text-rose-500";
+}
+
+function drawSpectrumBars(
+  canvas: HTMLCanvasElement | null,
+  bins: Float32Array,
+): void {
+  if (!canvas) return;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+
+  const { width, height } = canvas;
+  ctx.fillStyle = "#09090b";
+  ctx.fillRect(0, 0, width, height);
+
+  // Skip DC; draw a subset of bins for readable bars
+  const usable = bins.length - 1;
+  const barCount = Math.min(96, usable);
+  const step = usable / barCount;
+  const gap = 1;
+  const barWidth = Math.max(1, width / barCount - gap);
+
+  for (let i = 0; i < barCount; i++) {
+    const binIndex = 1 + Math.floor(i * step);
+    const t = normalizeBinDb(bins[binIndex]);
+    const barH = t * (height - 4);
+    const x = i * (barWidth + gap);
+    const y = height - barH;
+    const [r, g, b] = spectrogramColor(t);
+    ctx.fillStyle = `rgb(${r},${g},${b})`;
+    ctx.fillRect(x, y, barWidth, barH);
+  }
+}
+
+function drawWaterfallColumn(
+  canvas: HTMLCanvasElement | null,
+  bins: Float32Array,
+): void {
+  if (!canvas) return;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+
+  const { width, height } = canvas;
+
+  // Scroll history left by 1px
+  const image = ctx.getImageData(1, 0, width - 1, height);
+  ctx.putImageData(image, 0, 0);
+
+  const col = ctx.createImageData(1, height);
+  const usable = bins.length - 1;
+
+  for (let y = 0; y < height; y++) {
+    // Low frequencies at the bottom
+    const binIndex =
+      1 + Math.floor(((height - 1 - y) / height) * usable);
+    const t = normalizeBinDb(bins[Math.min(binIndex, bins.length - 1)]);
+    const [r, g, b] = spectrogramColor(t);
+    const o = y * 4;
+    col.data[o] = r;
+    col.data[o + 1] = g;
+    col.data[o + 2] = b;
+    col.data[o + 3] = 255;
+  }
+
+  ctx.putImageData(col, width - 1, 0);
+}

--- a/src/lib/noise/fftSpectrogram.ts
+++ b/src/lib/noise/fftSpectrogram.ts
@@ -1,0 +1,79 @@
+/**
+ * Helpers for WebAudio AnalyserNode FFT spectrum / waterfall rendering.
+ */
+
+export const FFT_SIZE = 2048;
+export const TARGET_FPS = 60;
+export const FRAME_INTERVAL_MS = 1000 / TARGET_FPS;
+
+export type NoiseClass = "Quiet" | "Moderate" | "Loud";
+
+export function classifyNoise(db: number): NoiseClass {
+  if (db < 45) return "Quiet";
+  if (db <= 65) return "Moderate";
+  return "Loud";
+}
+
+/**
+ * Map AnalyserNode getFloatFrequencyData values (dBFS, typically ≤ 0)
+ * into an approximate 20–120 dB display range used elsewhere in the app.
+ */
+export function peakDbFromFrequencyBins(bins: Float32Array): number {
+  let peak = -Infinity;
+  for (let i = 0; i < bins.length; i++) {
+    const v = bins[i];
+    if (Number.isFinite(v) && v > peak) peak = v;
+  }
+  if (!Number.isFinite(peak)) return 20;
+  return Math.max(20, Math.min(120, Math.round((peak + 100) * 10) / 10));
+}
+
+/** Average of the loudest bins — smoother live readout than a single spike. */
+export function averageDbFromFrequencyBins(
+  bins: Float32Array,
+  topN = 8,
+): number {
+  if (bins.length === 0) return 20;
+  const sorted = Array.from(bins)
+    .filter((v) => Number.isFinite(v))
+    .sort((a, b) => b - a);
+  const n = Math.min(topN, sorted.length);
+  if (n === 0) return 20;
+  let sum = 0;
+  for (let i = 0; i < n; i++) sum += sorted[i];
+  const avg = sum / n;
+  return Math.max(20, Math.min(120, Math.round((avg + 100) * 10) / 10));
+}
+
+/** Hot→cold color for waterfall intensity (0–1). */
+export function spectrogramColor(t: number): [number, number, number] {
+  const x = Math.min(1, Math.max(0, t));
+  if (x < 0.33) {
+    const k = x / 0.33;
+    return [
+      Math.round(10 + 20 * k),
+      Math.round(20 + 100 * k),
+      Math.round(80 + 120 * k),
+    ];
+  }
+  if (x < 0.66) {
+    const k = (x - 0.33) / 0.33;
+    return [
+      Math.round(30 + 220 * k),
+      Math.round(120 + 80 * k),
+      Math.round(200 - 160 * k),
+    ];
+  }
+  const k = (x - 0.66) / 0.34;
+  return [
+    Math.round(250),
+    Math.round(200 - 160 * k),
+    Math.round(40 - 20 * k),
+  ];
+}
+
+/** Normalize a dBFS bin (−100…0) to 0–1 for bar / waterfall height. */
+export function normalizeBinDb(dbfs: number, minDb = -100, maxDb = -10): number {
+  if (!Number.isFinite(dbfs)) return 0;
+  return Math.min(1, Math.max(0, (dbfs - minDb) / (maxDb - minDb)));
+}


### PR DESCRIPTION
## Summary
- Connects the mic to an `AnalyserNode` with FFT size 2048 and renders a 60fps frequency bar chart plus rolling waterfall spectrogram on canvas.
- Computes peak decibel levels and classifies noise as Quiet, Moderate, or Loud.
Closes #1021
## Test plan
- [ ] `npx jest src/__tests__/lib/fftSpectrogram.test.ts src/__tests__/components/NoiseSpectrogram.test.tsx --no-coverage`
- [ ] Render `<NoiseSpectrogram />`, grant mic access, confirm spectrum bars and waterfall update
- [ ] Verify Quiet / Moderate / Loud badge tracks live dB
- [ ] Deny mic permission and confirm error state


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a real-time microphone noise spectrogram.
  * Displays frequency bars, a scrolling waterfall visualization, live sound level, peak level, and noise classification.
  * Includes controls to start monitoring and an error message when microphone access is unavailable.

* **Tests**
  * Added coverage for spectrogram rendering, microphone startup behavior, noise classification, sound-level calculations, normalization, and visualization colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->