### PR TITLE
feat: Localized timezone clock component on profile booking history

### DIFF
--- a/src/app/dashboard/CheckInHistory.tsx
+++ b/src/app/dashboard/CheckInHistory.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import React from "react";
 import { MapPin, Clock, Wifi, Calendar } from "lucide-react";
+import { TimezoneClock } from "@/components/bookings/TimezoneClock";
 
 interface CheckIn {
   id: string;
@@ -8,6 +11,8 @@ interface CheckIn {
   hoursSpent: number;
   wifiStatus: "Excellent" | "Good" | "Fair" | "Poor";
   thumbnail?: string;
+  /** IANA timezone of the venue (e.g. "America/New_York") */
+  timezone?: string;
 }
 
 const mockCheckIns: CheckIn[] = [
@@ -17,6 +22,7 @@ const mockCheckIns: CheckIn[] = [
     location: "The Roasted Bean Cafe",
     hoursSpent: 4.5,
     wifiStatus: "Excellent",
+    timezone: "America/New_York",
   },
   {
     id: "2",
@@ -24,6 +30,7 @@ const mockCheckIns: CheckIn[] = [
     location: "WeWork Downtown",
     hoursSpent: 3,
     wifiStatus: "Good",
+    timezone: "America/Chicago",
   },
   {
     id: "3",
@@ -31,6 +38,7 @@ const mockCheckIns: CheckIn[] = [
     location: "Central Library Co-working",
     hoursSpent: 6,
     wifiStatus: "Excellent",
+    timezone: "America/Los_Angeles",
   },
   {
     id: "4",
@@ -38,6 +46,7 @@ const mockCheckIns: CheckIn[] = [
     location: "Oceanview Tech Hub",
     hoursSpent: 2.5,
     wifiStatus: "Fair",
+    timezone: "Europe/London",
   },
   {
     id: "5",
@@ -45,6 +54,7 @@ const mockCheckIns: CheckIn[] = [
     location: "Startup Village",
     hoursSpent: 8,
     wifiStatus: "Excellent",
+    timezone: "Asia/Kolkata",
   },
 ];
 
@@ -86,28 +96,38 @@ export function CheckInHistory() {
               <div className="absolute w-4 h-4 rounded-full bg-white dark:bg-zinc-900 border-2 accent-border -left-[9px] top-1.5 group-hover:scale-110 group-hover:bg-[var(--primary-accent)] transition-all duration-300" />
 
               <div className="flex flex-col gap-3">
-                <div className="flex items-start justify-between">
-                  <div>
-                    <h3 className="text-base font-semibold text-zinc-900 dark:text-zinc-50 group-hover:text-[var(--primary-accent)] dark:group-hover:text-[var(--primary-accent)] transition-colors">
+                <div className="flex items-start justify-between gap-3">
+                  {/* Left: venue name + date + live timezone clock */}
+                  <div className="min-w-0 flex-1">
+                    <h3 className="text-base font-semibold text-zinc-900 dark:text-zinc-50 group-hover:text-[var(--primary-accent)] dark:group-hover:text-[var(--primary-accent)] transition-colors truncate">
                       {checkIn.location}
                     </h3>
+
+                    {/* Booking date — standardized alignment */}
                     <div className="flex items-center gap-1.5 text-sm text-zinc-500 dark:text-zinc-400 mt-1">
-                      <Calendar className="w-3.5 h-3.5" />
+                      <Calendar className="w-3.5 h-3.5 shrink-0" />
                       <span>{checkIn.date}</span>
                     </div>
+
+                    {/* Live localized clock for the venue's timezone */}
+                    {checkIn.timezone && (
+                      <TimezoneClock timezone={checkIn.timezone} />
+                    )}
                   </div>
 
+                  {/* Right: WiFi badge — vertically aligned with venue name */}
                   <div
-                    className={`px-2.5 py-1 rounded-full border text-xs font-semibold flex items-center gap-1.5 ${getWifiBadgeStyle(checkIn.wifiStatus)}`}
+                    className={`shrink-0 px-2.5 py-1 rounded-full border text-xs font-semibold flex items-center gap-1.5 ${getWifiBadgeStyle(checkIn.wifiStatus)}`}
                   >
                     <Wifi className="w-3 h-3" />
                     {checkIn.wifiStatus}
                   </div>
                 </div>
 
+                {/* Hours spent row */}
                 <div className="flex items-center gap-4 text-sm bg-zinc-50 dark:bg-zinc-800/50 p-3 rounded-lg border border-zinc-100 dark:border-zinc-800/80">
                   <div className="flex items-center gap-1.5 text-zinc-600 dark:text-zinc-300">
-                    <Clock className="w-4 h-4 text-zinc-400" />
+                    <Clock className="w-4 h-4 text-zinc-400 shrink-0" />
                     <span>
                       <strong className="text-zinc-900 dark:text-zinc-100">
                         {checkIn.hoursSpent}

--- a/src/components/bookings/TimezoneClock.tsx
+++ b/src/components/bookings/TimezoneClock.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Globe } from "lucide-react";
+
+interface TimezoneClockProps {
+  /** IANA timezone string e.g. "America/New_York", "Asia/Kolkata" */
+  timezone: string;
+  /** Optional label shown next to the clock (e.g. venue city name) */
+  label?: string;
+}
+
+/**
+ * TimezoneClock — displays a live, localized clock for a given IANA timezone.
+ * Updates every second via setInterval. Cleans up on unmount.
+ */
+export function TimezoneClock({ timezone, label }: TimezoneClockProps) {
+  const [time, setTime] = useState<string>("");
+  const [tzAbbr, setTzAbbr] = useState<string>("");
+  const [isValid, setIsValid] = useState(true);
+
+  useEffect(() => {
+    const tick = () => {
+      try {
+        const now = new Date();
+
+        // Format the time in the venue's local timezone
+        const timeFormatter = new Intl.DateTimeFormat("en-US", {
+          timeZone: timezone,
+          hour: "2-digit",
+          minute: "2-digit",
+          second: "2-digit",
+          hour12: true,
+        });
+
+        // Extract the timezone abbreviation (e.g. "EST", "IST")
+        const abbrFormatter = new Intl.DateTimeFormat("en-US", {
+          timeZone: timezone,
+          timeZoneName: "short",
+        });
+
+        const formattedTime = timeFormatter.format(now);
+        const parts = abbrFormatter.formatToParts(now);
+        const abbr =
+          parts.find((p) => p.type === "timeZoneName")?.value ?? timezone;
+
+        setTime(formattedTime);
+        setTzAbbr(abbr);
+        setIsValid(true);
+      } catch {
+        // Invalid timezone string — show a graceful fallback
+        setIsValid(false);
+        setTime("--:--:-- --");
+        setTzAbbr(timezone);
+      }
+    };
+
+    // Run immediately so there's no 1-second blank on mount
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [timezone]);
+
+  if (!isValid) return null;
+
+  return (
+    <div className="flex items-center gap-1.5 text-xs text-zinc-500 dark:text-zinc-400 font-mono tabular-nums mt-1">
+      <Globe className="w-3 h-3 shrink-0 text-blue-400" />
+      <span className="text-zinc-900 dark:text-zinc-100 font-semibold">
+        {time}
+      </span>
+      <span className="text-zinc-400 dark:text-zinc-500">{tzAbbr}</span>
+      {label && (
+        <span className="text-zinc-400 dark:text-zinc-500 ml-0.5">
+          · {label}
+        </span>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a live, localized clock next to each booking entry in the Check-In History panel, preventing schedule mismatches when venues are in different timezones. Closes #440.

## Changes

### New: src/components/bookings/TimezoneClock.tsx
- Client component accepting an IANA 	imezone string + optional label
- Uses Intl.DateTimeFormat for locale-aware time formatting and timezone abbreviation extraction
- Ticks every 1 second via setInterval, cleaned up on unmount
- Renders: 🌐 HH:MM:SS AM/PM · TZ_ABBR
- Graceful fallback — renders nothing if timezone string is invalid

### Modified: src/app/dashboard/CheckInHistory.tsx
- Added 	imezone?: string (IANA) field to the CheckIn interface
- Seeded all 5 mock entries with real IANA timezones (America/New\_York, America/Chicago, America/Los\_Angeles, Europe/London, Asia/Kolkata)
- Renders <TimezoneClock> under each booking date line
- Standardized layout:
  - min-w-0 flex-1 + 	runcate on venue name prevents overflow on long names
  - WiFi badge uses shrink-0 to stay right-aligned regardless of name length
  - Calendar icon uses shrink-0 for consistent icon alignment
- Marked component 'use client' to support the interactive clock child

## Testing
- Open /dashboard → Check-In History panel
- Each booking shows a live ticking clock in its venue's local timezone
- Clock updates every second, abbreviation visible (e.g. EDT, BST, IST)

Closes #440

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a live local-time clock to check-in history entries.
  * Displays the venue’s current time and timezone abbreviation when available.
  * Clock updates automatically every second and handles invalid timezone information gracefully.

* **Style**
  * Updated check-in history card layout to accommodate the local-time display while preserving existing WiFi and hours-spent details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->