### PR TITLE
docs: add comprehensive JSDoc for ReactiveUserButton

### DIFF
--- a/src/components/ReactiveUserButton.tsx
+++ b/src/components/ReactiveUserButton.tsx
@@ -11,6 +11,22 @@ import { ReactiveUserButton as CustomReactiveUserButton } from "./auth/ReactiveU
 
 type ClerkUserButtonProps = ComponentProps<typeof UserButton>;
 
+/**
+ * Props for the {@link ReactiveUserButton} component.
+ *
+ * Extends Clerk's {@link UserButton} props while adding optional
+ * properties for rendering a custom reactive avatar.
+ *
+ * @property userId - When provided, renders the custom reactive user button
+ * instead of Clerk's default {@link UserButton}.
+ * @property initialAvatarUrl - Initial avatar image URL used before any
+ * avatar update events are received.
+ * @property userName - Display name used for avatar fallback text and
+ * accessibility labels.
+ * @property size - Optional avatar size in pixels.
+ * @property className - Additional CSS classes applied to the custom button.
+ * @property onClick - Optional click handler for the custom button.
+ */
 export type ReactiveUserButtonProps = ClerkUserButtonProps & {
   userId?: string;
   initialAvatarUrl?: string | null;
@@ -20,8 +36,35 @@ export type ReactiveUserButtonProps = ClerkUserButtonProps & {
   onClick?: () => void;
 };
 
+/**
+ * Renders a user profile button that automatically refreshes its avatar
+ * whenever an avatar update event is received.
+ *
+ * The component behaves in two modes:
+ *
+ * - If `userId` is provided, it renders the custom
+ *   `ReactiveUserButton` implementation that supports reactive avatar
+ *   updates without requiring a page reload.
+ * - Otherwise, it falls back to Clerk's `UserButton`, forwarding all
+ *   inherited props.
+ *
+ * An internal `avatarRevision` counter is incremented whenever an
+ * `AVATAR_UPDATED_EVENT` is dispatched. This revision is included in the
+ * rendered `UserButton` key, forcing React to remount the component and
+ * bypass any cached avatar image.
+ *
+ * While Clerk is resolving the current authentication state, the component
+ * uses a temporary anonymous key until the authenticated user's information
+ * becomes available.
+ *
+ * @param props Props inherited from Clerk's `UserButton` along with
+ * reactive avatar options.
+ * @returns A reactive custom user button or Clerk's `UserButton`.
+ */
 export function ReactiveUserButton(props: ReactiveUserButtonProps) {
   const { user } = useUser();
+  // Acts as a cache-busting revision so React remounts the UserButton
+  // whenever an avatar update event is received.
   const [avatarRevision, setAvatarRevision] = useState(0);
 
   useEffect(() => {


### PR DESCRIPTION
## Description

This PR adds comprehensive JSDoc documentation for the `ReactiveUserButton` component.

Fixes  #1439

### Changes
- Documented `ReactiveUserButtonProps` and its inheritance from Clerk's `UserButton` props.
- Explained the purpose of the `avatarRevision` cache-busting mechanism.
- Documented component behavior while Clerk authentication state is pending.
- Improved IDE hover tooltips with detailed JSDoc annotations.

## Type of Change
- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
- [x] `npm run lint`
- [x] No functional changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the Reactive User Button component and its properties.
  * Clarified how avatar refresh behavior works after profile image updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->