### PR TITLE
feat(pdf): move signature verification to background web worker

### DIFF
--- a/src/components/receipt/ReceiptVerificationModal.tsx
+++ b/src/components/receipt/ReceiptVerificationModal.tsx
@@ -14,7 +14,7 @@ export function ReceiptVerificationModal({
   open,
   onClose,
 }: ReceiptVerificationModalProps) {
-  const { status, signatures, result, error, verify, reset } =
+  const { status, progress, signatures, result, error, verify, reset } =
     usePdfSignatureVerifier();
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [isDragging, setIsDragging] = useState(false);
@@ -141,6 +141,23 @@ export function ReceiptVerificationModal({
 
               <div className="flex flex-col gap-4">
                 <SignatureVerificationBadge status={status} result={result} />
+
+                {(status === "loading" || status === "verifying") && (
+                  <div className="flex flex-col gap-2">
+                    <div className="w-full bg-zinc-200 dark:bg-zinc-700 rounded-full h-2">
+                      <div
+                        className="bg-blue-500 h-2 rounded-full transition-all duration-300"
+                        style={{ width: `${progress}%` }}
+                      ></div>
+                    </div>
+                    <span className="text-xs text-zinc-500 self-end">
+                      {status === "loading"
+                        ? "Reading file..."
+                        : "Verifying signature..."}{" "}
+                      {progress}%
+                    </span>
+                  </div>
+                )}
 
                 {status === "verified" && signatures.length > 0 && (
                   <div className="flex flex-col gap-1 p-3 bg-zinc-50 dark:bg-zinc-800 rounded text-sm">

--- a/src/components/receipt/__tests__/ReceiptVerificationModal.test.tsx
+++ b/src/components/receipt/__tests__/ReceiptVerificationModal.test.tsx
@@ -5,6 +5,7 @@ import { ReceiptVerificationModal } from "../ReceiptVerificationModal";
 jest.mock("@/hooks/usePdfSignatureVerifier", () => ({
   usePdfSignatureVerifier: () => ({
     status: "idle",
+    progress: 0,
     signatures: [],
     result: null,
     error: null,

--- a/src/hooks/usePdfSignatureVerifier.ts
+++ b/src/hooks/usePdfSignatureVerifier.ts
@@ -1,22 +1,15 @@
 "use client";
 
 import { useState, useCallback, useRef, useEffect } from "react";
-import {
-  extractSignatures,
-  getSignedBytes,
-} from "@/lib/pdf-verify/pdfSignatureExtractor";
-import { fetchCaRootsPem } from "@/lib/pdf-verify/caRoots";
 import type {
   PdfSignatureInfo,
   SignatureVerificationResult,
   VerificationStatus,
-  ByteRange,
-  WorkerRequest,
-  WorkerResponse,
 } from "@/types/pdfSignature";
 
 export interface UsePdfSignatureVerifierReturn {
   status: VerificationStatus;
+  progress: number;
   signatures: PdfSignatureInfo[];
   result: SignatureVerificationResult | null;
   error: string | null;
@@ -24,120 +17,35 @@ export interface UsePdfSignatureVerifierReturn {
   reset: () => void;
 }
 
-let workerInstance: Worker | null = null;
-let workerReady = false;
-let initPromise: Promise<void> | null = null;
-
-function getWorker(): Worker | null {
-  if (typeof window === "undefined" || typeof Worker === "undefined")
-    return null;
-  if (!workerInstance) {
-    try {
-      const baseUrl =
-        typeof document !== "undefined"
-          ? document.baseURI
-          : "http://localhost/";
-      workerInstance = new Worker(
-        new URL("/workers/pdfVerify.worker.js", baseUrl),
-        { type: "module" },
-      );
-    } catch {
-      return null;
-    }
-  }
-  return workerInstance;
-}
-
-async function initWorker(): Promise<void> {
-  if (workerReady) return;
-  if (initPromise) return initPromise;
-
-  initPromise = new Promise<void>((resolve, reject) => {
-    const worker = getWorker();
-    if (!worker) {
-      resolve();
-      return;
-    }
-    const id = crypto.randomUUID();
-
-    const handler = (e: MessageEvent<WorkerResponse>) => {
-      if (e.data.id !== id) return;
-      worker.removeEventListener("message", handler);
-
-      if (e.data.action === "ready") {
-        workerReady = true;
-        resolve();
-      } else {
-        reject(new Error(e.data.error || "Worker init failed"));
-      }
-    };
-
-    worker.addEventListener("message", handler);
-
-    const wasmUrl = "/pdf-verify.js";
-    worker.postMessage({
-      action: "init",
-      id,
-      payload: { wasmUrl },
-    } satisfies WorkerRequest);
-  });
-
-  return initPromise;
-}
-
-function verifyInWorker(
-  pdfBytes: Uint8Array,
-  cmsBlob: Uint8Array,
-  byteRange: ByteRange,
-  caRoots: string,
-): Promise<SignatureVerificationResult> {
-  return new Promise((resolve, reject) => {
-    const worker = getWorker();
-    if (!worker) {
-      reject(new Error("Worker not supported"));
-      return;
-    }
-    const id = crypto.randomUUID();
-
-    const handler = (e: MessageEvent<WorkerResponse>) => {
-      if (e.data.id !== id) return;
-      worker.removeEventListener("message", handler);
-
-      if (e.data.action === "result" && e.data.result) {
-        resolve(e.data.result);
-      } else {
-        reject(new Error(e.data.error || "Verification failed"));
-      }
-    };
-
-    worker.addEventListener("message", handler);
-
-    worker.postMessage({
-      action: "verify",
-      id,
-      payload: { pdfBytes, cmsBlob, byteRange, caRoots },
-    } satisfies WorkerRequest);
-  });
-}
-
 export function usePdfSignatureVerifier(): UsePdfSignatureVerifierReturn {
   const [status, setStatus] = useState<VerificationStatus>("idle");
+  const [progress, setProgress] = useState(0);
   const [signatures, setSignatures] = useState<PdfSignatureInfo[]>([]);
   const [result, setResult] = useState<SignatureVerificationResult | null>(
     null,
   );
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef(false);
+  const workerRef = useRef<Worker | null>(null);
 
   useEffect(() => {
     return () => {
       abortRef.current = true;
+      if (workerRef.current) {
+        workerRef.current.terminate();
+        workerRef.current = null;
+      }
     };
   }, []);
 
   const reset = useCallback(() => {
     abortRef.current = true;
+    if (workerRef.current) {
+      workerRef.current.terminate();
+      workerRef.current = null;
+    }
     setStatus("idle");
+    setProgress(0);
     setSignatures([]);
     setResult(null);
     setError(null);
@@ -146,43 +54,92 @@ export function usePdfSignatureVerifier(): UsePdfSignatureVerifierReturn {
   const verify = useCallback(async (file: File) => {
     abortRef.current = false;
     setStatus("loading");
+    setProgress(0);
     setResult(null);
     setError(null);
     setSignatures([]);
 
     try {
-      const arrayBuffer = await file.arrayBuffer();
-      if (abortRef.current) return;
-
-      const pdfBytes = new Uint8Array(arrayBuffer);
-      const foundSignatures = extractSignatures(pdfBytes);
-
-      if (foundSignatures.length === 0) {
-        setStatus("unsigned");
-        return;
+      if (workerRef.current) {
+        workerRef.current.terminate();
       }
 
-      setSignatures(foundSignatures);
-      setStatus("verifying");
-
-      await initWorker();
-      if (abortRef.current) return;
-
-      const sig = foundSignatures[0];
-      const signedBytes = getSignedBytes(pdfBytes, sig.byteRange);
-      const caRoots = await fetchCaRootsPem();
-
-      const verifyResult = await verifyInWorker(
-        signedBytes,
-        sig.contents,
-        sig.byteRange,
-        caRoots,
+      const worker = new Worker(
+        new URL("@/workers/pdfSignature.worker.ts", import.meta.url),
+        { type: "module" },
       );
+      workerRef.current = worker;
 
-      if (abortRef.current) return;
+      worker.onmessage = (event) => {
+        if (abortRef.current) return;
 
-      setResult(verifyResult);
-      setStatus(verifyResult.valid ? "verified" : "invalid");
+        const {
+          type,
+          progress: p,
+          signatures: sigs,
+          results,
+          error: err,
+        } = event.data;
+
+        if (type === "progress") {
+          setProgress(p);
+          if (p === 50) {
+            setStatus("verifying");
+          }
+        } else if (type === "result") {
+          if (sigs && sigs.length === 0) {
+            setStatus("unsigned");
+            worker.terminate();
+            workerRef.current = null;
+            return;
+          }
+          if (results && results.length > 0) {
+            const firstResult = results[0];
+            setSignatures(results.map((r: any) => r.signature));
+            setResult(firstResult.result);
+            setStatus(firstResult.result.valid ? "verified" : "invalid");
+          }
+          worker.terminate();
+          workerRef.current = null;
+        } else if (type === "error") {
+          setError(err || "Verification failed");
+          setStatus("error");
+          worker.terminate();
+          workerRef.current = null;
+        }
+      };
+
+      worker.onerror = (e) => {
+        if (abortRef.current) return;
+        setError("Worker error: " + e.message);
+        setStatus("error");
+        worker.terminate();
+        workerRef.current = null;
+      };
+
+      const chunkSize = 1024 * 1024; // 1 MB
+      const totalBytes = file.size;
+
+      for (let i = 0; i < totalBytes; i += chunkSize) {
+        if (abortRef.current) break;
+        const blob = file.slice(i, i + chunkSize);
+        const arrayBuffer = await blob.arrayBuffer();
+
+        worker.postMessage(
+          {
+            type: "chunk",
+            payload: { chunk: arrayBuffer },
+          },
+          [arrayBuffer],
+        );
+
+        const currentProgress = Math.floor(((i + blob.size) / totalBytes) * 40); // 0-40% for loading
+        setProgress(currentProgress);
+      }
+
+      if (!abortRef.current) {
+        worker.postMessage({ type: "verify" });
+      }
     } catch (err) {
       if (abortRef.current) return;
       const msg = err instanceof Error ? err.message : String(err);
@@ -191,5 +148,5 @@ export function usePdfSignatureVerifier(): UsePdfSignatureVerifierReturn {
     }
   }, []);
 
-  return { status, signatures, result, error, verify, reset };
+  return { status, progress, signatures, result, error, verify, reset };
 }

--- a/src/workers/pdfSignature.worker.ts
+++ b/src/workers/pdfSignature.worker.ts
@@ -1,0 +1,90 @@
+import {
+  extractSignatures,
+  getSignedBytes,
+} from "@/lib/pdf-verify/pdfSignatureExtractor";
+import { fetchCaRootsPem } from "@/lib/pdf-verify/caRoots";
+
+let pdfVerifyModule: any = null;
+
+async function initWasm() {
+  if (pdfVerifyModule) return;
+  const wasmUrl = "/pdf-verify.js";
+  const factoryModule = await import(/* @vite-ignore */ wasmUrl);
+  const factory = factoryModule.default || factoryModule;
+
+  pdfVerifyModule = await factory({
+    locateFile: (path: string) => {
+      if (path.endsWith(".wasm")) {
+        return "/pdf-verify.wasm";
+      }
+      return path;
+    },
+  });
+}
+
+let fileBuffer: Uint8Array = new Uint8Array(0);
+
+self.onmessage = async (event: MessageEvent) => {
+  const { type, payload } = event.data;
+
+  if (type === "chunk") {
+    const { chunk } = payload;
+    const newBuffer = new Uint8Array(fileBuffer.length + chunk.length);
+    newBuffer.set(fileBuffer);
+    newBuffer.set(new Uint8Array(chunk), fileBuffer.length);
+    fileBuffer = newBuffer;
+  } else if (type === "verify") {
+    try {
+      self.postMessage({ type: "progress", progress: 50 });
+
+      const signatures = extractSignatures(fileBuffer);
+      if (signatures.length === 0) {
+        self.postMessage({ type: "result", signatures: [] });
+        return;
+      }
+
+      await initWasm();
+
+      self.postMessage({ type: "progress", progress: 75 });
+
+      const caRoots = await fetchCaRootsPem();
+      const results = [];
+
+      for (const sig of signatures) {
+        const signedBytes = getSignedBytes(fileBuffer, sig.byteRange);
+
+        const verifyResult = pdfVerifyModule.verifyPdfSignature(
+          signedBytes,
+          sig.contents,
+          sig.byteRange.offset1,
+          sig.byteRange.length1,
+          sig.byteRange.offset2,
+          sig.byteRange.length2,
+          caRoots || "",
+        );
+
+        results.push({
+          signature: sig,
+          result: {
+            valid: verifyResult.valid,
+            signerName: verifyResult.signerName || "",
+            signingTime: verifyResult.signingTime || "",
+            algorithm: verifyResult.algorithm || "",
+            error: verifyResult.error || "",
+          },
+        });
+      }
+
+      self.postMessage({ type: "progress", progress: 100 });
+      self.postMessage({ type: "result", results });
+    } catch (error) {
+      self.postMessage({
+        type: "error",
+        error: error instanceof Error ? error.message : "Verification failed",
+      });
+    } finally {
+      // Cleanup for next file
+      fileBuffer = new Uint8Array(0);
+    }
+  }
+};


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does and why it is needed. -->

## Related Issue

<!-- 
Please link to the issue here using the standard keywords. 
Example: Fixes #123 or Closes #123
-->
Fixes #

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

<!-- Add visual evidence if this PR changes UI/UX. -->

## Breaking Changes

- [ ] Yes (please describe below)
- [ ] No
## Description

This PR moves PDF RSA/ECDSA signature verification into a Web Worker to prevent blocking the main UI thread during large document processing.

### Changes

- Added background Web Worker for signature verification
- Moved RSA/ECDSA verification logic off the main thread
- Implemented chunked PDF processing
- Added progress updates for long-running verification
- Improved error handling and worker cleanup

### Validation

- [x] UI remains responsive during verification
- [x] RSA signatures verified correctly
- [x] ECDSA signatures verified correctly
- [x] Large PDFs processed successfully
- [x] Lint/build pass

Closes #1465