### PR TITLE
docs: document venue rating enum values and request examples

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -230,6 +230,29 @@ The optional **venue** object may contain:
 - `address`
 - `placeId`
 
+### Accepted Enum Values
+
+| Field           | Accepted Values                                                   |
+| --------------- | ----------------------------------------------------------------- |
+| `noiseLevel`    | `quiet`, `moderate`, `loud`                                       |
+| `lighting`      | `natural_daylight`, `warm_ambient`, `fluorescent`, `bright_white` |
+| `outletDensity` | `every_table`, `some_tables`, `wall_seats`, `none`                |
+| `powerTypes`    | `usb_c`, `ac_wall`, `wireless`                                    |
+
+### Example Request
+
+{
+"wifiQuality": 5,
+"hasOutlets": true,
+"noiseLevel": "quiet",
+"comment": "Excellent workspace with reliable Wi-Fi.",
+"outletDensity": "every_table",
+"lighting": "natural_daylight",
+"powerTypes": ["ac_wall", "usb_c"],
+"wifiSpeed": 250,
+"hasQuietZone": true
+}
+
 ### Aggregate Recalculation
 
 After a rating is submitted, the venue's aggregate values are recalculated automatically.
@@ -251,7 +274,11 @@ After a rating is submitted, the venue's aggregate values are recalculated autom
     "wifiQuality": 5,
     "hasOutlets": true,
     "noiseLevel": "quiet",
-    "comment": "Super fast fiber connection!",
+    "outletDensity": "every_table",
+    "lighting": "natural_daylight",
+    "powerTypes": ["ac_wall", "usb_c"],
+    "hasQuietZone": true,
+    "comment": "Excellent workspace with reliable Wi-Fi.",
     "createdAt": "2026-07-10T10:30:00.000Z"
   }
 }


### PR DESCRIPTION
## Description

This PR improves the Venue Rating API documentation by aligning it with the current implementation.

Fixes #1442

### Changes
- Added accepted enum values for rating fields.
- Added a sample request body for `POST /api/venues/{venueId}/rate`.
- Updated the success response to include supported rating fields.
- Improved documentation clarity for API consumers.

### Type of Change
- [x] Documentation

### Testing
- Verified the documentation matches the current validation schema (`venueRatingSchema`) and rating route implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the “Submit Venue Rating” API documentation with accepted values for lighting, outlet density, and power types.
  * Added examples covering Wi-Fi speed, quiet zones, and other rating details.
  * Updated the success response example to reflect the expanded rating information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->