### PR TITLE
[Refactor] Unify Filter Validation Schema - Eliminate Client/Server Duplication

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -4,6 +4,7 @@ import Groq from "groq-sdk";
 import { rateLimit, getRateLimitInfo } from "@/lib/rateLimit";
 import { triggerBackgroundMemorySync } from "@/lib/backgroundSync";
 import { chatRequestSchema, validateRequest } from "@/lib/validations";
+import { applyFilters } from "@/lib/filters";
 import {
   checkSemanticCache,
   setSemanticCache,
@@ -377,74 +378,7 @@ async function dataAgent(
 
       // Apply filters if provided
       if (filters) {
-        if (filters.wifi) venues = venues.filter((v: any) => v.wifi);
-        if (filters.outlets) venues = venues.filter((v: any) => v.hasOutlets);
-        if (filters.quiet)
-          venues = venues.filter((v: any) => v.noiseLevel === "quiet");
-        if (filters.ergonomic)
-          venues = venues.filter((v: any) => v.hasErgonomic);
-        if (filters.outletDensity && filters.outletDensity !== "none") {
-          if (filters.outletDensity === "every_table") {
-            venues = venues.filter(
-              (v: any) => v.outletDensity === "every_table",
-            );
-          } else if (filters.outletDensity === "some_tables") {
-            venues = venues.filter((v: any) =>
-              ["every_table", "some_tables"].includes(v.outletDensity),
-            );
-          } else if (filters.outletDensity === "wall_seats") {
-            venues = venues.filter((v: any) =>
-              ["every_table", "some_tables", "wall_seats"].includes(
-                v.outletDensity,
-              ),
-            );
-          }
-        }
-        if (filters.wifiSpeedBand && filters.wifiSpeedBand !== "all") {
-          if (filters.wifiSpeedBand === "basic") {
-            venues = venues.filter(
-              (v: any) => v.wifiSpeed !== null && v.wifiSpeed >= 10,
-            );
-          } else if (filters.wifiSpeedBand === "fast") {
-            venues = venues.filter(
-              (v: any) => v.wifiSpeed !== null && v.wifiSpeed >= 50,
-            );
-          } else if (filters.wifiSpeedBand === "ultra") {
-            venues = venues.filter(
-              (v: any) => v.wifiSpeed !== null && v.wifiSpeed >= 100,
-            );
-          }
-        }
-        if (filters.hasPhoneBooths)
-          venues = venues.filter((v: any) => v.hasPhoneBooths);
-        if (filters.hasAncHeadsetRental)
-          venues = venues.filter((v: any) => v.hasAncHeadsetRental);
-        if (filters.singleOriginBeans)
-          venues = venues.filter((v: any) => v.singleOriginBeans);
-
-        if (filters.specialtyEspresso)
-          venues = venues.filter((v: any) => v.specialtyEspresso);
-
-        if (filters.oatAlmondMilk)
-          venues = venues.filter((v: any) => v.oatAlmondMilk);
-
-        if (filters.pourOverAvailable)
-          venues = venues.filter((v: any) => v.pourOverAvailable);
-        if (filters.hasNoMusic)
-          venues = venues.filter((v: any) => v.hasNoMusic);
-        if (filters.hasQuietZone)
-          venues = venues.filter((v: any) => v.hasQuietZone);
-        if (filters.musicStyle && filters.musicStyle !== "all") {
-          if (filters.musicStyle === "no_music") {
-            venues = venues.filter(
-              (v: any) => v.musicStyle === "no_music" || v.hasNoMusic,
-            );
-          } else {
-            venues = venues.filter(
-              (v: any) => v.musicStyle === filters.musicStyle,
-            );
-          }
-        }
+        venues = applyFilters(venues, filters);
       }
 
       return {
@@ -539,67 +473,7 @@ async function dataAgent(
   ];
 
   // Apply filters to mock data as well so the user can test filters
-  let filteredMock = mockVenues;
-  if (filters) {
-    if (filters.wifi) filteredMock = filteredMock.filter((v: any) => v.wifi);
-    if (filters.outlets)
-      filteredMock = filteredMock.filter((v: any) => v.hasOutlets);
-    if (filters.quiet)
-      filteredMock = filteredMock.filter((v: any) => v.noiseLevel === "quiet");
-    if (filters.ergonomic)
-      filteredMock = filteredMock.filter((v: any) => v.hasErgonomic);
-    if (filters.outletDensity && filters.outletDensity !== "none") {
-      if (filters.outletDensity === "every_table") {
-        filteredMock = filteredMock.filter(
-          (v: any) => v.outletDensity === "every_table",
-        );
-      } else if (filters.outletDensity === "some_tables") {
-        filteredMock = filteredMock.filter((v: any) =>
-          ["every_table", "some_tables"].includes(v.outletDensity),
-        );
-      } else if (filters.outletDensity === "wall_seats") {
-        filteredMock = filteredMock.filter((v: any) =>
-          ["every_table", "some_tables", "wall_seats"].includes(
-            v.outletDensity,
-          ),
-        );
-      }
-    }
-    if (filters.wifiSpeedBand && filters.wifiSpeedBand !== "all") {
-      if (filters.wifiSpeedBand === "basic") {
-        filteredMock = filteredMock.filter(
-          (v: any) => v.wifiSpeed !== null && v.wifiSpeed >= 10,
-        );
-      } else if (filters.wifiSpeedBand === "fast") {
-        filteredMock = filteredMock.filter(
-          (v: any) => v.wifiSpeed !== null && v.wifiSpeed >= 50,
-        );
-      } else if (filters.wifiSpeedBand === "ultra") {
-        filteredMock = filteredMock.filter(
-          (v: any) => v.wifiSpeed !== null && v.wifiSpeed >= 100,
-        );
-      }
-    }
-    if (filters.hasPhoneBooths)
-      filteredMock = filteredMock.filter((v: any) => v.hasPhoneBooths);
-    if (filters.hasAncHeadsetRental)
-      filteredMock = filteredMock.filter((v: any) => v.hasAncHeadsetRental);
-    if (filters.hasNoMusic)
-      filteredMock = filteredMock.filter((v: any) => v.hasNoMusic);
-    if (filters.hasQuietZone)
-      filteredMock = filteredMock.filter((v: any) => v.hasQuietZone);
-    if (filters.musicStyle && filters.musicStyle !== "all") {
-      if (filters.musicStyle === "no_music") {
-        filteredMock = filteredMock.filter(
-          (v: any) => v.musicStyle === "no_music" || v.hasNoMusic,
-        );
-      } else {
-        filteredMock = filteredMock.filter(
-          (v: any) => v.musicStyle === filters.musicStyle,
-        );
-      }
-    }
-  }
+  const filteredMock = filters ? applyFilters(mockVenues, filters) : mockVenues;
 
   return {
     venues: filteredMock,
@@ -1186,86 +1060,9 @@ export async function POST(req: Request) {
       );
 
       // Apply advanced filters post-DB enrichment
-      let finalFilteredVenues = enrichedVenues;
-      if (filters) {
-        if (filters.wifi)
-          finalFilteredVenues = finalFilteredVenues.filter((v: any) => v.wifi);
-        if (filters.outlets)
-          finalFilteredVenues = finalFilteredVenues.filter(
-            (v: any) => v.hasOutlets,
-          );
-        if (filters.quiet)
-          finalFilteredVenues = finalFilteredVenues.filter(
-            (v: any) => v.noiseLevel === "quiet",
-          );
-        if (filters.ergonomic)
-          finalFilteredVenues = finalFilteredVenues.filter(
-            (v: any) => v.hasErgonomic,
-          );
-        if (filters.outletDensity && filters.outletDensity !== "none") {
-          if (filters.outletDensity === "every_table") {
-            finalFilteredVenues = finalFilteredVenues.filter(
-              (v: any) => v.outletDensity === "every_table",
-            );
-          } else if (filters.outletDensity === "some_tables") {
-            finalFilteredVenues = finalFilteredVenues.filter((v: any) =>
-              ["every_table", "some_tables"].includes(v.outletDensity),
-            );
-          } else if (filters.outletDensity === "wall_seats") {
-            finalFilteredVenues = finalFilteredVenues.filter((v: any) =>
-              ["every_table", "some_tables", "wall_seats"].includes(
-                v.outletDensity,
-              ),
-            );
-          }
-        }
-        if (filters.wifiSpeedBand && filters.wifiSpeedBand !== "all") {
-          if (filters.wifiSpeedBand === "basic") {
-            finalFilteredVenues = finalFilteredVenues.filter(
-              (v: any) => v.wifiSpeed !== null && v.wifiSpeed >= 10,
-            );
-          } else if (filters.wifiSpeedBand === "fast") {
-            finalFilteredVenues = finalFilteredVenues.filter(
-              (v: any) => v.wifiSpeed !== null && v.wifiSpeed >= 50,
-            );
-          } else if (filters.wifiSpeedBand === "ultra") {
-            finalFilteredVenues = finalFilteredVenues.filter(
-              (v: any) => v.wifiSpeed !== null && v.wifiSpeed >= 100,
-            );
-          }
-        }
-        if (filters.hasPhoneBooths) {
-          finalFilteredVenues = finalFilteredVenues.filter(
-            (v: any) => v.hasPhoneBooths,
-          );
-        }
-        if (filters.hasAncHeadsetRental) {
-          finalFilteredVenues = finalFilteredVenues.filter(
-            (v: any) => v.hasAncHeadsetRental,
-          );
-        }
-        if (filters.hasNoMusic) {
-          finalFilteredVenues = finalFilteredVenues.filter(
-            (v: any) => v.hasNoMusic,
-          );
-        }
-        if (filters.hasQuietZone) {
-          finalFilteredVenues = finalFilteredVenues.filter(
-            (v: any) => v.hasQuietZone,
-          );
-        }
-        if (filters.musicStyle && filters.musicStyle !== "all") {
-          if (filters.musicStyle === "no_music") {
-            finalFilteredVenues = finalFilteredVenues.filter(
-              (v: any) => v.musicStyle === "no_music" || v.hasNoMusic,
-            );
-          } else {
-            finalFilteredVenues = finalFilteredVenues.filter(
-              (v: any) => v.musicStyle === filters.musicStyle,
-            );
-          }
-        }
-      }
+      const finalFilteredVenues = filters
+        ? applyFilters(enrichedVenues, filters)
+        : enrichedVenues;
 
       if (orchestratorResult.complexity === "simple") {
         console.log("Bypassing Reasoning Agent for Simple query...");

--- a/src/lib/filters.ts
+++ b/src/lib/filters.ts
@@ -1,0 +1,173 @@
+import { z } from "zod";
+
+export const VENUE_FILTERS = {
+  wifi: { type: "boolean" as const, default: false },
+  outlets: { type: "boolean" as const, default: false },
+  quiet: { type: "boolean" as const, default: false },
+  ergonomic: { type: "boolean" as const, default: false },
+  outletDensity: {
+    type: "enum" as const,
+    values: ["every_table", "some_tables", "wall_seats", "none"] as const,
+    default: "none",
+  },
+  wifiSpeedBand: {
+    type: "enum" as const,
+    values: ["basic", "fast", "ultra", "all"] as const,
+    default: "all",
+  },
+  hasPhoneBooths: { type: "boolean" as const, default: false },
+  hasNoMusic: { type: "boolean" as const, default: false },
+  hasQuietZone: { type: "boolean" as const, default: false },
+  hasAncHeadsetRental: { type: "boolean" as const, default: false },
+  singleOriginBeans: { type: "boolean" as const, default: false },
+  specialtyEspresso: { type: "boolean" as const, default: false },
+  oatAlmondMilk: { type: "boolean" as const, default: false },
+  pourOverAvailable: { type: "boolean" as const, default: false },
+  lighting: {
+    type: "enum" as const,
+    values: [
+      "natural_daylight",
+      "warm_ambient",
+      "fluorescent",
+      "bright_white",
+    ] as const,
+    default: undefined,
+  },
+  petsAllowedIndoors: { type: "boolean" as const, default: false },
+  patioOnly: { type: "boolean" as const, default: false },
+  waterBowlsProvided: { type: "boolean" as const, default: false },
+  dogFriendly: { type: "boolean" as const, default: false },
+  catsAllowed: { type: "boolean" as const, default: false },
+  musicStyle: {
+    type: "enum" as const,
+    values: ["lofi", "classical_jazz", "no_music", "all"] as const,
+    default: "all",
+  },
+} as const satisfies Record<
+  string,
+  { type: "boolean" | "enum"; values?: readonly string[]; default: unknown }
+>;
+
+export type VenueFilterKey = keyof typeof VENUE_FILTERS;
+export type VenueFilters = Partial<Record<VenueFilterKey, unknown>>;
+
+interface VenueLike {
+  wifi?: boolean;
+  hasOutlets?: boolean;
+  noiseLevel?: string;
+  hasErgonomic?: boolean;
+  outletDensity?: string;
+  wifiSpeed?: number | null;
+  hasPhoneBooths?: boolean;
+  hasNoMusic?: boolean;
+  hasQuietZone?: boolean;
+  hasAncHeadsetRental?: boolean;
+  singleOriginBeans?: boolean;
+  specialtyEspresso?: boolean;
+  oatAlmondMilk?: boolean;
+  pourOverAvailable?: boolean;
+  musicStyle?: string;
+  [key: string]: unknown;
+}
+
+function matchesOutletDensity(venue: VenueLike, target: string): boolean {
+  if (target === "every_table") return venue.outletDensity === "every_table";
+  if (target === "some_tables")
+    return ["every_table", "some_tables"].includes(venue.outletDensity ?? "");
+  if (target === "wall_seats")
+    return ["every_table", "some_tables", "wall_seats"].includes(
+      venue.outletDensity ?? "",
+    );
+  return true;
+}
+
+function matchesWifiSpeedBand(venue: VenueLike, band: string): boolean {
+  const speed = venue.wifiSpeed;
+  if (speed === null || speed === undefined) return false;
+  if (band === "basic") return speed >= 10;
+  if (band === "fast") return speed >= 50;
+  if (band === "ultra") return speed >= 100;
+  return true;
+}
+
+function matchesMusicStyle(venue: VenueLike, style: string): boolean {
+  if (style === "no_music")
+    return venue.musicStyle === "no_music" || venue.hasNoMusic === true;
+  return venue.musicStyle === style;
+}
+
+export function applyFilters<T extends VenueLike>(
+  venues: T[],
+  filters: VenueFilters,
+): T[] {
+  const active = Object.entries(filters).filter(
+    ([key, value]) =>
+      value !== undefined &&
+      value !== null &&
+      value !== VENUE_FILTERS[key as VenueFilterKey]?.default,
+  );
+  if (active.length === 0) return venues;
+
+  return venues.filter((venue) =>
+    active.every(([key, value]) => {
+      switch (key) {
+        case "wifi":
+          return venue.wifi === true;
+        case "outlets":
+          return venue.hasOutlets === true;
+        case "quiet":
+          return venue.noiseLevel === "quiet";
+        case "ergonomic":
+          return venue.hasErgonomic === true;
+        case "outletDensity":
+          return matchesOutletDensity(venue, value as string);
+        case "wifiSpeedBand":
+          return matchesWifiSpeedBand(venue, value as string);
+        case "hasPhoneBooths":
+          return venue.hasPhoneBooths === true;
+        case "hasAncHeadsetRental":
+          return venue.hasAncHeadsetRental === true;
+        case "singleOriginBeans":
+          return venue.singleOriginBeans === true;
+        case "specialtyEspresso":
+          return venue.specialtyEspresso === true;
+        case "oatAlmondMilk":
+          return venue.oatAlmondMilk === true;
+        case "pourOverAvailable":
+          return venue.pourOverAvailable === true;
+        case "hasNoMusic":
+          return venue.hasNoMusic === true;
+        case "hasQuietZone":
+          return venue.hasQuietZone === true;
+        case "musicStyle":
+          return matchesMusicStyle(venue, value as string);
+        default:
+          return true;
+      }
+    }),
+  );
+}
+
+export function buildVenueSearchSchema() {
+  const shape: Record<string, z.ZodTypeAny> = {
+    lat: z.coerce.number().min(-90).max(90),
+    lng: z.coerce.number().min(-180).max(180),
+    radius: z.coerce.number().min(100).max(50000).default(5000),
+    category: z.enum(["cafe", "coworking", "library", "all"]).optional(),
+    cities: z.string().optional(),
+  };
+
+  for (const [key, config] of Object.entries(VENUE_FILTERS)) {
+    if (config.type === "boolean") {
+      shape[key] = z.coerce.boolean().optional();
+    } else if (config.type === "enum" && config.values) {
+      shape[key] = z.enum(config.values as [string, ...string[]]).optional();
+    }
+  }
+
+  return z.object(shape);
+}
+
+export type VenueSearchFilters = z.infer<
+  ReturnType<typeof buildVenueSearchSchema>
+>;

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { buildVenueSearchSchema } from "@/lib/filters";
 
 // =========================================================================
 // CORE SCHEMAS
@@ -23,38 +24,7 @@ export const chatRequestSchema = z.object({
 });
 
 // Venue schemas
-export const venueSearchSchema = z.object({
-  lat: z.coerce.number().min(-90).max(90),
-  lng: z.coerce.number().min(-180).max(180),
-  radius: z.coerce.number().min(100).max(50000).default(5000),
-  category: z.enum(["cafe", "coworking", "library", "all"]).optional(),
-  wifi: z.coerce.boolean().optional(),
-  outlets: z.coerce.boolean().optional(),
-  quiet: z.coerce.boolean().optional(),
-  ergonomic: z.coerce.boolean().optional(),
-  outletDensity: z
-    .enum(["every_table", "some_tables", "wall_seats", "none"])
-    .optional(),
-  wifiSpeedBand: z.enum(["basic", "fast", "ultra", "all"]).optional(),
-  hasPhoneBooths: z.coerce.boolean().optional(),
-  hasNoMusic: z.coerce.boolean().optional(),
-  hasQuietZone: z.coerce.boolean().optional(),
-  hasAncHeadsetRental: z.coerce.boolean().optional(),
-  singleOriginBeans: z.coerce.boolean().optional(),
-  specialtyEspresso: z.coerce.boolean().optional(),
-  oatAlmondMilk: z.coerce.boolean().optional(),
-  pourOverAvailable: z.coerce.boolean().optional(),
-  lighting: z
-    .enum(["natural_daylight", "warm_ambient", "fluorescent", "bright_white"])
-    .optional(),
-  petsAllowedIndoors: z.coerce.boolean().optional(),
-  patioOnly: z.coerce.boolean().optional(),
-  waterBowlsProvided: z.coerce.boolean().optional(),
-  dogFriendly: z.coerce.boolean().optional(),
-  catsAllowed: z.coerce.boolean().optional(),
-  musicStyle: z.enum(["lofi", "classical_jazz", "no_music", "all"]).optional(),
-  cities: z.string().optional(),
-});
+export const venueSearchSchema = buildVenueSearchSchema();
 
 export const venueCreateSchema = z.object({
   name: z.string().min(1).max(200),


### PR DESCRIPTION
﻿Fixes #1494

Create single source of truth for filter validation, eliminating duplicate logic across server (validations.ts) and client (chat/route.ts dataAgent).

Changes

src/lib/filters.ts (new): VENUE_FILTERS definition object with all filter keys, types, defaults. applyFilters() shared function for array-based filtering (replaces 3 copies in chat/route.ts). buildVenueSearchSchema() to generate Zod schema from definitions.

src/lib/validations.ts: venueSearchSchema now generated from buildVenueSearchSchema() instead of hand-written. All existing filter fields preserved (wifi, outlets, quiet, ergonomic, outletDensity, wifiSpeedBand, hasPhoneBooths, hasNoMusic, hasQuietZone, hasAncHeadsetRental, singleOriginBeans, specialtyEspresso, oatAlmondMilk, pourOverAvailable, lighting, petsAllowedIndoors, patioOnly, waterBowlsProvided, dogFriendly, catsAllowed, musicStyle, cities).

src/app/api/chat/route.ts: Replaced ~300 lines of duplicated filter logic in dataAgent (Overpass section + mock fallback) and POST handler with applyFilters() calls. Added import of applyFilters from @/lib/filters.

Benefits

Single source of truth for all 20+ filter definitions
Adding a new filter requires changes in only ONE file
Type-safe filter keys across frontend/backend
All existing tests pass (13 advancedFilters tests + 3 ancHeadsetRental tests)
