### PR TITLE
[Feature]: add shimmering skeleton loading state to analytics dashboard

### DIFF
--- a/src/app/analytics/AnalyticsDashboard.tsx
+++ b/src/app/analytics/AnalyticsDashboard.tsx
@@ -154,16 +154,123 @@ export default function AnalyticsDashboard() {
 
   if (loading && !data) {
     return (
-      <div className="min-h-screen bg-white dark:bg-zinc-950 flex items-center justify-center">
-        <div className="flex flex-col items-center gap-4">
-          <RefreshCw className="w-12 h-12 accent-text animate-spin" />
-          <div className="text-center">
-            <p className="text-[10px] font-black uppercase tracking-[0.3em] text-zinc-500">
-              Decrypting Neural Identity...
-            </p>
-            <p className="text-[8px] font-bold text-zinc-400 mt-2 uppercase tracking-widest animate-pulse">
-              Syncing Cloud Ledger
-            </p>
+      <div className="min-h-screen bg-zinc-50 dark:bg-zinc-950 text-zinc-900 dark:text-zinc-50 font-sans p-6 md:p-12">
+        <div className="max-w-7xl mx-auto space-y-12">
+          {/* Header Skeleton */}
+          <div className="flex flex-col md:flex-row justify-between gap-8">
+            <div className="space-y-4">
+              <div className="w-24 h-4 bg-zinc-200 dark:bg-zinc-800 rounded animate-pulse"></div>
+              <div className="flex items-center gap-4">
+                <div className="w-20 h-20 rounded-[2rem] bg-zinc-200 dark:bg-zinc-800 animate-pulse"></div>
+                <div className="space-y-2">
+                  <div className="flex gap-2">
+                    <div className="w-24 h-4 bg-zinc-200 dark:bg-zinc-800 rounded animate-pulse"></div>
+                    <div className="w-12 h-4 bg-zinc-200 dark:bg-zinc-800 rounded animate-pulse"></div>
+                  </div>
+                  <div className="w-64 h-10 bg-zinc-200 dark:bg-zinc-800 rounded animate-pulse"></div>
+                  <div className="w-40 h-3 bg-zinc-200 dark:bg-zinc-800 rounded animate-pulse"></div>
+                </div>
+              </div>
+            </div>
+            <div className="hidden lg:flex items-center gap-3">
+              <div className="w-14 h-14 rounded-2xl bg-zinc-200 dark:bg-zinc-800 animate-pulse"></div>
+              <div className="h-10 w-px bg-zinc-200 dark:bg-zinc-800 mx-2"></div>
+              <div className="space-y-2 text-right">
+                <div className="w-24 h-3 bg-zinc-200 dark:bg-zinc-800 rounded animate-pulse ml-auto"></div>
+                <div className="w-12 h-8 bg-zinc-200 dark:bg-zinc-800 rounded animate-pulse ml-auto"></div>
+              </div>
+            </div>
+          </div>
+
+          {/* Grid Skeleton */}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+            {[1, 2, 3, 4].map((i) => (
+              <div
+                key={i}
+                className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 p-8 rounded-[2.5rem] shadow-sm"
+              >
+                <div className="w-16 h-16 rounded-2xl bg-zinc-200 dark:bg-zinc-800 animate-pulse mb-6"></div>
+                <div className="w-20 h-3 bg-zinc-200 dark:bg-zinc-800 rounded animate-pulse mb-3"></div>
+                <div className="w-16 h-8 bg-zinc-200 dark:bg-zinc-800 rounded animate-pulse"></div>
+              </div>
+            ))}
+          </div>
+
+          {/* Progress Card Skeleton */}
+          <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 p-8 rounded-[2.5rem] shadow-sm">
+            <div className="flex flex-col md:flex-row md:items-center justify-between gap-6 mb-6">
+              <div className="space-y-3">
+                <div className="flex gap-3">
+                  <div className="w-20 h-5 rounded-full bg-zinc-200 dark:bg-zinc-800 animate-pulse"></div>
+                  <div className="w-24 h-3 bg-zinc-200 dark:bg-zinc-800 rounded animate-pulse mt-1"></div>
+                </div>
+                <div className="w-64 h-8 bg-zinc-200 dark:bg-zinc-800 rounded animate-pulse"></div>
+              </div>
+              <div className="space-y-3 md:text-right">
+                <div className="w-24 h-3 bg-zinc-200 dark:bg-zinc-800 rounded animate-pulse md:ml-auto"></div>
+                <div className="flex flex-wrap gap-4">
+                  <div className="w-20 h-3 bg-zinc-200 dark:bg-zinc-800 rounded animate-pulse"></div>
+                  <div className="w-20 h-3 bg-zinc-200 dark:bg-zinc-800 rounded animate-pulse"></div>
+                  <div className="w-24 h-3 bg-zinc-200 dark:bg-zinc-800 rounded animate-pulse"></div>
+                </div>
+              </div>
+            </div>
+            <div className="w-full h-4 bg-zinc-200 dark:bg-zinc-800 rounded-full animate-pulse"></div>
+          </div>
+
+          {/* Lists Skeleton */}
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-12">
+            <div className="lg:col-span-2 space-y-6">
+              <div className="flex justify-between items-center">
+                <div className="w-48 h-6 bg-zinc-200 dark:bg-zinc-800 rounded animate-pulse"></div>
+                <div className="w-24 h-4 bg-zinc-200 dark:bg-zinc-800 rounded animate-pulse"></div>
+              </div>
+              <div className="grid gap-4">
+                {[1, 2, 3].map((i) => (
+                  <div
+                    key={i}
+                    className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-[2rem] p-6 flex flex-col md:flex-row gap-6 justify-between"
+                  >
+                    <div className="flex gap-5">
+                      <div className="w-16 h-16 rounded-[1.25rem] bg-zinc-200 dark:bg-zinc-800 animate-pulse"></div>
+                      <div className="space-y-2 py-1">
+                        <div className="w-32 h-5 bg-zinc-200 dark:bg-zinc-800 rounded animate-pulse"></div>
+                        <div className="w-24 h-3 bg-zinc-200 dark:bg-zinc-800 rounded animate-pulse"></div>
+                      </div>
+                    </div>
+                    <div className="flex gap-6 items-center">
+                      <div className="space-y-2 text-right">
+                        <div className="w-20 h-4 bg-zinc-200 dark:bg-zinc-800 rounded animate-pulse ml-auto"></div>
+                        <div className="w-16 h-3 bg-zinc-200 dark:bg-zinc-800 rounded animate-pulse ml-auto"></div>
+                      </div>
+                      <div className="flex gap-2">
+                        <div className="w-12 h-12 rounded-2xl bg-zinc-200 dark:bg-zinc-800 animate-pulse"></div>
+                        <div className="w-12 h-12 rounded-2xl bg-zinc-200 dark:bg-zinc-800 animate-pulse"></div>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className="space-y-8">
+              <div>
+                <div className="w-32 h-4 bg-zinc-200 dark:bg-zinc-800 rounded animate-pulse mb-6"></div>
+                <div className="space-y-3">
+                  {[1, 2, 3].map((i) => (
+                    <div
+                      key={i}
+                      className="bg-white dark:bg-zinc-900 border border-zinc-100 dark:border-zinc-800 p-4 rounded-2xl flex gap-3"
+                    >
+                      <div className="w-10 h-10 rounded-xl bg-zinc-200 dark:bg-zinc-800 animate-pulse"></div>
+                      <div className="space-y-2 py-1 flex-1">
+                        <div className="w-24 h-4 bg-zinc-200 dark:bg-zinc-800 rounded animate-pulse"></div>
+                        <div className="w-16 h-3 bg-zinc-200 dark:bg-zinc-800 rounded animate-pulse"></div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
- closes #1187

This PR enhances the loading experience on the `AnalyticsDashboard` by replacing the basic spinner with a comprehensive, dimension-accurate skeleton UI. The new loading state provides a smoother visual transition when telemetry data finishes fetching and pops into the DOM.

### Changes Made
* **AnalyticsDashboard.tsx:** Replaced the `<RefreshCw animate-spin />` loading block with a fully structured `animate-pulse` skeleton layout.
* **Layout Matching:** The skeleton perfectly mirrors the actual data structure, maintaining layout stability for:
  * The navigation header and user profile area.
  * The 4-column summary metrics grid.
  * The level progress card.
  * The dual-column layout containing the history ledger and high-signal nodes.

### Screenshot

<img width="2880" height="1562" alt="image" src="https://github.com/user-attachments/assets/a2c2d2a5-5c10-4a62-89a1-3c745418843b" />

### Testing Instructions
1. Navigate to `/analytics` in the application.
2. If data fetches too quickly, throttle your network connection in DevTools to "Slow 3G" or temporarily comment out the `fetchUserStats()` call.
3. Verify that the skeleton matches the exact dimensions of the loaded data cards.
4. Verify the smooth transition to actual data without layout shifts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Replaced the loading spinner and status messages with a full-page skeleton layout.
  * Added placeholders for dashboard headers, summary cards, progress indicators, and list sections.
  * Improved perceived loading continuity by mirroring the dashboard’s structure while data loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->