### PR TITLE
fix: add aria-checked state to theme toggle

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -8,6 +8,8 @@ export function ThemeToggle() {
 
   return (
     <button
+      role="switch"
+      aria-checked={theme === "dark"}
       onClick={toggleTheme}
       className="p-2 cursor-pointer bg-zinc-100 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl text-zinc-600 dark:text-zinc-400 hover:bg-[var(--primary-accent,#2563eb)] hover:text-white transition-all active:scale-95"
       title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}


### PR DESCRIPTION
## Description
Added accessibility state handling for the theme toggle switch.

closes #1283

## Changes
- Added `role="switch"` to ThemeToggle
- Added `aria-checked` to reflect the current dark theme state
- Improved screen reader support for theme switching

## Testing
- Ran ThemeToggle tests:
  `npm test -- ThemeToggle.test.tsx`

## Notes
The issue referenced Scratchpad.tsx, but the actual theme switch implementation is handled by ThemeToggle.tsx, so the fix was applied there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved the theme toggle’s accessibility by exposing its current on/off state to assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->