### PR TITLE
Feat/booking cancellation window

### DIFF
--- a/src/__tests__/lib/bookingCancellation.test.ts
+++ b/src/__tests__/lib/bookingCancellation.test.ts
@@ -1,0 +1,98 @@
+import {
+  BOOKING_CANCELLATION_POLICY_MESSAGE,
+  BOOKING_CANCELLATION_WINDOW_MS,
+  cancellationWindowHoursRemaining,
+  getBookingCancellationEligibility,
+  parseBookingStart,
+} from "@/lib/bookingCancellation";
+
+describe("booking cancellation policy", () => {
+  const now = new Date(2026, 6, 23, 10, 0, 0, 0);
+
+  it("allows cancellation when exactly two hours remain", () => {
+    const result = getBookingCancellationEligibility({
+      date: "2026-07-23",
+      time: "12:00",
+      now,
+    });
+
+    expect(result.allowed).toBe(true);
+
+    if (result.allowed) {
+      expect(result.millisecondsUntilStart).toBe(
+        BOOKING_CANCELLATION_WINDOW_MS,
+      );
+    }
+  });
+
+  it("allows cancellation when more than two hours remain", () => {
+    const result = getBookingCancellationEligibility({
+      date: "2026-07-23",
+      time: "12:01",
+      now,
+    });
+
+    expect(result.allowed).toBe(true);
+  });
+
+  it("rejects cancellation when less than two hours remain", () => {
+    const result = getBookingCancellationEligibility({
+      date: "2026-07-23",
+      time: "11:59",
+      now,
+    });
+
+    expect(result.allowed).toBe(false);
+
+    if (!result.allowed) {
+      expect(result.reason).toBe("INSIDE_WINDOW");
+      expect(result.message).toBe(BOOKING_CANCELLATION_POLICY_MESSAGE);
+    }
+  });
+
+  it("rejects a booking that has already started", () => {
+    const result = getBookingCancellationEligibility({
+      date: "2026-07-23",
+      time: "09:30",
+      now,
+    });
+
+    expect(result.allowed).toBe(false);
+
+    if (!result.allowed) {
+      expect(result.reason).toBe("BOOKING_ALREADY_STARTED");
+    }
+  });
+
+  it("rejects invalid booking date and time values", () => {
+    const result = getBookingCancellationEligibility({
+      date: "2026-02-31",
+      time: "25:90",
+      now,
+    });
+
+    expect(result.allowed).toBe(false);
+
+    if (!result.allowed) {
+      expect(result.reason).toBe("INVALID_START_TIME");
+      expect(result.bookingStart).toBeNull();
+    }
+  });
+
+  it("parses valid local booking values", () => {
+    const parsed = parseBookingStart("2026-07-23", "15:45");
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.getFullYear()).toBe(2026);
+    expect(parsed?.getMonth()).toBe(6);
+    expect(parsed?.getDate()).toBe(23);
+    expect(parsed?.getHours()).toBe(15);
+    expect(parsed?.getMinutes()).toBe(45);
+  });
+
+  it("converts the remaining duration to hours", () => {
+    expect(cancellationWindowHoursRemaining(90 * 60 * 1000)).toBe(1.5);
+
+    expect(cancellationWindowHoursRemaining(-1)).toBe(0);
+  });
+});

