### PR TITLE
[Feature]: add clear button to search input

### DIFF
--- a/src/components/chat/ChatMessages.tsx
+++ b/src/components/chat/ChatMessages.tsx
@@ -27,6 +27,7 @@ import {
   Check,
   Clock,
   Trash2,
+  X,
 } from "lucide-react";
 import { RefObject, useState, useEffect, useRef, useCallback } from "react";
 import { motion, AnimatePresence, LayoutGroup } from "framer-motion";
@@ -1210,6 +1211,12 @@ export function ChatInput({
   const [isFocused, setIsFocused] = useState(false);
   const [keyboardInset, setKeyboardInset] = useState(0);
   const [shortcutLabel, setShortcutLabel] = useState("Ctrl+K");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleClear = () => {
+    onInputChange("");
+    inputRef.current?.focus();
+  };
 
   useEffect(() => {
     const history = localStorage.getItem("ws-recent-searches");
@@ -1457,6 +1464,7 @@ export function ChatInput({
         </button>
         <div className="relative flex min-w-0 flex-1 items-center">
           <input
+            ref={inputRef}
             type="text"
             value={safeInput}
             onChange={(e) => onInputChange(e.target.value ?? "")}
@@ -1468,6 +1476,16 @@ export function ChatInput({
             disabled={isLoading}
             className="w-full bg-transparent px-4 py-3 pr-16 text-sm font-bold text-zinc-900 placeholder:text-zinc-500 focus:placeholder-transparent focus:outline-none disabled:opacity-50 dark:text-zinc-50"
           />
+          {safeInput.length > 0 && (
+            <button
+              type="button"
+              onClick={handleClear}
+              className="absolute right-2 p-1.5 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 rounded-full hover:bg-zinc-200 dark:hover:bg-zinc-700 transition-colors"
+              aria-label="Clear search"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          )}
           {!safeInput.trim() && (
             <kbd
               className="pointer-events-none absolute right-2 hidden select-none rounded-md border border-zinc-200 bg-white px-1.5 py-0.5 font-mono text-[10px] font-semibold tracking-wide text-zinc-400 shadow-sm sm:inline-block dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-500"


### PR DESCRIPTION
- closes #1189

### Description:

### What does this PR do?
Adds an "X" clear button inside the main chat search input, allowing users to instantly reset their search terms.

### Key Changes:
- **Conditional Rendering:** The clear button dynamically appears only when text is present in the search field (hiding the keyboard shortcut `Ctrl+K` / `⌘K` hint).
- **State Reset:** Clicking the button resets the search state to an empty string.
- **Focus Management:** Attaches a React `ref` to the `<input>` element so that after the text is cleared, the input is immediately refocused for a seamless user experience.

### Files Modified:
- `src/components/chat/ChatMessages.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clear button to the chat composer when text is entered.
  * Clearing the input keeps the composer focused and does not submit the message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->