### PR TITLE
fix: validate WebAuthn assertion origins for cross-origin iframe embeds (closes #1076)

### DIFF
--- a/src/__tests__/lib/webauthn.test.ts
+++ b/src/__tests__/lib/webauthn.test.ts
@@ -208,6 +208,45 @@ describe("getExpectedOrigin", () => {
       "apple-touch-icon://embed",
     ]);
   });
+
+  describe("ALLOWED_EMBED_ORIGINS support", () => {
+    const prev = process.env.ALLOWED_EMBED_ORIGINS;
+
+    afterEach(() => {
+      if (prev === undefined) delete process.env.ALLOWED_EMBED_ORIGINS;
+      else process.env.ALLOWED_EMBED_ORIGINS = prev;
+    });
+
+    it("returns array including clientDataOrigin when it is listed in ALLOWED_EMBED_ORIGINS", () => {
+      process.env.ALLOWED_EMBED_ORIGINS =
+        "https://partner.com, https://dashboard.partner.com";
+      const req = new Request(
+        "https://worksphere.app/api/auth/passkey/verify",
+        {
+          headers: { host: "worksphere.app" },
+        },
+      );
+
+      expect(getExpectedOrigin(req, "https://partner.com")).toEqual([
+        "https://worksphere.app",
+        "https://partner.com",
+      ]);
+    });
+
+    it("ignores clientDataOrigin when it is NOT listed in ALLOWED_EMBED_ORIGINS", () => {
+      process.env.ALLOWED_EMBED_ORIGINS = "https://partner.com";
+      const req = new Request(
+        "https://worksphere.app/api/auth/passkey/verify",
+        {
+          headers: { host: "worksphere.app" },
+        },
+      );
+
+      expect(getExpectedOrigin(req, "https://evil.com")).toBe(
+        "https://worksphere.app",
+      );
+    });
+  });
 });
 
 describe("parseClientDataJSON", () => {

--- a/src/lib/passkey.ts
+++ b/src/lib/passkey.ts
@@ -35,12 +35,21 @@ export function getExpectedOrigin(
   const defaultOrigin = getOrigin(req);
   const userAgent = req.headers.get("user-agent");
 
+  const expectedOrigins = new Set<string>([defaultOrigin]);
+
   if (isMobileWebview(userAgent) && clientDataOrigin) {
-    if (clientDataOrigin === defaultOrigin) {
-      return defaultOrigin;
-    }
-    return [defaultOrigin, clientDataOrigin];
+    expectedOrigins.add(clientDataOrigin);
   }
 
-  return defaultOrigin;
+  const allowedEmbedOrigins = (process.env.ALLOWED_EMBED_ORIGINS || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  if (clientDataOrigin && allowedEmbedOrigins.includes(clientDataOrigin)) {
+    expectedOrigins.add(clientDataOrigin);
+  }
+
+  const origins = Array.from(expectedOrigins);
+  return origins.length === 1 ? origins[0] : origins;
 }


### PR DESCRIPTION
## Description

This PR fixes a bug where WebAuthn assertion verification fails (400 Bad Request) when passkey login is initiated inside an embedded cross-origin iframe on a partner domain.

The `getExpectedOrigin` function previously strictly expected the server's own origin unless the user agent was a mobile webview. It has been updated to parse an optional `ALLOWED_EMBED_ORIGINS` environment variable (comma-separated string). If the browser-supplied `clientDataOrigin` is present in this trusted list, it is safely appended to the array of acceptable origins, allowing SimpleWebAuthn to correctly verify the assertion.

Unit tests have been added to cover edge cases, environment variable mocking, and both accept/reject scenarios.

## Related Issue

Fixes #1076

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

N/A

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring additional permitted passkey origins through `ALLOWED_EMBED_ORIGINS`.
  * Embedded and mobile web experiences can now accept approved client origins while retaining the request’s default origin.

* **Tests**
  * Added coverage for approved and unapproved embedded origins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->