### PR TITLE
fix(notifications): reset notification badge count when panel is opened

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18264,6 +18264,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -689,6 +689,7 @@ model PushNotificationLog {
   body      String
   status    String
   error     String?
+  read      Boolean  @default(false)
   createdAt DateTime @default(now())
 
   @@index([createdAt])

--- a/src/__tests__/components/NotificationBell.test.tsx
+++ b/src/__tests__/components/NotificationBell.test.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { NotificationBell } from "@/components/NotificationBell";
+
+// Mock matchMedia
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+describe("NotificationBell Component (#685)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders closed bell button with no unread badge initially", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ notifications: [], unreadCount: 0 }),
+    } as any);
+
+    render(<NotificationBell />);
+
+    await waitFor(() => {
+      expect(screen.getByTitle("Notifications")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
+  });
+
+  it("renders unread badge count when unreadCount > 0", async () => {
+    const mockNotifications = [
+      {
+        id: "notif-1",
+        title: "Seat Available",
+        body: "A seat at Coffee House has opened up.",
+        read: false,
+        createdAt: new Date().toISOString(),
+        venueId: "venue-1",
+      },
+    ];
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        notifications: mockNotifications,
+        unreadCount: 1,
+      }),
+    } as any);
+
+    render(<NotificationBell />);
+
+    const badge = await screen.findByText("1");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveClass("bg-red-500");
+  });
+
+  it("marks all notifications as read when panel is opened", async () => {
+    const mockNotifications = [
+      {
+        id: "notif-1",
+        title: "Seat Available",
+        body: "A seat at Coffee House has opened up.",
+        read: false,
+        createdAt: new Date().toISOString(),
+        venueId: "venue-1",
+      },
+    ];
+
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          notifications: mockNotifications,
+          unreadCount: 1,
+        }),
+      } as any)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      } as any);
+
+    render(<NotificationBell />);
+
+    // Wait for the badge to render
+    const badge = await screen.findByText("1");
+    expect(badge).toBeInTheDocument();
+
+    const bellBtn = screen.getByRole("button", { name: "Open notifications menu" });
+    fireEvent.click(bellBtn);
+
+    // Opening should trigger markAsRead API call
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/user/notifications",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ action: "markAsRead" }),
+        })
+      );
+    });
+
+    // Count is set to 0 locally on click
+    expect(screen.queryByText("1")).not.toBeInTheDocument();
+  });
+});

