### PR TITLE
fix: prevent WASM audio DSP memory leak

### DIFF
--- a/src/__tests__/lib/wasm/audioDSP.test.ts
+++ b/src/__tests__/lib/wasm/audioDSP.test.ts
@@ -13,6 +13,7 @@ class MockAudioWorkletNode {
     onmessage: null as ((ev: any) => void) | null,
   };
   connect = jest.fn();
+  disconnect = jest.fn();
 }
 
 class MockAudioContext {
@@ -72,5 +73,17 @@ describe("AudioDSP Manager & WASM SIMD Alignment (Issue #1080)", () => {
         wasmBinary: expect.any(ArrayBuffer),
       }),
     );
+  });
+
+  test("stopAudioProcessing sends a destroy message to the worklet to prevent memory leaks", async () => {
+    await initAudioDSP();
+
+    // Clear previous calls like 'init'
+    mockPostMessage.mockClear();
+
+    const { stopAudioProcessing } = await import("@/lib/wasm/audioDSPManager");
+    stopAudioProcessing();
+
+    expect(mockPostMessage).toHaveBeenCalledWith({ type: "destroy" });
   });
 });

--- a/src/lib/wasm/audioDSPManager.ts
+++ b/src/lib/wasm/audioDSPManager.ts
@@ -178,6 +178,7 @@ export function stopAudioProcessing(): void {
   }
 
   if (state.workletNode) {
+    state.workletNode.port.postMessage({ type: "destroy" });
     state.workletNode.disconnect();
   }
 

--- a/src/lib/wasm/audioDSPWorklet.js
+++ b/src/lib/wasm/audioDSPWorklet.js
@@ -12,6 +12,7 @@ class AudioDSPProcessor extends AudioWorkletProcessor {
     this.wasmExports = null;
     this.inputBufferPtr = 0;
     this.outputBufferPtr = 0;
+    this.noiseProfilePtr = 0;
     this.frameSize = 256;
     this.port.onmessage = this.handleMessage.bind(this);
   }
@@ -65,15 +66,39 @@ class AudioDSPProcessor extends AudioWorkletProcessor {
         break;
       case "getNoiseProfile":
         if (this.wasmExports) {
-          const ptr = this.wasmExports.malloc(this.align16(513 * 4));
-          this.wasmExports.getNoiseProfile(ptr, 513);
-          const profile = new Float32Array(
-            this.wasmExports.memory.buffer,
-            ptr,
-            513,
-          ).slice();
-          this.wasmExports.free(ptr, this.align16(513 * 4));
-          this.port.postMessage({ type: "noiseProfile", profile });
+          const profileBytes = this.align16(513 * 4);
+          if (!this.noiseProfilePtr) {
+            this.noiseProfilePtr = this.wasmExports.malloc(profileBytes);
+          }
+          try {
+            this.wasmExports.getNoiseProfile(this.noiseProfilePtr, 513);
+            const profile = new Float32Array(
+              this.wasmExports.memory.buffer,
+              this.noiseProfilePtr,
+              513,
+            ).slice();
+            this.port.postMessage({ type: "noiseProfile", profile });
+          } catch (error) {
+            this.port.postMessage({ type: "error", error: error.message });
+          }
+        }
+        break;
+      case "destroy":
+        if (this.wasmExports) {
+          const frameBytes = this.align16(this.frameSize * 4);
+          if (this.inputBufferPtr) {
+            this.wasmExports.free(this.inputBufferPtr, frameBytes);
+            this.inputBufferPtr = 0;
+          }
+          if (this.outputBufferPtr) {
+            this.wasmExports.free(this.outputBufferPtr, frameBytes);
+            this.outputBufferPtr = 0;
+          }
+          if (this.noiseProfilePtr) {
+            this.wasmExports.free(this.noiseProfilePtr, this.align16(513 * 4));
+            this.noiseProfilePtr = 0;
+          }
+          this.wasmReady = false;
         }
         break;
     }
@@ -83,7 +108,7 @@ class AudioDSPProcessor extends AudioWorkletProcessor {
     try {
       const wasmModule = await WebAssembly.compile(wasmBinary);
 
-      const simdAvailable = await AudioDSPProcessor.probeSIMDSupport();
+      const _simdAvailable = await AudioDSPProcessor.probeSIMDSupport();
 
       const instance = await WebAssembly.instantiate(wasmModule);
 


### PR DESCRIPTION
## Description

This PR fixes a WebAssembly memory leak in the audio DSP pipeline by ensuring allocated WASM buffers are properly reused during processing and explicitly released when audio processing stops.

### Changes

- Reused the noise profile WASM buffer to prevent repeated heap allocations during continuous audio processing.
- Added explicit cleanup for allocated WASM buffers (`inputBufferPtr`, `outputBufferPtr`, and `noiseProfilePtr`) during DSP teardown.
- Integrated cleanup with the audio processing lifecycle by sending a `destroy` message before disconnecting the worklet.
- Improved robustness of the DSP processing path to ensure allocated resources are properly managed.
- Added regression tests verifying that memory cleanup is triggered during shutdown.

## Related Issue

- Fixes #1278

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (Not applicable)

## Screenshots / Screen Recordings (if applicable)

Not applicable. This PR only changes the WebAssembly audio processing backend and unit tests.

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio processing cleanup to fully release resources when processing stops.
  * Prevented repeated noise profile requests from allocating unnecessary memory.
  * Added error handling for noise profile retrieval failures.
  * Improved teardown reliability for Web Audio processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->