### PR TITLE
feat: implement client-side export to CSV for venue analytics report

### DIFF
--- a/src/app/admin/analytics/AdminAnalyticsDashboard.tsx
+++ b/src/app/admin/analytics/AdminAnalyticsDashboard.tsx
@@ -8,6 +8,7 @@ import {
   BarChart3,
   Bot,
   CalendarDays,
+  Download,
   Gauge,
   RefreshCw,
   Search,
@@ -99,6 +100,50 @@ function MetricCard({
       <p className="mt-2 text-xs text-zinc-500">{detail}</p>
     </article>
   );
+}
+
+function exportVenueCSV(data: AnalyticsData): void {
+  const rows = data.venueLeaderboard.map((venue) => ({
+    Timestamp: data.generatedAt,
+    "Venue ID": venue.id,
+    "Venue Name": `"${venue.name.replace(/"/g, '""')}"`,
+    Category: `"${venue.category}"`,
+    "Visitor Count": venue.views,
+    Bookings: venue.bookings,
+    Rating: venue.rating.toFixed(1),
+    Score: venue.score,
+  }));
+
+  const headers = [
+    "Timestamp",
+    "Venue ID",
+    "Venue Name",
+    "Category",
+    "Visitor Count",
+    "Bookings",
+    "Rating",
+    "Score",
+  ];
+
+  const csvContent = [
+    headers.join(","),
+    ...rows.map((row) =>
+      headers
+        .map((header) => String(row[header as keyof typeof row]))
+        .join(","),
+    ),
+  ].join("\n");
+
+  const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = `venue-analytics-${data.range}-${new Date(data.generatedAt).toISOString().slice(0, 10)}.csv`;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
 }
 
 export default function AdminAnalyticsDashboard() {
@@ -207,6 +252,16 @@ export default function AdminAnalyticsDashboard() {
               <RefreshCw
                 className={`h-5 w-5 ${loading ? "animate-spin" : ""}`}
               />
+            </button>
+
+            <button
+              onClick={() => data && exportVenueCSV(data)}
+              disabled={!data || loading}
+              className="inline-flex items-center gap-2 rounded-2xl border border-violet-400/20 bg-violet-500/10 px-4 py-2.5 text-sm font-medium text-violet-200 transition hover:bg-violet-500/20 hover:text-white disabled:opacity-40 disabled:cursor-not-allowed"
+              aria-label="Export venue analytics to CSV"
+            >
+              <Download className="h-4 w-4" />
+              Export CSV
             </button>
           </div>
         </header>


### PR DESCRIPTION
Implementation of client-side export to CSV for the venue analytics report is complete.

Changes made to src/app/admin/analytics/AdminAnalyticsDashboard.tsx:

Added Download icon import from lucide-react (line with other icon imports).

Added exportVenueCSV function (lines before the component) that:

Maps venueLeaderboard data into CSV rows with columns: Timestamp, Venue ID, Venue Name, Category, Visitor Count, Bookings, Rating, Score
Properly quotes venue names and categories to handle commas/special characters


closes #1452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **Export CSV** button to the analytics dashboard.
  * Administrators can download venue leaderboard data, including venue names, rankings, and the report timestamp.
  * The export is unavailable while analytics are loading or before data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->