### PR TITLE
fix: dynamically bind footer copyright year

### DIFF
--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -291,7 +291,7 @@ export default function SiteFooter() {
 
         {/* Footer Bottom Strip */}
         <div className="mt-12 flex justify-end text-xs text-zinc-400 dark:text-white/30">
-          <p>© 2026 WorkSphere</p>
+          <p>© {new Date().getFullYear()} WorkSphere</p>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Description
Swapped out the hardcoded 2026 copyright year in the site footer with a dynamic React expression using the `Date` object so it updates automatically.

## Related Issue
Closes #1450


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the footer copyright year to automatically display the current year.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->