### PR TITLE
Add share option for Scratchpad sessions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18264,7 +18264,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/components/sessions/Scratchpad.tsx
+++ b/src/components/sessions/Scratchpad.tsx
@@ -5,7 +5,8 @@ import * as Y from "yjs";
 import usePartySocket from "partysocket/react";
 import { CryptoManager, bufferToBase64, base64ToBuffer } from "@/lib/e2ee/CryptoManager";
 import { KeyStore } from "@/lib/e2ee/KeyStore";
-import { Lock, Unlock, Key, Loader2 } from "lucide-react";
+import { Lock, Unlock, Key, Loader2, Share2 } from "lucide-react";
+import { useToast } from "@/components/ui/Toast";
 import {
   generateKeyPair,
   exportPublicKey,
@@ -24,6 +25,7 @@ export default function Scratchpad({ sessionId }: Props) {
   const [hasKey, setHasKey] = useState(false);
   const [isNegotiating, setIsNegotiating] = useState(false);
   const [text, setText] = useState("");
+  const { toast } = useToast();
   
   const clientId = useRef(crypto.randomUUID());
   const ecdhKeyPair = useRef<KeyPair | null>(null);
@@ -183,6 +185,15 @@ export default function Scratchpad({ sessionId }: Props) {
       doc.off("update", handleUpdate);
     };
   }, [socket, hasKey]);
+  const handleShare = async () => {
+  try {
+    await navigator.clipboard.writeText(window.location.href);
+    toast("Scratchpad link copied to clipboard!", "success");
+  } catch (error) {
+    console.error("Failed to copy scratchpad link", error);
+    toast("Failed to copy scratchpad link.", "error");
+  }
+};
 
 
 
@@ -248,13 +259,24 @@ export default function Scratchpad({ sessionId }: Props) {
           <Unlock className="h-4 w-4" />
           <span className="text-sm font-medium">E2EE Scratchpad</span>
         </div>
-        <button
-          onClick={handleClearKey}
-          className="text-xs text-zinc-400 hover:text-zinc-200 flex items-center gap-1"
-        >
-          <Key className="h-3 w-3" />
-          Clear Key
-        </button>
+        <div className="flex items-center gap-2">
+  <button
+    onClick={handleShare}
+    className="text-xs text-zinc-400 hover:text-zinc-200 flex items-center gap-1"
+  >
+    <Share2 className="h-3 w-3" />
+    Share
+  </button>
+
+  <button
+    onClick={handleClearKey}
+    className="text-xs text-zinc-400 hover:text-zinc-200 flex items-center gap-1"
+  >
+    <Key className="h-3 w-3" />
+    Clear Key
+  </button>
+</div>
+        
       </div>
       <div className="flex-1 p-4">
         <textarea


### PR DESCRIPTION
## Description
Added a share button for Scratchpad sessions so users can easily copy and share the active session link.

## Changes Made
- Added a Share button in the session view
- Added clipboard copy functionality using the current page URL
- Added a success message after the link is copied

## Testing
- Tested the Share button on the session page
- Confirmed that the session link is copied successfully
- Confirmed that the copy success message is displayed

Closes #1271 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Share button to the secured scratchpad.
  * Users can copy the current page link and receive confirmation or error feedback.

* **UI Improvements**
  * Updated the scratchpad header actions to display Share alongside Clear Key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->