### PR TITLE
[Security] Add Content Security Policy (CSP) Headers with Nonce Support

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 
 import "./globals.css";
 
@@ -121,6 +121,8 @@ export default async function RootLayout({
   const publishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
 
   const cookieStore = await cookies();
+  const headersList = await headers();
+  const nonce = headersList.get("x-csp-nonce") ?? "";
   const storedTheme = cookieStore.get("worksphere-theme")?.value;
   const theme: "light" | "dark" | "cyberpunk" =
     storedTheme === "dark" ||
@@ -181,6 +183,7 @@ export default async function RootLayout({
         <meta name="mobile-web-app-capable" content="yes" />
         <script
           id="theme-init"
+          nonce={nonce}
           dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }}
         />
       </head>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,6 +9,21 @@ import {
   verifyCsrfToken,
 } from "./lib/csrf";
 
+function generateCsp(nonce: string): string {
+  return [
+    `base-uri 'self'`,
+    `default-src 'self'`,
+    `script-src 'self' 'nonce-${nonce}' https://cdn.clerk.com`,
+    `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com`,
+    `font-src 'self' https://fonts.gstatic.com data:`,
+    `img-src 'self' https://images.unsplash.com https://*.unsplash.com https://res.cloudinary.com data: blob:`,
+    `connect-src 'self' https://*.clerk.com https://api.groq.com https://router.project-osrm.org wss://*.partykit.dev`,
+    `frame-src 'self' https://*.clerk.com`,
+    `worker-src 'self' blob:`,
+    `object-src 'none'`,
+  ].join("; ");
+}
+
 const isPublicRoute = createRouteMatcher([
   "/",
   "/sign-in(.*)",
@@ -130,6 +145,8 @@ export default function middleware(request: any, event: any) {
 
     const requestHeaders = new Headers(req.headers);
     requestHeaders.set("x-pathname", req.nextUrl.pathname);
+    const nonce = crypto.randomUUID();
+    requestHeaders.set("x-csp-nonce", nonce);
     const start = Date.now();
     requestHeaders.set("x-request-start", String(start));
 
@@ -149,6 +166,7 @@ export default function middleware(request: any, event: any) {
         headers: requestHeaders,
       },
     });
+    res.headers.set("Content-Security-Policy", generateCsp(nonce));
     return applyCsrfProtection(req, res);
   });
 


### PR DESCRIPTION
## Description

Fixes #1488

Adds Content Security Policy headers with per-request nonce support to protect against XSS attacks.

### Changes

**src/middleware.ts:**
- Added \generateCsp()\ helper that builds a comprehensive CSP policy string
- Generates a cryptographically random nonce per request via \crypto.randomUUID()\
- Sets \x-csp-nonce\ on request headers for downstream server components
- Adds \Content-Security-Policy\ header to all responses

**src/app/layout.tsx:**
- Reads \x-csp-nonce\ header via \headers()\ from \
ext/headers\
- Applies the nonce to the inline THEME_INIT_SCRIPT via \
once={nonce}\ prop

### CSP Allowlist

| Directive | Sources |
|-----------|---------|
| base-uri | 'self' |
| default-src | 'self' |
| script-src | 'self', 'nonce-{nonce}', https://cdn.clerk.com |
| style-src | 'self', 'unsafe-inline', https://fonts.googleapis.com |
| font-src | 'self', https://fonts.gstatic.com, data: |
| img-src | 'self', Unsplash, Cloudinary, data:, blob: |
| connect-src | 'self', Clerk, Groq, OSRM, PartyKit WebSockets |
| frame-src | 'self', Clerk |
| worker-src | 'self', blob: |
| object-src | 'none' |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Added per-request Content Security Policy protection.
  * Secured the application’s theme initialization script with a request-specific nonce.
  * Updated allowed sources for scripts, styles, fonts, images, connections, frames, and workers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->