### PR TITLE
fix: bind footer copyright year dynamically instead of hardcoding (cl…

### DIFF
--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -291,9 +291,10 @@ export default function SiteFooter() {
 
         {/* Footer Bottom Strip */}
         <div className="mt-12 flex justify-end text-xs text-zinc-400 dark:text-white/30">
-          <p>© 2026 WorkSphere</p>
+          <p>© {new Date().getFullYear()} WorkSphere</p>
         </div>
       </div>
     </footer>
   );
 }
+


### PR DESCRIPTION
fixes #449 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The footer copyright year now updates automatically to the current year.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->