### PR TITLE
feat: add copy button for passkey credential IDs (closes #1)

### DIFF
--- a/src/components/auth/PasskeyManager.tsx
+++ b/src/components/auth/PasskeyManager.tsx
@@ -19,6 +19,7 @@ import {
   CheckCircle2,
   RefreshCw,
   Clock,
+  Copy,
 } from "lucide-react";
 import { useCsrfToken } from "@/hooks/useCsrfToken";
 
@@ -61,6 +62,22 @@ export function PasskeyManager() {
   const [customName, setCustomName] = useState("");
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editName, setEditName] = useState("");
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  const handleCopyId = async (credentialId: string) => {
+    try {
+      await navigator.clipboard.writeText(credentialId);
+      setCopiedId(credentialId);
+      setSuccess("Credential ID copied to clipboard");
+      setTimeout(() => {
+        setCopiedId(null);
+        setSuccess(null);
+      }, 3000);
+    } catch {
+      setError("Failed to copy credential ID");
+      setTimeout(() => setError(null), 3000);
+    }
+  };
 
   useEffect(() => {
     setIsWebAuthnSupported(browserSupportsWebAuthn());
@@ -406,6 +423,25 @@ export function PasskeyManager() {
                           <> • Attestation: {pk.attestationFormat}</>
                         )}
                     </p>
+                    <div className="flex items-center gap-1.5 mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                      <span className="font-mono bg-zinc-200/50 dark:bg-zinc-800/50 px-1.5 py-0.5 rounded">
+                        ID:{" "}
+                        {pk.credentialId.length > 12
+                          ? `${pk.credentialId.slice(0, 6)}...${pk.credentialId.slice(-6)}`
+                          : pk.credentialId}
+                      </span>
+                      <button
+                        onClick={() => handleCopyId(pk.credentialId)}
+                        className="p-1 hover:text-zinc-700 dark:hover:text-zinc-300 rounded hover:bg-zinc-200 dark:hover:bg-zinc-700 transition-colors"
+                        title="Copy Credential ID"
+                      >
+                        {copiedId === pk.credentialId ? (
+                          <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" />
+                        ) : (
+                          <Copy className="h-3.5 w-3.5" />
+                        )}
+                      </button>
+                    </div>
                   </div>
                 </div>
 


### PR DESCRIPTION
- closes #1185

### Description

This PR enhances the Passkey Security Settings by allowing users to quickly copy their passkey's `credentialId` directly to their system clipboard. Previously, the raw credential ID wasn't visible or easily accessible.

### Changes Included
- **Credential ID Display**: Rendered a truncated version of the `credentialId` next to each registered passkey for better visibility.
- **One-Click Copy**: Added a copy icon button adjacent to the credential ID.
- **Visual Feedback**: Implemented a temporary checkmark icon and a success toast notification that displays when the credential ID is successfully copied to the clipboard. 

### Motivation & Context
This change improves the user experience by making it significantly easier to reference and share passkey credentials when troubleshooting or auditing security settings without needing to inspect raw network requests or database entries.

### Screenshot

<img width="2434" height="822" alt="Screenshot 2026-07-22 214637" src="https://github.com/user-attachments/assets/df17d2d0-ca0a-455d-8e31-5d64431fe907" />

### How to Test
1. Navigate to the Security Settings page where Passkeys are managed.
2. Locate any registered passkey.
3. Observe the newly displayed truncated Credential ID.
4. Click the copy icon next to it.
5. Verify that the checkmark temporarily appears, the success toast is shown, and the full credential ID is securely placed into your system clipboard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to copy passkey credential IDs directly from each passkey card.
  * Added visual feedback confirming successful copies or indicating when copying fails.
  * Credential IDs are now displayed in a clear, compact format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->