--- a/src/app/api/user/notifications/route.ts
+++ b/src/app/api/user/notifications/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/prisma";
+
+export async function GET() {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const notifications = await prisma.pushNotificationLog.findMany({
+      where: { userId },
+      orderBy: { createdAt: "desc" },
+      take: 20,
+    });
+
+    const unreadCount = await prisma.pushNotificationLog.count({
+      where: { userId, read: false },
+    });
+
+    return NextResponse.json({
+      notifications,
+      unreadCount,
+    });
+  } catch (error: any) {
+    console.error("GET /api/user/notifications error:", error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await req.json().catch(() => ({}));
+    
+    if (body.action === "markAsRead") {
+      await prisma.pushNotificationLog.updateMany({
+        where: { userId, read: false },
+        data: { read: true },
+      });
+      return NextResponse.json({ success: true });
+    }
+
+    return NextResponse.json({ error: "Invalid action" }, { status: 400 });
+  } catch (error: any) {
+    console.error("POST /api/user/notifications error:", error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useEffect, useRef, useState, useCallback } from "react";
+import { Bell, Check, Inbox, Calendar, Zap, Wifi } from "lucide-react";
+import Link from "next/link";
+
+interface NotificationItem {
+  id: string;
+  title: string;
+  body: string;
+  read: boolean;
+  createdAt: string;
+  venueId?: string | null;
+}
+
+export function NotificationBell() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [notifications, setNotifications] = useState<NotificationItem[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const fetchNotifications = useCallback(async () => {
+    try {
+      const res = await fetch("/api/user/notifications", { cache: "no-store" });
+      if (res.ok) {
+        const data = await res.json();
+        setNotifications(data.notifications || []);
+        setUnreadCount(data.unreadCount || 0);
+      }
+    } catch (e) {
+      console.error("Failed to fetch notifications:", e);
+    }
+  }, []);
+
+  // Poll for new notifications every 20 seconds
+  useEffect(() => {
+    fetchNotifications();
+    const interval = setInterval(fetchNotifications, 20000);
+    return () => clearInterval(interval);
+  }, [fetchNotifications]);
+
+  // Handle outside clicks to close the dropdown
+  useEffect(() => {
+    if (!isOpen) return;
+    const handlePointerDown = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => document.removeEventListener("mousedown", handlePointerDown);
+  }, [isOpen]);
+
+  const markAllAsRead = async () => {
+    try {
+      const res = await fetch("/api/user/notifications", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "markAsRead" }),
+      });
+      if (res.ok) {
+        setUnreadCount(0);
+        setNotifications((prev) =>
+          prev.map((n) => ({ ...n, read: true }))
+        );
+      }
+    } catch (e) {
+      console.error("Failed to mark notifications as read:", e);
+    }
+  };
+
+  // Mark all as read when opening the panel to ensure badge count clears immediately
+  const handleToggleOpen = () => {
+    const nextState = !isOpen;
+    setIsOpen(nextState);
+    if (nextState && unreadCount > 0) {
+      markAllAsRead();
+    }
+  };
+
+  const getNotificationIcon = (title: string, body: string) => {
+    const combined = `${title} ${body}`.toLowerCase();
+    if (combined.includes("seat") || combined.includes("available")) return <Zap className="w-4 h-4 text-orange-400" />;
+    if (combined.includes("booking") || combined.includes("reservation")) return <Calendar className="w-4 h-4 text-blue-400" />;
+    if (combined.includes("wifi") || combined.includes("internet")) return <Wifi className="w-4 h-4 text-emerald-400" />;
+    return <Bell className="w-4 h-4 text-indigo-400" />;
+  };
+
+  const formatTimeAgo = (dateStr: string) => {
+    const now = new Date();
+    const diffMs = now.getTime() - new Date(dateStr).getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+    if (diffMins < 1) return "Just now";
+    if (diffMins < 60) return `${diffMins}m ago`;
+    const diffHours = Math.floor(diffMins / 60);
+    if (diffHours < 24) return `${diffHours}h ago`;
+    return new Date(dateStr).toLocaleDateString([], { month: "short", day: "numeric" });
+  };
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={handleToggleOpen}
+        className={`relative p-2 border cursor-pointer rounded-xl transition-all active:scale-95 ${
+          isOpen
+            ? "bg-indigo-600 border-indigo-400 text-white shadow-lg shadow-indigo-500/20"
+            : "bg-zinc-100 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-[var(--primary-accent)] hover:text-white"
+        }`}
+        title="Notifications"
+        aria-expanded={isOpen}
+        aria-label="Open notifications menu"
+      >
+        <Bell className="w-4 h-4" />
+        {unreadCount > 0 && (
+          <span className="absolute -top-1.5 -right-1.5 min-w-[18px] h-[18px] px-1 bg-red-500 text-white text-[9px] font-black rounded-full border-2 border-white dark:border-zinc-950 flex items-center justify-center animate-pulse">
+            {unreadCount}
+          </span>
+        )}
+      </button>
+
+      {isOpen && (
+        <div className="absolute top-full right-0 mt-2 w-80 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-2xl shadow-2xl z-[60] overflow-hidden animate-in slide-in-from-top-2 duration-150">
+          <div className="flex items-center justify-between p-4 border-b border-zinc-100 dark:border-zinc-800">
+            <h3 className="text-xs font-black uppercase tracking-widest text-zinc-800 dark:text-zinc-200">
+              Notifications
+            </h3>
+            {unreadCount > 0 && (
+              <button
+                onClick={markAllAsRead}
+                className="flex items-center gap-1 text-[10px] font-black uppercase tracking-wider text-indigo-500 hover:text-indigo-400 cursor-pointer"
+              >
+                <Check className="w-3 h-3" />
+                Read All
+              </button>
+            )}
+          </div>
+
+          <div className="max-h-80 overflow-y-auto divide-y divide-zinc-100 dark:divide-zinc-800 scrollbar-thin">
+            {notifications.length > 0 ? (
+              notifications.map((n) => (
+                <div
+                  key={n.id}
+                  className={`p-4 flex gap-3 transition-colors ${
+                    !n.read ? "bg-indigo-500/5 dark:bg-indigo-500/10" : "hover:bg-zinc-50 dark:hover:bg-zinc-800/50"
+                  }`}
+                >
+                  <div className="p-2 rounded-xl bg-zinc-100 dark:bg-zinc-800 shrink-0 self-start">
+                    {getNotificationIcon(n.title, n.body)}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <h4 className="text-xs font-bold text-zinc-900 dark:text-zinc-50 truncate">
+                      {n.title}
+                    </h4>
+                    <p className="mt-1 text-xs text-zinc-600 dark:text-zinc-400 leading-normal break-words">
+                      {n.body}
+                    </p>
+                    <div className="mt-2 flex items-center justify-between gap-2">
+                      <span className="text-[9px] font-bold text-zinc-400 dark:text-zinc-500 uppercase tracking-wider">
+                        {formatTimeAgo(n.createdAt)}
+                      </span>
+                      {n.venueId && (
+                        <Link
+                          href={`/venues/${n.venueId}`}
+                          onClick={() => setIsOpen(false)}
+                          className="text-[9px] font-black uppercase tracking-wider text-indigo-500 hover:underline"
+                        >
+                          View Workspace
+                        </Link>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))
+            ) : (
+              <div className="p-8 flex flex-col items-center justify-center text-center">
+                <Inbox className="w-8 h-8 text-zinc-300 dark:text-zinc-700 mb-2" />
+                <p className="text-xs text-zinc-500 dark:text-zinc-500">
+                  No notifications yet.
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -6,6 +6,7 @@ import { useUser } from "@clerk/nextjs";
 import { ReactiveUserButton } from "@/components/ReactiveUserButton";
 import { Coffee, LayoutGrid, MapPin, Menu, Shield, X } from "lucide-react";
 import { ThemeToggle } from "@/components/ThemeToggle";
+import { NotificationBell } from "@/components/NotificationBell";
 
 interface TopNavProps {
   hideAuth?: boolean;
@@ -107,6 +108,7 @@ export function TopNav({ hideAuth = false }: TopNavProps) {
                     <Shield className="w-4 h-4" />
                     Admin
                   </Link>
+                  <NotificationBell />
                   <div className="flex items-center justify-center w-8 h-8 rounded-full overflow-hidden shrink-0 ml-1">
                     <ReactiveUserButton
                       userProfileMode="navigation"

--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -27,6 +27,7 @@ import {
   X,
 } from "lucide-react";
 import { ReactiveUserButton } from "@/components/ReactiveUserButton";
+import { NotificationBell } from "@/components/NotificationBell";
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { ThemeToggle } from "../ThemeToggle";
@@ -372,6 +373,8 @@ export function ChatHeader({
           </button>
 
           <div className="w-px h-8 bg-zinc-200 dark:bg-zinc-800 mx-1 hidden sm:block" />
+
+          <NotificationBell />
 
           {/* User Profile */}
           <div className="flex items-center gap-2 p-1 pl-3 bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl">


### PR DESCRIPTION
### Title
fix(notifications): reset notification badge count when panel is opened

### Description
Resolves the issue where the red notification badge counter in the header did not clear after the user opened the notifications panel.

### Key Changes
1. **Schema Update (`schema.prisma` & client)**:
   - Added a `read` boolean field to the `PushNotificationLog` model to track the read status of notifications.
2. **API Endpoint (`route.ts` under `/api/user/notifications`)**:
   - Created endpoint to fetch user's notifications and current unread count (`GET`).
   - Created endpoint to mark all unread notifications of the user as read (`POST` with action `markAsRead`).
3. **Notification Bell Component (`NotificationBell.tsx`)**:
   - Created the bell icon with an unread badge indicator.
   - Built a dropdown notifications panel displaying list of user's notifications (real-time unread/read state styling, venue detail navigation).
   - Hooked up automatically marking all notifications as read when the panel is opened, which resets the badge count immediately.
4. **Header Navigation Integration**:
   - Integrated `NotificationBell` into `TopNav.tsx` and `ChatHeader.tsx`.
5. **Unit Tests (`NotificationBell.test.tsx`)**:
   - Implemented tests verifying initial closed state, badge rendering for unreadCount > 0, and triggering markAsRead on panel open.

### Related Issue
Closes #685

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a notification bell with an unread-count badge and dropdown notification list.
  - Notifications refresh automatically and can link directly to related venues.
  - Opening the notification menu marks notifications as read and clears the badge.
  - Added the notification bell to the main and chat navigation headers.

- **Tests**
  - Added coverage for unread badges, notification loading, and mark-as-read behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->