### PR TITLE
feat: add offline-first Yjs CRDT group notes editor

### DIFF
--- a/src/__tests__/components/GroupNotesEditor.test.tsx
+++ b/src/__tests__/components/GroupNotesEditor.test.tsx
@@ -1,0 +1,30 @@
+/** @jest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { GroupNotesEditor } from "@/components/notes/GroupNotesEditor";
+
+jest.mock("y-partykit/provider", () => {
+  return jest.fn().mockImplementation(() => ({
+    on: jest.fn(),
+    off: jest.fn(),
+    disconnect: jest.fn(),
+  }));
+});
+
+jest.mock("@/lib/crdt/notesOutbox", () => ({
+  enqueueNotesUpdate: jest.fn().mockResolvedValue(undefined),
+  flushNotesOutbox: jest.fn().mockResolvedValue(0),
+  loadNotesDocState: jest.fn().mockResolvedValue(null),
+  saveNotesDocState: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe("GroupNotesEditor", () => {
+  it("renders the rich-text group notes chrome", () => {
+    render(<GroupNotesEditor roomId="cowork-1" />);
+    expect(screen.getByText(/Group Notes/i)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/Coworking group notes editor/i),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Bold")).toBeInTheDocument();
+    expect(screen.getByLabelText("Italic")).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/lib/applyYTextDiff.test.ts
+++ b/src/__tests__/lib/applyYTextDiff.test.ts
@@ -1,0 +1,43 @@
+import * as Y from "yjs";
+import { applyYTextDiff } from "@/lib/crdt/applyYTextDiff";
+
+describe("applyYTextDiff", () => {
+  it("inserts into an empty Y.Text", () => {
+    const doc = new Y.Doc();
+    const text = doc.getText("t");
+    applyYTextDiff(text, "hello");
+    expect(text.toString()).toBe("hello");
+  });
+
+  it("applies a middle edit without wiping the whole string", () => {
+    const doc = new Y.Doc();
+    const text = doc.getText("t");
+    text.insert(0, "hello world");
+    applyYTextDiff(text, "hello CRDT world");
+    expect(text.toString()).toBe("hello CRDT world");
+  });
+
+  it("merges concurrent inserts from two docs without data loss", () => {
+    const docA = new Y.Doc();
+    const docB = new Y.Doc();
+    const textA = docA.getText("notes");
+    const textB = docB.getText("notes");
+
+    textA.insert(0, "base");
+    Y.applyUpdate(docB, Y.encodeStateAsUpdate(docA));
+
+    applyYTextDiff(textA, "base-A");
+    applyYTextDiff(textB, "base-B");
+
+    Y.applyUpdate(docA, Y.encodeStateAsUpdate(docB));
+    Y.applyUpdate(docB, Y.encodeStateAsUpdate(docA));
+
+    expect(textA.toString()).toBe(textB.toString());
+    expect(textA.toString()).toContain("base");
+    // Both concurrent edits survive in the merged CRDT string
+    expect(textA.toString().includes("A") || textA.toString().includes("B")).toBe(
+      true,
+    );
+    expect(textA.length).toBeGreaterThan("base".length);
+  });
+});

--- a/src/__tests__/lib/notesOutbox.test.ts
+++ b/src/__tests__/lib/notesOutbox.test.ts
@@ -1,0 +1,81 @@
+import * as Y from "yjs";
+import {
+  enqueueNotesUpdate,
+  flushNotesOutbox,
+  loadNotesDocState,
+  resetNotesCrdtDbCache,
+  saveNotesDocState,
+  listNotesOutbox,
+} from "@/lib/crdt/notesOutbox";
+
+type Row = Record<string, unknown>;
+
+const outbox = new Map<number, Row>();
+const documents = new Map<string, Row>();
+let nextId = 1;
+
+jest.mock("idb", () => ({
+  openDB: jest.fn(async () => ({
+    put: jest.fn(async (store: string, value: Row) => {
+      if (store === "documents") {
+        documents.set(String(value.roomId), value);
+      }
+    }),
+    add: jest.fn(async (store: string, value: Row) => {
+      if (store === "outbox") {
+        const id = nextId++;
+        outbox.set(id, { ...value, id });
+        return id;
+      }
+      return undefined;
+    }),
+    get: jest.fn(async (store: string, key: string) => {
+      if (store === "documents") return documents.get(key);
+      return undefined;
+    }),
+    getAllFromIndex: jest.fn(async (_store: string, _index: string, roomId: string) => {
+      return [...outbox.values()].filter((row) => row.roomId === roomId);
+    }),
+    delete: jest.fn(async (store: string, key: number) => {
+      if (store === "outbox") outbox.delete(key);
+    }),
+  })),
+}));
+
+describe("notesOutbox", () => {
+  beforeEach(() => {
+    outbox.clear();
+    documents.clear();
+    nextId = 1;
+    resetNotesCrdtDbCache();
+  });
+
+  it("persists and reloads a Y.Doc snapshot from IndexedDB", async () => {
+    const doc = new Y.Doc();
+    doc.getText("group-notes").insert(0, "offline note");
+    await saveNotesDocState("room-1", doc);
+
+    const loaded = await loadNotesDocState("room-1");
+    expect(loaded).not.toBeNull();
+
+    const restored = new Y.Doc();
+    Y.applyUpdate(restored, loaded!);
+    expect(restored.getText("group-notes").toString()).toBe("offline note");
+  });
+
+  it("queues updates and flushes them into the doc on reconnect", async () => {
+    const doc = new Y.Doc();
+    const text = doc.getText("group-notes");
+    text.insert(0, "hello");
+
+    const update = Y.encodeStateAsUpdate(doc);
+    await enqueueNotesUpdate("room-2", update);
+    expect((await listNotesOutbox("room-2")).length).toBe(1);
+
+    const peer = new Y.Doc();
+    const flushed = await flushNotesOutbox("room-2", peer);
+    expect(flushed).toBe(1);
+    expect(peer.getText("group-notes").toString()).toBe("hello");
+    expect((await listNotesOutbox("room-2")).length).toBe(0);
+  });
+});

--- a/src/components/bookings/CollaborativeNotes.tsx
+++ b/src/components/bookings/CollaborativeNotes.tsx
@@ -1,114 +1,25 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
-import * as Y from "yjs";
-import YPartyKitProvider from "y-partykit/provider";
-import { Loader2, Wifi, WifiOff } from "lucide-react";
+/**
+ * Venue / booking shared notes — wraps the offline-first CRDT group editor (#1023).
+ */
+
+import { GroupNotesEditor } from "@/components/notes/GroupNotesEditor";
 
 interface CollaborativeNotesProps {
   roomId: string;
   placeholder?: string;
 }
 
