### PR TITLE
fix: handle network disconnection gracefully

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,9 +19,10 @@ const THEME_INIT_SCRIPT = `
 (function () {
   try {
     var stored = localStorage.getItem("worksphere-theme");
+    var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
     var theme = stored === "light" || stored === "dark" || stored === "cyberpunk"
       ? stored
-      : (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+      : (prefersDark ? "dark" : "light");
 
     var root = document.documentElement;
     root.classList.remove("dark", "cyberpunk");
@@ -33,6 +34,19 @@ const THEME_INIT_SCRIPT = `
     }
 
     root.style.colorScheme = theme === "light" ? "light" : "dark";
+
+    // ─── Inline background/foreground to prevent white flash ───
+    // Set colors directly on <html> before external CSS loads
+    if (theme === "dark") {
+      root.style.backgroundColor = "#0a0a0a";
+      root.style.color = "#ededed";
+    } else if (theme === "cyberpunk") {
+      root.style.backgroundColor = "#090014";
+      root.style.color = "#f4f4ff";
+    } else {
+      root.style.backgroundColor = "#ffffff";
+      root.style.color = "#171717";
+    }
 
     if (document.cookie.indexOf("worksphere-theme=") === -1) {
       document.cookie =
@@ -176,13 +190,13 @@ export default async function RootLayout({
       suppressHydrationWarning
     >
       <head>
-        <link rel="apple-touch-icon" href="/icons/icon-192x192.png" />
-        <meta name="apple-mobile-web-app-capable" content="yes" />
-        <meta name="mobile-web-app-capable" content="yes" />
         <script
           id="theme-init"
           dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }}
         />
+        <link rel="apple-touch-icon" href="/icons/icon-192x192.png" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="mobile-web-app-capable" content="yes" />
       </head>
 
       <body


### PR DESCRIPTION
Dark Mode Flash Fix — Complete
The white flash on initial dark mode hydration has been fixed with two changes to src/app/layout.tsx:

Change 1: Inline background/foreground colors in THEME_INIT_SCRIPT
The inline <script> in <head> now directly sets style.backgroundColor and style.color on <html> before the external CSS (globals.css) loads. This ensures the correct theme colors paint immediately on the very first render frame:

Dark mode: background: #0a0a0a, color: #ededed
Cyberpunk mode: background: #090014, color: #f4f4ff
Light mode: background: #ffffff, color: #171717
Change 2: Script moved to first child of <head>
The <script id="theme-init"> is now the very first element inside <head>, before any <link> or <meta> tags. This ensures it executes as early as possible in the parsing pipeline, blocking rendering until the correct theme colors are applied.


closes #1457

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the brief white flash during page load by applying the selected or system theme immediately.
  * Improved initial dark-mode rendering before styles finish loading.
  * Adjusted theme initialization order for more consistent appearance across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->