### PR TITLE
feat: audio level indicator meter

### DIFF
--- a/src/app/sessions/[slug]/session-detail-client.tsx
+++ b/src/app/sessions/[slug]/session-detail-client.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import ScreenSharePanel from "@/components/sessions/ScreenSharePanel";
 import Scratchpad from "@/components/sessions/Scratchpad";
+import { MeshCallGrid } from "@/components/audio/MeshCallGrid";
 
 type Props = {
   session: {
@@ -175,6 +176,13 @@ export default function SessionDetailClient({ session }: Props) {
               hostId={session.host.id}
               currentUserId={user?.id}
             />
+
+            <div className="mt-8">
+              <MeshCallGrid
+                sessionSlug={session.slug}
+                hostId={session.host.id}
+              />
+            </div>
 
             <div className="mt-8">
               <Scratchpad sessionId={session.slug} />

--- a/src/components/audio/AudioLevelIndicator.tsx
+++ b/src/components/audio/AudioLevelIndicator.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { type ReactNode } from "react";
+
+type AudioLevelIndicatorProps = {
+  /** Normalized audio level 0–1 */
+  level: number;
+  /** Diameter in px (default 80) */
+  size?: number;
+  /** Ring stroke width (default 3) */
+  strokeWidth?: number;
+  /** Show muted state */
+  muted?: boolean;
+  /** Content to render inside the ring */
+  children?: ReactNode;
+};
+
+/**
+ * AudioLevelIndicator renders a circular audio volume meter around a child element.
+ */
+export function AudioLevelIndicator({
+  level,
+  size = 80,
+  strokeWidth = 3,
+  muted = false,
+  children,
+}: AudioLevelIndicatorProps): ReactNode {
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const center = size / 2;
+
+  // Map 0–1 level to 0–circumference arc length (16% min visible ring)
+  const clamped = Math.min(1, Math.max(0, muted ? 0 : level));
+  const offset = circumference * (1 - Math.max(0.16, clamped));
+
+  // Animated gradient hue for active audio
+  const hue = muted ? 0 : 120 - clamped * 120; // green → red as volume increases
+  const ringColor = muted
+    ? "rgba(255,255,255,0.15)"
+    : `hsla(${hue}, 80%, 55%, 0.9)`;
+
+  return (
+    <div
+      className="relative inline-flex items-center justify-center"
+      style={{ width: size, height: size }}
+      role="meter"
+      aria-valuenow={Math.round(clamped * 100)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-label={
+        muted ? "Audio muted" : `Audio level ${Math.round(clamped * 100)}%`
+      }
+    >
+      {/* Background ring */}
+      <svg width={size} height={size} className="absolute" aria-hidden="true">
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke="rgba(255,255,255,0.06)"
+          strokeWidth={strokeWidth}
+        />
+        {/* Active ring – animated */}
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke={ringColor}
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          transform={`rotate(-90 ${center} ${center})`}
+          className="transition-[stroke-dashoffset,stroke] duration-75 ease-linear"
+          style={{
+            filter:
+              clamped > 0.7 ? `drop-shadow(0 0 4px ${ringColor})` : undefined,
+          }}
+        />
+      </svg>
+
+      {/* Glow ring for loud audio */}
+      {!muted && clamped > 0.6 && (
+        <svg
+          width={size + 8}
+          height={size + 8}
+          className="absolute animate-pulse"
+          aria-hidden="true"
+          style={{ opacity: (clamped - 0.6) * 2.5 }}
+        >
+          <circle
+            cx={center + 4}
+            cy={center + 4}
+            r={radius + 2}
+            fill="none"
+            stroke={ringColor}
+            strokeWidth={strokeWidth * 0.5}
+            strokeLinecap="round"
+            strokeDasharray={circumference}
+            strokeDashoffset={offset}
+            transform={`rotate(-90 ${center + 4} ${center + 4})`}
+            className="transition-all duration-75 ease-linear"
+          />
+        </svg>
+      )}
+
+      {/* Muted indicator */}
+      {muted && (
+        <span
+          className="absolute flex items-center justify-center rounded-full bg-white/10"
+          style={{
+            width: size * 0.35,
+            height: size * 0.35,
+          }}
+          aria-hidden="true"
+        >
+          <svg
+            width={size * 0.18}
+            height={size * 0.18}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="rgba(255,255,255,0.4)"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M11 5L6 9H2v6h4l5 4V5z" />
+            <line x1="23" y1="9" x2="17" y2="15" />
+            <line x1="17" y1="9" x2="23" y2="15" />
+          </svg>
+        </span>
+      )}
+
+      {/* Children (avatar / video thumbnail) */}
+      {children && (
+        <div className="relative z-10 flex items-center justify-center">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/audio/MeshCallGrid.tsx
+++ b/src/components/audio/MeshCallGrid.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { useWebRTCMesh } from "@/hooks/useWebRTCMesh";
+import { useUser } from "@clerk/nextjs";
+import { PeerAvatarTile } from "./PeerAvatarTile";
+import {
+  Mic,
+  MicOff,
+  Video,
+  VideoOff,
+  MonitorUp,
+  MonitorDown,
+  PhoneOff,
+  Signal,
+  Loader2,
+} from "lucide-react";
+
+type MeshCallGridProps = {
+  /** Session slug used as PartyKit room ID */
+  sessionSlug: string;
+  /** Session host userId */
+  hostId?: string;
+};
+
+/**
+ * MeshCallGrid renders a responsive grid of peer avatar tiles
+ * with audio level indicators for a WebRTC mesh call room.
+ */
+export function MeshCallGrid({ sessionSlug }: MeshCallGridProps) {
+  const { user } = useUser();
+  const [isJoined, setIsJoined] = useState(false);
+
+  const {
+    localStream,
+    remoteStreams,
+    audioLevels,
+    isAudioEnabled,
+    isVideoEnabled,
+    isScreenSharing,
+    error,
+    rtt,
+    networkQuality,
+    toggleAudio,
+    toggleVideo,
+    toggleScreenShare,
+  } = useWebRTCMesh({
+    roomId: `session-${sessionSlug}`,
+    userId: user?.id,
+  });
+
+  // Collect all peers: local + remotes
+  const peers = useMemo(() => {
+    const items: Array<{
+      peerId: string;
+      name: string;
+      stream: MediaStream | null;
+      isLocal: boolean;
+      audioLevel: number;
+      audioEnabled: boolean;
+      videoEnabled: boolean;
+      isSpeaking: boolean;
+    }> = [];
+
+    // Local peer
+    if (isJoined) {
+      items.push({
+        peerId: "local",
+        name:
+          `${user?.firstName ?? ""} ${user?.lastName ?? ""}`.trim() || "You",
+        stream: localStream,
+        isLocal: true,
+        audioLevel: audioLevels["local"] ?? 0,
+        audioEnabled: isAudioEnabled,
+        videoEnabled: isVideoEnabled,
+        isSpeaking: (audioLevels["local"] ?? 0) > 0.15 && isAudioEnabled,
+      });
+    }
+
+    // Remote peers
+    for (const [peerId, stream] of Object.entries(remoteStreams)) {
+      const level = audioLevels[peerId] ?? 0;
+      items.push({
+        peerId,
+        name: `Peer ${peerId.slice(0, 6)}`,
+        stream,
+        isLocal: false,
+        audioLevel: level,
+        audioEnabled: true,
+        videoEnabled: true,
+        isSpeaking: level > 0.15,
+      });
+    }
+
+    return items;
+  }, [
+    isJoined,
+    localStream,
+    remoteStreams,
+    audioLevels,
+    isAudioEnabled,
+    isVideoEnabled,
+    user,
+  ]);
+
+  const handleJoin = useCallback(() => {
+    setIsJoined(true);
+  }, []);
+
+  const handleLeave = useCallback(() => {
+    setIsJoined(false);
+    // Refreshing the page will clean up WebRTC state
+    window.location.reload();
+  }, []);
+
+  const networkColor =
+    networkQuality === "good"
+      ? "text-emerald-400"
+      : networkQuality === "fair"
+        ? "text-amber-400"
+        : networkQuality === "poor"
+          ? "text-rose-400"
+          : "text-zinc-500";
+
+  // Error banner
+  if (error) {
+    return (
+      <div className="rounded-2xl border border-rose-500/20 bg-rose-500/10 p-4 text-sm text-rose-300">
+        <p className="font-medium">Connection error</p>
+        <p className="mt-1 text-rose-400/80">{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-zinc-950 to-violet-950/30 p-5">
+      {/* Header */}
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <h2 className="text-sm font-semibold text-zinc-200">Video Room</h2>
+          {isJoined && (
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-2.5 py-0.5 text-[10px] font-medium text-emerald-300">
+              <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 animate-pulse" />
+              Live ({peers.length})
+            </span>
+          )}
+        </div>
+
+        {isJoined && (
+          <div className="flex items-center gap-2 text-[10px] text-zinc-500">
+            <Signal className={`h-3 w-3 ${networkColor}`} />
+            <span className="capitalize">{networkQuality}</span>
+            {rtt > 0 && <span>{rtt.toFixed(0)}ms</span>}
+          </div>
+        )}
+      </div>
+
+      {!isJoined ? (
+        /* Join prompt */
+        <div className="flex flex-col items-center gap-4 py-8">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-violet-500/10">
+            <Video className="h-7 w-7 text-violet-300" />
+          </div>
+          <div className="text-center">
+            <p className="text-sm font-medium text-zinc-200">
+              Join the video room
+            </p>
+            <p className="mt-1 text-xs text-zinc-500">
+              Connect with others in this session via peer-to-peer video call
+            </p>
+          </div>
+          <button
+            onClick={handleJoin}
+            className="inline-flex items-center gap-2 rounded-xl bg-violet-600 px-5 py-2.5 text-sm font-medium text-white transition-all hover:bg-violet-500 active:scale-95"
+          >
+            <Video className="h-4 w-4" />
+            Join Video Call
+          </button>
+        </div>
+      ) : (
+        <>
+          {/* Peer tiles grid */}
+          <div
+            className={`grid gap-4 ${
+              peers.length <= 1
+                ? "grid-cols-1"
+                : peers.length <= 2
+                  ? "grid-cols-2"
+                  : peers.length <= 4
+                    ? "grid-cols-2"
+                    : "grid-cols-2 sm:grid-cols-3"
+            }`}
+          >
+            {peers.map((peer) => (
+              <PeerAvatarTile
+                key={peer.peerId}
+                peerId={peer.peerId}
+                name={peer.name}
+                stream={peer.stream}
+                isLocal={peer.isLocal}
+                audioLevel={peer.audioLevel}
+                audioEnabled={peer.audioEnabled}
+                videoEnabled={peer.videoEnabled}
+                isSpeaking={peer.isSpeaking}
+              />
+            ))}
+          </div>
+
+          {/* Empty state */}
+          {peers.length === 0 && (
+            <div className="flex flex-col items-center gap-3 py-8 text-zinc-500">
+              <Loader2 className="h-6 w-6 animate-spin" />
+              <p className="text-xs">Waiting for peers to connect...</p>
+            </div>
+          )}
+
+          {/* Call controls */}
+          <div className="mt-4 flex flex-wrap items-center justify-center gap-2 rounded-xl bg-white/5 p-3">
+            {/* Audio toggle */}
+            <button
+              onClick={toggleAudio}
+              className={`flex items-center gap-2 rounded-lg px-3 py-2 text-xs font-medium transition-all ${
+                isAudioEnabled
+                  ? "bg-white/10 text-zinc-200 hover:bg-white/15"
+                  : "bg-rose-500/20 text-rose-300 hover:bg-rose-500/30"
+              }`}
+              title={isAudioEnabled ? "Mute microphone" : "Unmute microphone"}
+            >
+              {isAudioEnabled ? (
+                <Mic className="h-3.5 w-3.5" />
+              ) : (
+                <MicOff className="h-3.5 w-3.5" />
+              )}
+              <span className="hidden sm:inline">
+                {isAudioEnabled ? "Mute" : "Unmute"}
+              </span>
+            </button>
+
+            {/* Video toggle */}
+            <button
+              onClick={toggleVideo}
+              className={`flex items-center gap-2 rounded-lg px-3 py-2 text-xs font-medium transition-all ${
+                isVideoEnabled
+                  ? "bg-white/10 text-zinc-200 hover:bg-white/15"
+                  : "bg-amber-500/20 text-amber-300 hover:bg-amber-500/30"
+              }`}
+              title={isVideoEnabled ? "Turn off camera" : "Turn on camera"}
+            >
+              {isVideoEnabled ? (
+                <Video className="h-3.5 w-3.5" />
+              ) : (
+                <VideoOff className="h-3.5 w-3.5" />
+              )}
+              <span className="hidden sm:inline">
+                {isVideoEnabled ? "Video off" : "Video on"}
+              </span>
+            </button>
+
+            {/* Screen share toggle */}
+            <button
+              onClick={toggleScreenShare}
+              className={`flex items-center gap-2 rounded-lg px-3 py-2 text-xs font-medium transition-all ${
+                isScreenSharing
+                  ? "bg-cyan-500/20 text-cyan-300 hover:bg-cyan-500/30"
+                  : "bg-white/10 text-zinc-200 hover:bg-white/15"
+              }`}
+              title={
+                isScreenSharing ? "Stop sharing screen" : "Share your screen"
+              }
+            >
+              {isScreenSharing ? (
+                <MonitorDown className="h-3.5 w-3.5" />
+              ) : (
+                <MonitorUp className="h-3.5 w-3.5" />
+              )}
+              <span className="hidden sm:inline">
+                {isScreenSharing ? "Stop share" : "Share screen"}
+              </span>
+            </button>
+
+            <span className="mx-1 h-6 w-px bg-white/5" />
+
+            {/* Leave call */}
+            <button
+              onClick={handleLeave}
+              className="flex items-center gap-2 rounded-lg bg-rose-500/20 px-3 py-2 text-xs font-medium text-rose-300 transition-all hover:bg-rose-500/30"
+              title="Leave video call"
+            >
+              <PhoneOff className="h-3.5 w-3.5" />
+              <span className="hidden sm:inline">Leave</span>
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/audio/PeerAvatarTile.tsx
+++ b/src/components/audio/PeerAvatarTile.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useEffect, useRef, type ReactNode } from "react";
+import { AudioLevelIndicator } from "./AudioLevelIndicator";
+
+type PeerAvatarTileProps = {
+  /** Unique peer identifier */
+  peerId: string;
+  /** Display name */
+  name: string;
+  /** Avatar image URL or null */
+  avatarUrl?: string | null;
+  /** MediaStream (remote peer or local) */
+  stream?: MediaStream | null;
+  /** Whether this tile represents the local user */
+  isLocal?: boolean;
+  /** Current audio level 0–1 */
+  audioLevel?: number;
+  /** Whether audio track is enabled */
+  audioEnabled?: boolean;
+  /** Whether video track is enabled */
+  videoEnabled?: boolean;
+  /** Whether the user is speaking (for visual indicator) */
+  isSpeaking?: boolean;
+  /** Extra action buttons to render in the overlay */
+  actions?: ReactNode;
+};
+
+/**
+ * PeerAvatarTile renders a single peer in the mesh call grid.
+ * Shows user avatar / video thumbnail wrapped in an animated audio level ring.
+ */
+export function PeerAvatarTile({
+  name,
+  avatarUrl,
+  stream,
+  isLocal = false,
+  audioLevel = 0,
+  audioEnabled = true,
+  videoEnabled = true,
+  isSpeaking = false,
+  actions,
+}: PeerAvatarTileProps) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  // Attach media stream to video element
+  useEffect(() => {
+    const el = videoRef.current;
+    if (!el) return;
+    if (stream && stream.getVideoTracks().length > 0) {
+      el.srcObject = stream;
+    } else {
+      el.srcObject = null;
+    }
+  }, [stream]);
+
+  const initials = name
+    .split(" ")
+    .map((s) => s.charAt(0))
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+
+  const hasVideo = !!(
+    stream &&
+    stream.getVideoTracks().length > 0 &&
+    videoEnabled
+  );
+
+  return (
+    <div
+      className={`group relative flex flex-col items-center gap-2 rounded-2xl border bg-black/40 p-3 transition-all duration-200 ${
+        isSpeaking && audioEnabled
+          ? "border-emerald-400/40 shadow-lg shadow-emerald-500/10"
+          : "border-white/10 hover:border-white/20"
+      }`}
+    >
+      {/* Peer name badge */}
+      <span className="absolute top-2 left-3 z-20 rounded-full bg-black/60 px-2.5 py-0.5 text-[10px] font-medium text-zinc-300 backdrop-blur-sm">
+        {isLocal ? "You" : name}
+        {isLocal && (
+          <span className="ml-1 text-[9px] text-zinc-500">(local)</span>
+        )}
+      </span>
+
+      {/* Audio level ring with avatar / video inside */}
+      <AudioLevelIndicator
+        level={audioLevel}
+        size={88}
+        strokeWidth={3}
+        muted={!audioEnabled}
+      >
+        {hasVideo ? (
+          <video
+            ref={videoRef}
+            autoPlay
+            playsInline
+            muted={isLocal}
+            className="h-[76px] w-[76px] rounded-full object-cover"
+          />
+        ) : (
+          <div className="flex h-[76px] w-[76px] items-center justify-center rounded-full bg-gradient-to-br from-violet-600/30 to-fuchsia-600/20 text-lg font-bold tracking-wide text-violet-200">
+            {avatarUrl ? (
+              /* eslint-disable-next-line @next/next/no-img-element */
+              <img
+                src={avatarUrl}
+                alt={name}
+                className="h-full w-full rounded-full object-cover"
+              />
+            ) : (
+              initials
+            )}
+          </div>
+        )}
+      </AudioLevelIndicator>
+
+      {/* Status badges */}
+      <div className="flex items-center gap-2">
+        {!audioEnabled && (
+          <span className="inline-flex items-center gap-1 rounded-full bg-rose-500/15 px-2 py-0.5 text-[9px] font-medium text-rose-300">
+            <svg
+              width="10"
+              height="10"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M11 5L6 9H2v6h4l5 4V5z" />
+              <line x1="23" y1="9" x2="17" y2="15" />
+              <line x1="17" y1="9" x2="23" y2="15" />
+            </svg>
+            Muted
+          </span>
+        )}
+        {!videoEnabled && hasVideo && (
+          <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/15 px-2 py-0.5 text-[9px] font-medium text-amber-300">
+            <svg
+              width="10"
+              height="10"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M16 16v1a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h2m5.66 0H14a2 2 0 0 1 2 2v3.34" />
+              <line x1="23" y1="1" x2="1" y2="23" />
+            </svg>
+            Video off
+          </span>
+        )}
+        {isSpeaking && audioEnabled && (
+          <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-[9px] font-medium text-emerald-300 animate-pulse">
+            Speaking
+          </span>
+        )}
+      </div>
+
+      {/* Actions overlay */}
+      {actions && (
+        <div className="absolute bottom-2 right-2 z-20 flex gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+          {actions}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
New Files Created
1. src/components/audio/AudioLevelIndicator.tsx
Reusable circular SVG ring meter that renders a real-time audio volume bar around any child element. Features:

Animated SVG ring with stroke-dashoffset transitioning at 75ms intervals for smooth real-time updates
Color transitions: green → red as volume increases (hue 120→0)
Glow effect on outer ring when volume > 60% with animate-pulse
Muted state with a muted speaker icon overlay and dimmed ring
ARIA role="meter" with aria-valuenow for accessibility
2. src/components/audio/PeerAvatarTile.tsx
Single peer tile wrapping AudioLevelIndicator with:

Video stream rendering (autoplay, playsInline, muted for local)
Avatar fallback with gradient background and initials when no video
Speaking detection — green border glow when audioLevel > 0.15
Status badges: "Muted" (rose), "Video off" (amber), "Speaking" (emerald with pulse)
Hover actions overlay for extensibility
3. src/components/audio/MeshCallGrid.tsx
Full mesh call room grid container using useWebRTCMesh hook:

Join/Leave flow: "Join Video Call" button → requests camera/mic → renders peer grid
Responsive grid adapts from 1 to 3 columns based on participant count
Live indicator badge with participant count and animated dot
Network quality indicator with RTT display (good/fair/poor)
Call controls: Mute/Unmute, Video on/off, Screen share, Leave call with hover tooltips
Error state banner for connection failures


closes #1458

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added video calling to session detail pages.
  * Added join and leave controls for video rooms.
  * Added microphone, camera, and screen-sharing controls.
  * Added responsive participant tiles with video, avatars, speaking indicators, and connection status.
  * Added audio-level visualization with mute indicators and accessibility support.
  * Added network diagnostics and error messaging for call connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->