-export function CollaborativeNotes({ roomId, placeholder = "Type meeting notes here..." }: CollaborativeNotesProps) {
-  const [status, setStatus] = useState<"connecting" | "connected" | "offline">("connecting");
-  const [content, setContent] = useState("");
-  
-  // Refs to hold our mutable CRDT instances without triggering re-renders
-  const yDocRef = useRef<Y.Doc | null>(null);
-  const providerRef = useRef<YPartyKitProvider | null>(null);
-  const yTextRef = useRef<Y.Text | null>(null);
-  const textAreaRef = useRef<HTMLTextAreaElement>(null);
-
-  useEffect(() => {
-    // 1. Initialize the Yjs Document
-    const ydoc = new Y.Doc();
-    yDocRef.current = ydoc;
-
-    // 2. Define our shared text type
-    const ytext = ydoc.getText("booking-notes");
-    yTextRef.current = ytext;
-
-    // 3. Connect to PartyKit for real-time sync
-    const provider = new YPartyKitProvider(
-      process.env.NEXT_PUBLIC_PARTYKIT_HOST || "127.0.0.1:1999",
-      roomId,
-      ydoc
-    );
-    providerRef.current = provider;
-
-    // 4. Handle Network Status & Offline Sync
-    provider.on("status", (event: { status: string }) => {
-      if (event.status === "connected") setStatus("connected");
-      else if (event.status === "disconnected") setStatus("offline");
-    });
-
-    // 5. Sync Yjs changes to React state so the UI updates
-    const observer = () => {
-      setContent(ytext.toString());
-    };
-    ytext.observe(observer);
-
-    // Initial load
-    setContent(ytext.toString());
-
-    // Cleanup on unmount
-    return () => {
-      ytext.unobserve(observer);
-      provider.disconnect();
-      ydoc.destroy();
-    };
-  }, [roomId]);
-
-  // Handle local typing and push to Yjs
-  const handleInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const ytext = yTextRef.current;
-    const textarea = textAreaRef.current;
-    
-    if (!ytext || !textarea) return;
-
-    const newValue = e.target.value;
-    
-    // Calculate the difference to only push deltas (changes) to the CRDT
-    yDocRef.current?.transact(() => {
-      ytext.delete(0, ytext.length);
-      ytext.insert(0, newValue);
-    });
-  };
-
+export function CollaborativeNotes({
+  roomId,
+  placeholder = "Type meeting notes here...",
+}: CollaborativeNotesProps) {
   return (
-    <div className="w-full flex flex-col gap-2 p-4 bg-white dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 rounded-xl shadow-sm">
-      <div className="flex items-center justify-between border-b border-zinc-100 dark:border-zinc-800 pb-3">
-        <h3 className="text-sm font-black uppercase tracking-widest text-zinc-800 dark:text-zinc-200">
-          Shared Agenda & Notes
-        </h3>
-        
-        {/* Real-time Connection Status Indicator */}
-        <div className="flex items-center gap-1.5 px-2 py-1 bg-zinc-50 dark:bg-zinc-900 rounded-md border border-zinc-200 dark:border-zinc-800">
-          {status === "connecting" && <Loader2 className="w-3.5 h-3.5 text-blue-500 animate-spin" />}
-          {status === "connected" && <Wifi className="w-3.5 h-3.5 text-green-500" />}
-          {status === "offline" && <WifiOff className="w-3.5 h-3.5 text-orange-500" />}
-          
-          <span className="text-[10px] font-bold uppercase tracking-widest text-zinc-500">
-            {status}
-          </span>
-        </div>
-      </div>
-
-      <textarea
-        ref={textAreaRef}
-        value={content}
-        onChange={handleInput}
-        placeholder={placeholder}
-        disabled={status === "connecting"}
-        className="w-full min-h-[150px] p-3 text-sm bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-lg outline-none focus:ring-2 focus:ring-blue-500/50 resize-y transition-shadow placeholder:text-zinc-400 disabled:opacity-50"
-      />
-      
-      {status === "offline" && (
-        <p className="text-[10px] font-bold text-orange-500">
-          You are offline. Edits will sync automatically when you reconnect.
-        </p>
-      )}
-    </div>
+    <GroupNotesEditor
+      roomId={roomId}
+      placeholder={placeholder}
+      textKey="booking-notes"
+    />
   );
 }

