### PR TITLE
feat: show Ctrl+K shortcut badge in global search

### DIFF
--- a/src/__tests__/components/ChatInput.test.tsx
+++ b/src/__tests__/components/ChatInput.test.tsx
@@ -184,3 +184,58 @@ describe("ChatInput keyboard inset", () => {
     expect(wrap.style.paddingBottom).toContain("300px");
   });
 });
+
+describe("ChatInput Ctrl+K shortcut badge", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("shows Ctrl+K badge in the empty search bar on non-Apple platforms", () => {
+    Object.defineProperty(navigator, "platform", {
+      configurable: true,
+      value: "Win32",
+    });
+
+    render(
+      <ChatInput
+        input=""
+        isLoading={false}
+        onInputChange={jest.fn()}
+        onSubmit={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTitle("Focus search")).toHaveTextContent("Ctrl+K");
+  });
+
+  it("shows ⌘K badge on Apple platforms", () => {
+    Object.defineProperty(navigator, "platform", {
+      configurable: true,
+      value: "MacIntel",
+    });
+
+    render(
+      <ChatInput
+        input=""
+        isLoading={false}
+        onInputChange={jest.fn()}
+        onSubmit={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTitle("Focus search")).toHaveTextContent("⌘K");
+  });
+
+  it("hides the shortcut badge when the search input has text", () => {
+    render(
+      <ChatInput
+        input="quiet cafe"
+        isLoading={false}
+        onInputChange={jest.fn()}
+        onSubmit={jest.fn()}
+      />,
+    );
+
+    expect(screen.queryByTitle("Focus search")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/chat/ChatMessages.tsx
+++ b/src/components/chat/ChatMessages.tsx
@@ -1209,6 +1209,7 @@ export function ChatInput({
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
   const [isFocused, setIsFocused] = useState(false);
   const [keyboardInset, setKeyboardInset] = useState(0);
+  const [shortcutLabel, setShortcutLabel] = useState("Ctrl+K");
 
   useEffect(() => {
     const history = localStorage.getItem("ws-recent-searches");
@@ -1219,6 +1220,15 @@ export function ChatInput({
         console.error(e);
       }
     }
+  }, []);
+
+  useEffect(() => {
+    const isApple =
+      typeof navigator !== "undefined" &&
+      /Mac|iPhone|iPad|iPod/i.test(
+        navigator.platform || navigator.userAgent || "",
+      );
+    setShortcutLabel(isApple ? "⌘K" : "Ctrl+K");
   }, []);
 
   // Keep the composer above the iOS soft keyboard / browser chrome.
@@ -1445,18 +1455,29 @@ export function ChatInput({
         >
           <Mic className="w-5 h-5" />
         </button>
-        <input
-          type="text"
-          value={safeInput}
-          onChange={(e) => onInputChange(e.target.value ?? "")}
-          onFocus={() => setIsFocused(true)}
-          onBlur={() => setIsFocused(false)}
-          placeholder={
-            isListening ? "Listening…" : "Where's the focus mode hotspot?"
-          }
-          disabled={isLoading}
-          className="flex-1 px-4 py-3 bg-transparent text-zinc-900 dark:text-zinc-50 placeholder:text-zinc-500 focus:placeholder-transparent focus:outline-none disabled:opacity-50 text-sm font-bold"
-        />
+        <div className="relative flex min-w-0 flex-1 items-center">
+          <input
+            type="text"
+            value={safeInput}
+            onChange={(e) => onInputChange(e.target.value ?? "")}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
+            placeholder={
+              isListening ? "Listening…" : "Where's the focus mode hotspot?"
+            }
+            disabled={isLoading}
+            className="w-full bg-transparent px-4 py-3 pr-16 text-sm font-bold text-zinc-900 placeholder:text-zinc-500 focus:placeholder-transparent focus:outline-none disabled:opacity-50 dark:text-zinc-50"
+          />
+          {!safeInput.trim() && (
+            <kbd
+              className="pointer-events-none absolute right-2 hidden select-none rounded-md border border-zinc-200 bg-white px-1.5 py-0.5 font-mono text-[10px] font-semibold tracking-wide text-zinc-400 shadow-sm sm:inline-block dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-500"
+              aria-hidden="true"
+              title="Focus search"
+            >
+              {shortcutLabel}
+            </kbd>
+          )}
+        </div>
 
         {/* ── Microphone button ──────────────────────────────────────────── */}
         <button


### PR DESCRIPTION
## Summary
- Adds a subtle `⌘K` / `Ctrl+K` badge inside the empty global search input to surface the existing focus shortcut.
Closes #1449
## Test plan
- [ ] `npx jest src/__tests__/components/ChatInput.test.tsx --no-coverage --forceExit`
- [ ] Open the chat search bar empty and confirm the badge shows (`⌘K` on Mac, `Ctrl+K` elsewhere)
- [ ] Type in the input and confirm the badge hides
- [ ] Press Ctrl/⌘+K and confirm the search input still focuses


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a keyboard shortcut hint to the empty search field: `Ctrl+K` on most platforms and `⌘K` on Apple devices.
  * The hint automatically disappears once text is entered.

* **Tests**
  * Added coverage for platform-specific shortcut labels and hint visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->