### PR TITLE
fix: Chatbot message bubbles overlap during rapid layout changes

### DIFF
--- a/src/components/EnhancedChatbot.tsx
+++ b/src/components/EnhancedChatbot.tsx
@@ -146,6 +146,14 @@ export function EnhancedChatbot({
   >({});
   const [typingUsers, setTypingUsers] = useState<string[]>([]);
 
+  // Monotonic message ID counter — avoids React key collisions when
+  // multiple messages arrive within the same millisecond (Date.now() issue).
+  const msgIdCounter = useRef(0);
+  const nextMsgId = () => {
+    msgIdCounter.current += 1;
+    return `msg-${Date.now()}-${msgIdCounter.current}`;
+  };
+
   // Core state
   const [location, setLocation] = useState(userLocation);
   const [messages, setMessages] = useState<Message[]>([]);
@@ -737,17 +745,13 @@ export function EnhancedChatbot({
     }
 
     const newUserMessage: Message = {
-      id: Date.now().toString(),
+      id: nextMsgId(),
       role: "user",
       content: userMessage,
       name: user?.firstName || "Anonymous",
     };
 
-    // Prevent user message duplication on hot reload
-    setMessages((prev) => {
-      if (prev.some((m) => m.id === newUserMessage.id)) return prev;
-      return [...prev, newUserMessage];
-    });
+    setMessages((prev) => [...prev, newUserMessage]);
 
     if (socket && roomId) {
       sendSocketMessage(
@@ -793,20 +797,16 @@ export function EnhancedChatbot({
         throw new Error(errorMessage);
       }
 
-      const assistantMessageId = (Date.now() + 1).toString();
-      // Prevent assistant message duplication on hot reload
-      setMessages((prev) => {
-        if (prev.some((m) => m.id === assistantMessageId)) return prev;
-        return [
-          ...prev,
-          {
-            id: assistantMessageId,
-            role: "assistant",
-            content: "",
-            isStreaming: true,
-          },
-        ];
-      });
+      const assistantMessageId = nextMsgId();
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: assistantMessageId,
+          role: "assistant",
+          content: "",
+          isStreaming: true,
+        },
+      ]);
 
       setIsLoading(false); // Stream starts, disable loading spinner
 


### PR DESCRIPTION
## Summary

Fixes a visual bug where chatbot message bubble wrappers collide and overlap text lines when submitting multiple messages in rapid succession (e.g. within 200ms). Closes #444.

## Root Cause
- When a user sent messages very quickly, Date.now().toString() was used as the React key for messages.
- If multiple messages were processed within the same millisecond, key collisions occurred.
- This caused React's virtual DOM reconciliation to get confused during transitions and render multiple elements in overlapping positions.

## Changes
- **src/components/EnhancedChatbot.tsx**:
  - Implemented msgIdCounter ref to keep a monotonic, per-component session sequence number.
  - Defined a helper function 
extMsgId() returning msg-\-\.
  - Guaranteed completely unique and sequentially stable keys for all messages generated during the session.
  - Simplified state-setting callbacks by removing obsolete hot-reload duplication checks that relied on the unique keys.

## Testing
- Verified that rapid inputs do not produce key collisions.
- Checked that consecutive messages in the chat log layout flow correctly and stack cleanly.

Closes #444

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat message handling to ensure each user and assistant message receives a unique, consistently ordered identifier.
  * Prevented message duplication during chat interactions and hot reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->