### PR TITLE
docs: add PartySocket reconnection state transitions (#1443)

### DIFF
--- a/src/lib/partySocketReconnect.ts
+++ b/src/lib/partySocketReconnect.ts
@@ -1,4 +1,33 @@
 /**
+ * PartySocket Reconnection Protocol
+ *
+ * ### State Machine Transitions
+ * | Current State  | Next State     | Trigger / Description |
+ * | :------------- | :------------- | :-------------------- |
+ * | `DISCONNECTED` | `CONNECTING`   | Initial connection attempt or manual connect call. |
+ * | `CONNECTING`   | `CONNECTED`    | Connection established successfully. |
+ * | `CONNECTING`   | `RECONNECTING` | Initial connection failed, attempting to retry. |
+ * | `CONNECTED`    | `RECONNECTING` | Connection dropped unexpectedly. |
+ * | `RECONNECTING` | `CONNECTING`   | Executing the next retry attempt. |
+ * | `RECONNECTING` | `DISCONNECTED` | Max retries reached, giving up. |
+ *
+ * ### Configuration Options
+ * - `maxRetries` (number): The maximum number of reconnection attempts before terminating the process.
+ * - `initialDelayMs` / `minReconnectionDelay` (number): The base delay in milliseconds before the first reconnection attempt.
+ * - `maxDelayMs` / `maxReconnectionDelay` (number): The maximum delay in milliseconds between reconnection attempts (used for backoff limits).
+ *
+ * ### Example: Custom Event Listener Binding
+ * ```typescript
+ * const socket = new PartySocket({ host: "localhost:8080" });
+ *
+ * // Bind a custom listener to track reconnection attempts
+ * socket.addEventListener("reconnecting", (event) => {
+ *   console.log(`Reconnecting... Attempt ${event.detail.attempt}`);
+ * });
+ * ```
+ */
+
+/**
  * Shared PartySocket reconnect tuning.
  *
  * Default partysocket uses infinite retries and a 0ms delay on the first


### PR DESCRIPTION
## Description

Added a comprehensive documentation block at the top of `partySocketReconnect.ts` to improve developer onboarding. This update includes:
* A state machine transition table detailing the flow between `DISCONNECTED`, `CONNECTING`, `CONNECTED`, and `RECONNECTING`.
* Clear definitions for configuration options like `maxRetries`, `minReconnectionDelay`, and `maxReconnectionDelay`.
* A TypeScript code snippet demonstrating how to bind a custom event listener to the socket.

## Related Issue

Fixes #1443

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic reconnection with exponential backoff, capped retries, and jitter.
  * Added connection state tracking to prevent redundant connection attempts.
  * Added regional health checks to select the fastest available region before reconnecting.
  * Added configurable retry limits, delays, and probe timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->