### PR TITLE
docs: Create beginner guide for testing offline storage with IndexedDB (closes #1211)

### DIFF
--- a/docs/OFFLINE_STORAGE_TESTING.md
+++ b/docs/OFFLINE_STORAGE_TESTING.md
@@ -1,0 +1,96 @@
+# Offline Storage Testing Guide
+
+This guide provides step-by-step instructions for inspecting, clearing, and testing the offline database (IndexedDB) in WorkSphere using browser Developer Tools.
+
+## 1. Inspecting IndexedDB Tables in DevTools
+
+You can view the raw data stored in your local offline database directly from your browser.
+
+### In Google Chrome / Edge
+
+1. Open the Developer Tools by pressing `F12` or `Ctrl + Shift + I` (`Cmd + Option + I` on macOS).
+2. Navigate to the **Application** tab at the top.
+3. In the left sidebar, expand the **Storage** section, then expand **IndexedDB**.
+4. Click on the WorkSphere database (e.g., `worksphere-offline-db`).
+5. You will see a list of object stores (tables). Click on any table to view its stored records in the main pane.
+6. To refresh the data, click the **Refresh** icon above the data table.
+
+### In Mozilla Firefox
+
+1. Open the Developer Tools by pressing `F12` or `Ctrl + Shift + I` (`Cmd + Option + I` on macOS).
+2. Navigate to the **Storage** tab at the top.
+3. In the left sidebar, expand the **Indexed DB** section.
+4. Expand the WorkSphere database origin (e.g., `http://localhost:3000`).
+5. Click on the database name to reveal the object stores.
+6. Click on a specific store to inspect the key-value entries.
+
+---
+
+## 2. Clearing the Offline Database Store
+
+If you need to reset your local environment or clear corrupted data, you can clear the database entirely.
+
+### Option A: Using DevTools (UI)
+
+1. Open the **Application** tab (Chrome) or **Storage** tab (Firefox).
+2. Navigate to **Storage > IndexedDB** and click on the specific database.
+3. Click the **Delete database** button at the top of the viewing pane.
+
+### Option B: Using Code / Console
+
+You can clear specific object stores programmatically. Run the following snippet in the browser console, or integrate it into your test setup:
+
+```javascript
+/**
+ * Clears all data from a specific IndexedDB store.
+ * @param {string} dbName - The name of the database.
+ * @param {string} storeName - The name of the object store to clear.
+ */
+function clearOfflineStore(dbName, storeName) {
+  const request = indexedDB.open(dbName);
+
+  request.onsuccess = (event) => {
+    const db = event.target.result;
+    const transaction = db.transaction(storeName, "readwrite");
+    const store = transaction.objectStore(storeName);
+
+    const clearRequest = store.clear();
+
+    clearRequest.onsuccess = () => {
+      console.log(`Successfully cleared the '${storeName}' store.`);
+    };
+
+    clearRequest.onerror = (err) => {
+      console.error(`Failed to clear store:`, err);
+    };
+  };
+
+  request.onerror = (err) => {
+    console.error(`Failed to open database:`, err);
+  };
+}
+
+// Example usage:
+// clearOfflineStore('worksphere-offline-db', 'venues');
+```
+
+---
+
+## 3. Simulating Network Disconnection
+
+Testing offline capabilities requires simulating a loss of network connectivity.
+
+### In Chrome / Edge
+
+1. Open the Developer Tools (`F12`).
+2. Navigate to the **Network** tab.
+3. Locate the throttling dropdown (usually says "No throttling" by default).
+4. Select **Offline** from the dropdown menu.
+5. A warning icon will appear on the Network tab, indicating that the browser is now simulating an offline state. All network requests will fail, triggering the service worker and offline IndexedDB fallbacks.
+
+### In Firefox
+
+1. Open the Developer Tools (`F12`).
+2. Navigate to the **Network** tab.
+3. Locate the throttling dropdown (default is "No throttling").
+4. Select **Offline**.


### PR DESCRIPTION
### Description

This PR adds a comprehensive beginner-friendly guide for inspecting and testing offline storage in WorkSphere using browser DevTools.

### Requirements & Scope Completed

- [x] Documented step-by-step instructions to view IndexedDB storage in Chrome/Firefox DevTools.
- [x] Provided a code snippet for clearing an offline database store programmatically.
- [x] Added a guide for simulating network disconnection in the Network tab.

### Changes

- **New file**: docs/OFFLINE_STORAGE_TESTING.md
  - Step-by-step walkthrough for Chrome/Edge and Firefox DevTools for inspecting IndexedDB tables.
  - Two options for clearing data: via the DevTools UI and via a browser console JavaScript snippet.
  - Instructions for simulating offline mode using the Network throttling panel in both Chrome and Firefox.

Fixes #1211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a guide for inspecting and clearing offline data in browser developer tools.
  * Documented how to simulate network disconnections and verify offline behavior.
  * Included instructions for Chrome, Edge, and Firefox.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->