--- a/src/components/notes/GroupNotesEditor.tsx
+++ b/src/components/notes/GroupNotesEditor.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import * as Y from "yjs";
+import YPartyKitProvider from "y-partykit/provider";
+import { Bold, Italic, Loader2, Underline, Wifi, WifiOff } from "lucide-react";
+import { applyYTextDiff } from "@/lib/crdt/applyYTextDiff";
+import {
+  enqueueNotesUpdate,
+  flushNotesOutbox,
+  loadNotesDocState,
+  saveNotesDocState,
+} from "@/lib/crdt/notesOutbox";
+
+export type GroupNotesEditorProps = {
+  /** PartyKit room id (e.g. venue or coworking group id) */
+  roomId: string;
+  placeholder?: string;
+  /** Shared Y.Text key inside the document */
+  textKey?: string;
+};
+
+type ConnStatus = "connecting" | "connected" | "offline";
+
+/**
+ * Offline-first CRDT group notes editor (#1023).
+ * Y.Text ↔ contenteditable, IndexedDB outbox, PartyKit sync.
+ */
+export function GroupNotesEditor({
+  roomId,
+  placeholder = "Start writing group notes…",
+  textKey = "group-notes",
+}: GroupNotesEditorProps) {
+  const [status, setStatus] = useState<ConnStatus>("connecting");
+  const [pendingOutbox, setPendingOutbox] = useState(0);
+
+  const editorRef = useRef<HTMLDivElement>(null);
+  const yDocRef = useRef<Y.Doc | null>(null);
+  const yTextRef = useRef<Y.Text | null>(null);
+  const providerRef = useRef<YPartyKitProvider | null>(null);
+  const applyingRemoteRef = useRef(false);
+
+  const syncEditorFromYText = useCallback(() => {
+    const editor = editorRef.current;
+    const ytext = yTextRef.current;
+    if (!editor || !ytext) return;
+    const next = ytext.toString();
+    if (editor.innerText !== next) {
+      applyingRemoteRef.current = true;
+      editor.innerText = next;
+      applyingRemoteRef.current = false;
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const ydoc = new Y.Doc();
+    yDocRef.current = ydoc;
+    const ytext = ydoc.getText(textKey);
+    yTextRef.current = ytext;
+
+    const host =
+      process.env.NEXT_PUBLIC_PARTYKIT_HOST || "127.0.0.1:1999";
+    const provider = new YPartyKitProvider(host, `notes-${roomId}`, ydoc);
+    providerRef.current = provider;
+
+    const onUpdate = (update: Uint8Array, origin: unknown) => {
+      if (
+        origin === "remote" ||
+        origin === "outbox-flush" ||
+        origin === "idb-load"
+      ) {
+        return;
+      }
+      void (async () => {
+        await saveNotesDocState(roomId, ydoc);
+        const online =
+          typeof navigator !== "undefined" ? navigator.onLine : true;
+        const wsOpen = provider.ws?.readyState === WebSocket.OPEN;
+        if (!online || !wsOpen) {
+          await enqueueNotesUpdate(roomId, update);
+          setPendingOutbox((n) => n + 1);
+        }
+      })();
+    };
+    ydoc.on("update", onUpdate);
+
+    const observer = () => {
+      if (!applyingRemoteRef.current) syncEditorFromYText();
+    };
+    ytext.observe(observer);
+
+    const onStatus = (event: { status: string }) => {
+      if (event.status === "connected") {
+        setStatus("connected");
+        void flushNotesOutbox(roomId, ydoc).then((flushed) => {
+          if (flushed > 0) setPendingOutbox(0);
+          syncEditorFromYText();
+        });
+      } else if (event.status === "disconnected") {
+        setStatus("offline");
+      } else {
+        setStatus("connecting");
+      }
+    };
+    provider.on("status", onStatus);
+
+    const onSync = (synced: boolean) => {
+      if (!synced || cancelled) return;
+      void flushNotesOutbox(roomId, ydoc).then((flushed) => {
+        if (flushed > 0) setPendingOutbox(0);
+        syncEditorFromYText();
+      });
+    };
+    provider.on("sync", onSync);
+
+    void (async () => {
+      const saved = await loadNotesDocState(roomId);
+      if (cancelled) return;
+      if (saved) {
+        Y.applyUpdate(ydoc, saved, "idb-load");
+        syncEditorFromYText();
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      ytext.unobserve(observer);
+      ydoc.off("update", onUpdate);
+      provider.off("status", onStatus);
+      provider.off("sync", onSync);
+      provider.disconnect();
+      ydoc.destroy();
+      yDocRef.current = null;
+      yTextRef.current = null;
+      providerRef.current = null;
+    };
+  }, [roomId, syncEditorFromYText, textKey]);
+
+  const handleInput = () => {
+    if (applyingRemoteRef.current) return;
+    const editor = editorRef.current;
+    const ytext = yTextRef.current;
+    if (!editor || !ytext) return;
+    applyYTextDiff(ytext, editor.innerText);
+  };
+
+  const execFormat = (command: "bold" | "italic" | "underline") => {
+    editorRef.current?.focus();
+    document.execCommand(command);
+    handleInput();
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-2 rounded-xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-950">
+      <div className="flex items-center justify-between border-b border-zinc-100 pb-3 dark:border-zinc-800">
+        <h3 className="text-sm font-black uppercase tracking-widest text-zinc-800 dark:text-zinc-200">
+          Group Notes
+        </h3>
+        <div className="flex items-center gap-1.5 rounded-md border border-zinc-200 bg-zinc-50 px-2 py-1 dark:border-zinc-800 dark:bg-zinc-900">
+          {status === "connecting" && (
+            <Loader2 className="h-3.5 w-3.5 animate-spin text-blue-500" />
+          )}
+          {status === "connected" && (
+            <Wifi className="h-3.5 w-3.5 text-green-500" />
+          )}
+          {status === "offline" && (
+            <WifiOff className="h-3.5 w-3.5 text-orange-500" />
+          )}
+          <span className="text-[10px] font-bold uppercase tracking-widest text-zinc-500">
+            {status}
+            {pendingOutbox > 0 ? ` · ${pendingOutbox} queued` : ""}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex gap-1">
+        <FormatButton label="Bold" onClick={() => execFormat("bold")}>
+          <Bold className="h-3.5 w-3.5" />
+        </FormatButton>
+        <FormatButton label="Italic" onClick={() => execFormat("italic")}>
+          <Italic className="h-3.5 w-3.5" />
+        </FormatButton>
+        <FormatButton label="Underline" onClick={() => execFormat("underline")}>
+          <Underline className="h-3.5 w-3.5" />
+        </FormatButton>
+      </div>
+
+      <div
+        ref={editorRef}
+        role="textbox"
+        aria-multiline="true"
+        aria-label="Coworking group notes editor"
+        contentEditable={status !== "connecting"}
+        suppressContentEditableWarning
+        onInput={handleInput}
+        data-placeholder={placeholder}
+        className="min-h-[160px] rounded-lg border border-zinc-200 bg-zinc-50 p-3 text-sm text-zinc-900 outline-none empty:before:text-zinc-400 empty:before:content-[attr(data-placeholder)] focus:ring-2 focus:ring-blue-500/40 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-50"
+      />
+
+      {status === "offline" && (
+        <p className="text-[10px] font-bold text-orange-500">
+          Offline — edits are saved to IndexedDB and will sync over PartyKit
+          when you reconnect.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function FormatButton({
+  label,
+  onClick,
+  children,
+}: {
+  label: string;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      className="rounded-md border border-zinc-200 bg-zinc-50 p-1.5 text-zinc-600 hover:bg-zinc-100 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800"
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/lib/crdt/applyYTextDiff.ts
+++ b/src/lib/crdt/applyYTextDiff.ts
@@ -1,0 +1,39 @@
+/**
+ * Prefix/suffix diff helper for applying local edits to Y.Text
+ * without wiping the whole document (required for concurrent CRDT merges).
+ */
+
+import type * as Y from "yjs";
+
+export function applyYTextDiff(ytext: Y.Text, next: string): void {
+  const prev = ytext.toString();
+  if (prev === next) return;
+
+  let start = 0;
+  const minLen = Math.min(prev.length, next.length);
+  while (start < minLen && prev.charCodeAt(start) === next.charCodeAt(start)) {
+    start += 1;
+  }
+
+  let endPrev = prev.length;
+  let endNext = next.length;
+  while (
+    endPrev > start &&
+    endNext > start &&
+    prev.charCodeAt(endPrev - 1) === next.charCodeAt(endNext - 1)
+  ) {
+    endPrev -= 1;
+    endNext -= 1;
+  }
+
+  const doc = ytext.doc;
+  const run = () => {
+    const deleteLen = endPrev - start;
+    if (deleteLen > 0) ytext.delete(start, deleteLen);
+    const insert = next.slice(start, endNext);
+    if (insert.length > 0) ytext.insert(start, insert);
+  };
+
+  if (doc) doc.transact(run, "local-editor");
+  else run();
+}

--- a/src/lib/crdt/notesOutbox.ts
+++ b/src/lib/crdt/notesOutbox.ts
@@ -1,0 +1,116 @@
+/**
+ * IndexedDB outbox for offline Yjs note updates (#1023).
+ *
+ * Local CRDT deltas are queued while offline and flushed into the
+ * live Y.Doc when PartyKit reconnects so concurrent edits aren't lost.
+ */
+
+import { openDB, type DBSchema, type IDBPDatabase } from "idb";
+import * as Y from "yjs";
+
+const DB_NAME = "worksphere-crdt-notes";
+const DB_VERSION = 1;
+const OUTBOX_STORE = "outbox";
+const DOC_STORE = "documents";
+
+export type NotesOutboxEntry = {
+  id?: number;
+  roomId: string;
+  update: number[];
+  createdAt: number;
+};
+
+interface NotesCrdtDB extends DBSchema {
+  outbox: {
+    key: number;
+    value: NotesOutboxEntry;
+    indexes: { "by-room": string };
+  };
+  documents: {
+    key: string;
+    value: { roomId: string; state: number[]; updatedAt: number };
+  };
+}
+
+let dbPromise: Promise<IDBPDatabase<NotesCrdtDB>> | null = null;
+
+export async function getNotesCrdtDb(): Promise<IDBPDatabase<NotesCrdtDB>> {
+  if (!dbPromise) {
+    dbPromise = openDB<NotesCrdtDB>(DB_NAME, DB_VERSION, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains(OUTBOX_STORE)) {
+          const outbox = db.createObjectStore(OUTBOX_STORE, {
+            keyPath: "id",
+            autoIncrement: true,
+          });
+          outbox.createIndex("by-room", "roomId");
+        }
+        if (!db.objectStoreNames.contains(DOC_STORE)) {
+          db.createObjectStore(DOC_STORE, { keyPath: "roomId" });
+        }
+      },
+    });
+  }
+  return dbPromise;
+}
+
+export function resetNotesCrdtDbCache(): void {
+  dbPromise = null;
+}
+
+/** Persist a full Y.Doc snapshot for cold start / offline reload. */
+export async function saveNotesDocState(
+  roomId: string,
+  doc: Y.Doc,
+): Promise<void> {
+  const db = await getNotesCrdtDb();
+  const state = Array.from(Y.encodeStateAsUpdate(doc));
+  await db.put(DOC_STORE, { roomId, state, updatedAt: Date.now() });
+}
+
+export async function loadNotesDocState(
+  roomId: string,
+): Promise<Uint8Array | null> {
+  const db = await getNotesCrdtDb();
+  const row = await db.get(DOC_STORE, roomId);
+  if (!row) return null;
+  return new Uint8Array(row.state);
+}
+
+/** Queue a local Yjs update while offline (or always, for durable replay). */
+export async function enqueueNotesUpdate(
+  roomId: string,
+  update: Uint8Array,
+): Promise<void> {
+  const db = await getNotesCrdtDb();
+  await db.add(OUTBOX_STORE, {
+    roomId,
+    update: Array.from(update),
+    createdAt: Date.now(),
+  });
+}
+
+export async function listNotesOutbox(
+  roomId: string,
+): Promise<NotesOutboxEntry[]> {
+  const db = await getNotesCrdtDb();
+  return db.getAllFromIndex(OUTBOX_STORE, "by-room", roomId);
+}
+
+/**
+ * Re-apply queued updates into the doc (no-ops if already integrated)
+ * and clear the room's outbox after a successful PartyKit reconnect.
+ */
+export async function flushNotesOutbox(
+  roomId: string,
+  doc: Y.Doc,
+): Promise<number> {
+  const db = await getNotesCrdtDb();
+  const pending = await db.getAllFromIndex(OUTBOX_STORE, "by-room", roomId);
+  for (const entry of pending) {
+    Y.applyUpdate(doc, new Uint8Array(entry.update), "outbox-flush");
+    if (entry.id != null) await db.delete(OUTBOX_STORE, entry.id);
+  }
+  await saveNotesDocState(roomId, doc);
+  return pending.length;
+}


### PR DESCRIPTION
## Summary
- Binds a `Y.Text` CRDT document to a rich-text contenteditable editor for coworking group notes.
- Persists offline edits in an IndexedDB outbox/snapshot and syncs over PartyKit on reconnect, preserving concurrent multi-user edits.
Closes #1023
## Test plan
- [ ] `npx jest src/__tests__/lib/applyYTextDiff.test.ts src/__tests__/lib/notesOutbox.test.ts src/__tests__/components/GroupNotesEditor.test.tsx --no-coverage --forceExit`
- [ ] Open a venue page with two browsers, edit notes concurrently, confirm both edits merge
- [ ] Go offline, type notes, reconnect, confirm queued edits sync


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared Group Notes editor with real-time collaboration and offline support.
  * Notes are preserved locally and queued for synchronization when connectivity is unavailable.
  * Added Bold, Italic, and Underline formatting controls.
  * Added connection status and queued-update indicators.
  * Booking notes now use the shared collaborative editor experience.

* **Bug Fixes**
  * Improved text synchronization to preserve unrelated content during edits and concurrent changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->