--- a/src/app/api/bookings/[bookingId]/route.ts
+++ b/src/app/api/bookings/[bookingId]/route.ts
@@ -1,0 +1,177 @@
+import { auth } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+
+import {
+  cancellationWindowHoursRemaining,
+  getBookingCancellationEligibility,
+} from "@/lib/bookingCancellation";
+import { prisma } from "@/lib/prisma";
+
+type RouteContext = {
+  params: Promise<{
+    bookingId: string;
+  }>;
+};
+
+/**
+ * DELETE /api/bookings/[bookingId]
+ *
+ * Cancels an authenticated user's booking when at least two hours remain
+ * before its scheduled start time.
+ */
+export async function DELETE(_request: Request, context: RouteContext) {
+  try {
+    const { userId } = await auth();
+
+    if (!userId) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Unauthorized",
+        },
+        { status: 401 },
+      );
+    }
+
+    const { bookingId } = await context.params;
+
+    if (!bookingId) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Booking ID is required.",
+        },
+        { status: 400 },
+      );
+    }
+
+    const booking = await prisma.booking.findFirst({
+      where: {
+        id: bookingId,
+        userId,
+      },
+      select: {
+        id: true,
+        date: true,
+        time: true,
+        status: true,
+      },
+    });
+
+    if (!booking) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Booking not found.",
+        },
+        { status: 404 },
+      );
+    }
+
+    if (booking.status === "CANCELLED") {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "This booking has already been cancelled.",
+        },
+        { status: 409 },
+      );
+    }
+
+    const eligibility = getBookingCancellationEligibility({
+      date: booking.date,
+      time: booking.time,
+    });
+
+    if (!eligibility.allowed) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: eligibility.message,
+          code: eligibility.reason,
+          cancellationWindowHours: 2,
+          hoursUntilStart:
+            eligibility.millisecondsUntilStart === null
+              ? null
+              : cancellationWindowHoursRemaining(
+                  eligibility.millisecondsUntilStart,
+                ),
+        },
+        { status: 400 },
+      );
+    }
+
+    const cancelledAt = new Date();
+
+    const cancellation = await prisma.$transaction(async (tx) => {
+      // updateMany makes a concurrent duplicate cancellation harmless.
+      const updated = await tx.booking.updateMany({
+        where: {
+          id: booking.id,
+          userId,
+          status: {
+            not: "CANCELLED",
+          },
+        },
+        data: {
+          status: "CANCELLED",
+        },
+      });
+
+      if (updated.count !== 1) {
+        return {
+          cancelled: false,
+        } as const;
+      }
+
+      await tx.bookingGuest.updateMany({
+        where: {
+          bookingId: booking.id,
+          status: {
+            in: ["PENDING", "SENT"],
+          },
+        },
+        data: {
+          status: "CANCELLED",
+        },
+      });
+
+      return {
+        cancelled: true,
+      } as const;
+    });
+
+    if (!cancellation.cancelled) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "The booking was already cancelled by another request.",
+        },
+        { status: 409 },
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: "Booking cancelled successfully.",
+      booking: {
+        id: booking.id,
+        status: "CANCELLED",
+        cancelledAt: cancelledAt.toISOString(),
+      },
+    });
+  } catch (error) {
+    console.error(
+      "[DELETE /api/bookings/[bookingId]] Cancellation error:",
+      error,
+    );
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Unable to cancel the booking. Please try again.",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/bookingCancellation.ts
+++ b/src/lib/bookingCancellation.ts
@@ -1,0 +1,108 @@
+export const BOOKING_CANCELLATION_WINDOW_HOURS = 2;
+export const BOOKING_CANCELLATION_WINDOW_MS =
+  BOOKING_CANCELLATION_WINDOW_HOURS * 60 * 60 * 1000;
+
+export const BOOKING_CANCELLATION_POLICY_MESSAGE =
+  "Bookings can only be cancelled at least 2 hours before the scheduled start time.";
+
+export type BookingCancellationEligibility =
+  | {
+      allowed: true;
+      bookingStart: Date;
+      millisecondsUntilStart: number;
+    }
+  | {
+      allowed: false;
+      bookingStart: Date | null;
+      millisecondsUntilStart: number | null;
+      reason:
+        "INVALID_START_TIME" | "BOOKING_ALREADY_STARTED" | "INSIDE_WINDOW";
+      message: string;
+    };
+
+const BOOKING_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const BOOKING_TIME_PATTERN = /^([01]\d|2[0-3]):([0-5]\d)$/;
+
+/**
+ * Converts the Booking model's YYYY-MM-DD date and HH:mm time fields into a
+ * local Date. Booking creation currently stores both values without a timezone,
+ * so cancellation checks intentionally follow the same local-time convention.
+ */
+export function parseBookingStart(date: string, time: string): Date | null {
+  if (!BOOKING_DATE_PATTERN.test(date) || !BOOKING_TIME_PATTERN.test(time)) {
+    return null;
+  }
+
+  const [year, month, day] = date.split("-").map(Number);
+  const [hour, minute] = time.split(":").map(Number);
+
+  const bookingStart = new Date(year, month - 1, day, hour, minute, 0, 0);
+
+  // Reject impossible dates such as 2026-02-31, which JavaScript normalizes.
+  if (
+    bookingStart.getFullYear() !== year ||
+    bookingStart.getMonth() !== month - 1 ||
+    bookingStart.getDate() !== day ||
+    bookingStart.getHours() !== hour ||
+    bookingStart.getMinutes() !== minute
+  ) {
+    return null;
+  }
+
+  return bookingStart;
+}
+
+export function getBookingCancellationEligibility(input: {
+  date: string;
+  time: string;
+  now?: Date;
+}): BookingCancellationEligibility {
+  const bookingStart = parseBookingStart(input.date, input.time);
+
+  if (!bookingStart) {
+    return {
+      allowed: false,
+      bookingStart: null,
+      millisecondsUntilStart: null,
+      reason: "INVALID_START_TIME",
+      message:
+        "The booking start date or time is invalid. Please contact support.",
+    };
+  }
+
+  const now = input.now ?? new Date();
+  const millisecondsUntilStart = bookingStart.getTime() - now.getTime();
+
+  if (millisecondsUntilStart <= 0) {
+    return {
+      allowed: false,
+      bookingStart,
+      millisecondsUntilStart,
+      reason: "BOOKING_ALREADY_STARTED",
+      message:
+        "This booking has already started and can no longer be cancelled.",
+    };
+  }
+
+  if (millisecondsUntilStart < BOOKING_CANCELLATION_WINDOW_MS) {
+    return {
+      allowed: false,
+      bookingStart,
+      millisecondsUntilStart,
+      reason: "INSIDE_WINDOW",
+      message: BOOKING_CANCELLATION_POLICY_MESSAGE,
+    };
+  }
+
+  return {
+    allowed: true,
+    bookingStart,
+    millisecondsUntilStart,
+  };
+}
+
+export function cancellationWindowHoursRemaining(
+  millisecondsUntilStart: number,
+): number {
+  return Math.max(0, millisecondsUntilStart / (60 * 60 * 1000));
+}


### PR DESCRIPTION
## Description

This PR implements the two-hour cancellation-window rule for venue seat
bookings.

### Changes

- Added `DELETE /api/bookings/[bookingId]` for authenticated booking
  cancellation.
- Calculates the time remaining between the current timestamp and the booking's
  stored start date/time.
- Allows cancellation at exactly two hours before the start.
- Returns `400 Bad Request` when fewer than two hours remain.
- Returns clear errors for already-started and malformed booking times.
- Verifies that the authenticated Clerk user owns the booking.
- Prevents duplicate and concurrent cancellation updates.
- Marks related pending or sent guest invitations as cancelled.
- Added reusable cancellation-policy utilities.
- Added focused tests for exact-boundary, inside-window, past, invalid-input,
  parsing, and duration-formatting behavior.
- Requires no Prisma schema migration.

## Related Issue

Fixes #1423

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no intentional new warnings
- [x] I have added tests that prove the cancellation rule works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


## Breaking Changes

- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added booking cancellation for authenticated customers.
  * Cancellations are allowed more than two hours before the booking starts.
  * Related pending guest invitations are cancelled automatically.
  * Responses now clearly indicate successful cancellations, conflicts, and validation errors.

* **Bug Fixes**
  * Prevented cancellation of bookings that have started, are already cancelled, or have invalid date and time details.

* **Tests**
  * Added coverage for cancellation eligibility, timing boundaries, invalid inputs, and time remaining calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->