### PR TITLE
 fix(tags): integrate Web Locks API and BroadcastChannel in favoriteTagSync

### DIFF
--- a/src/__tests__/lib/favoriteTagSync.test.ts
+++ b/src/__tests__/lib/favoriteTagSync.test.ts
@@ -5,6 +5,11 @@ import {
   queueFavoriteTagMutation,
   getQueuedTagMutations,
   processTagMutationsQueue,
+  withFavoriteTagWebLock,
+  broadcastTagSyncEvent,
+  subscribeTagSyncChannel,
+  TAG_SYNC_LOCK_NAME,
+  TAG_SYNC_CHANNEL_NAME,
 } from "@/lib/favoriteTagSync";
 import { prisma } from "@/lib/prisma";
 
@@ -181,6 +186,107 @@ describe("Client-side Offline Sync", () => {
     expect(retryCall[0]).toBe("/api/favorites/tags/sync");
     expect(JSON.parse(retryCall[1].body)).toEqual({
       updates: [{ id: "real-tag-id", name: "Existing Name" }],
+    });
+  });
+
+  describe("Web Locks API & BroadcastChannel Cross-Tab Synchronization (#1382)", () => {
+    it("acquires Exclusive Web Lock when navigator.locks is available", async () => {
+      const mockRequest = jest.fn((name, options, callback) => {
+        expect(name).toBe(TAG_SYNC_LOCK_NAME);
+        expect(options).toEqual({ mode: "exclusive" });
+        return callback({ name });
+      });
+
+      Object.defineProperty(navigator, "locks", {
+        value: { request: mockRequest },
+        writable: true,
+        configurable: true,
+      });
+
+      const result = await withFavoriteTagWebLock(async () => "locked-result");
+      expect(result).toBe("locked-result");
+      expect(mockRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls back gracefully when navigator.locks is missing or unsupported", async () => {
+      Object.defineProperty(navigator, "locks", {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+
+      const result = await withFavoriteTagWebLock(
+        async () => "fallback-result",
+      );
+      expect(result).toBe("fallback-result");
+    });
+
+    it("broadcasts and receives cross-tab tag sync events via BroadcastChannel", (done) => {
+      const postMessageMock = jest.fn();
+      const closeMock = jest.fn();
+      const channelListeners = new Set<(ev: { data: any }) => void>();
+
+      class MockBroadcastChannel {
+        name: string;
+        private _onmessage: ((ev: { data: any }) => void) | null = null;
+
+        constructor(name: string) {
+          this.name = name;
+        }
+
+        postMessage(data: any) {
+          postMessageMock(data);
+          channelListeners.forEach((listener) => listener({ data }));
+        }
+
+        close() {
+          closeMock();
+          if (this._onmessage) {
+            channelListeners.delete(this._onmessage);
+          }
+        }
+
+        set onmessage(fn: ((ev: { data: any }) => void) | null) {
+          if (this._onmessage) {
+            channelListeners.delete(this._onmessage);
+          }
+          this._onmessage = fn;
+          if (fn) {
+            channelListeners.add(fn);
+          }
+        }
+
+        get onmessage() {
+          return this._onmessage;
+        }
+      }
+
+      (global as any).BroadcastChannel = MockBroadcastChannel;
+
+      expect(TAG_SYNC_CHANNEL_NAME).toBe(
+        "worksphere:favorite-tags-sync-channel",
+      );
+
+      const unsubscribe = subscribeTagSyncChannel((payload) => {
+        expect(payload.type).toBe("TAG_MUTATION");
+        expect(payload.tagId).toBe("tag-lock-1");
+        expect(postMessageMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: "TAG_MUTATION",
+            tagId: "tag-lock-1",
+          }),
+        );
+        unsubscribe();
+        done();
+      });
+
+      broadcastTagSyncEvent({
+        type: "TAG_MUTATION",
+        tagId: "tag-lock-1",
+        operation: "CREATE",
+        data: { name: "Locked Tag" },
+        timestamp: Date.now(),
+      });
     });
   });
 });

--- a/src/lib/favoriteTagSync.ts
+++ b/src/lib/favoriteTagSync.ts
@@ -48,15 +48,92 @@ export async function syncFavoriteTagsBulk(updates: FavoriteTagBulkUpdate[]) {
 }
 
 // ---------------------------------------------------------------------------
-// Client-side Offline Sync Logic
+// Client-side Offline Sync & Web Locks / BroadcastChannel Cross-Tab Synchronization
 // ---------------------------------------------------------------------------
 
-import {
-  getDB,
-  withWebLock,
-  TAG_STORE_NAME,
-  MAX_SYNC_RETRIES,
-} from "./offlineStore";
+import { getDB, TAG_STORE_NAME, MAX_SYNC_RETRIES } from "./offlineStore";
+
+export const TAG_SYNC_LOCK_NAME = "worksphere:favorite-tags-sync-lock";
+export const TAG_SYNC_CHANNEL_NAME = "worksphere:favorite-tags-sync-channel";
+
+export interface TagSyncEventPayload {
+  type: "TAG_MUTATION" | "TAG_DEQUEUED" | "TAG_SYNC_COMPLETE";
+  tagId?: string;
+  operation?: "CREATE" | "UPDATE" | "DELETE";
+  data?: any;
+  timestamp: number;
+}
+
+/**
+ * Web Locks API wrapper to serialize IndexedDB tag mutations across multiple open tabs.
+ * Falls back gracefully in environments without Web Lock support.
+ */
+export async function withFavoriteTagWebLock<T>(
+  callback: () => Promise<T>,
+  options?: { mode?: "exclusive" | "shared" },
+): Promise<T> {
+  const lockMode = options?.mode ?? "exclusive";
+  if (
+    typeof navigator !== "undefined" &&
+    "locks" in navigator &&
+    navigator.locks?.request
+  ) {
+    try {
+      return await navigator.locks.request(
+        TAG_SYNC_LOCK_NAME,
+        { mode: lockMode },
+        async () => callback(),
+      );
+    } catch (err) {
+      console.warn("Web Locks request failed, falling back:", err);
+      return callback();
+    }
+  }
+  return callback();
+}
+
+/**
+ * Broadcasts cross-tab sync events using BroadcastChannel API.
+ */
+export function broadcastTagSyncEvent(event: TagSyncEventPayload): void {
+  if (typeof BroadcastChannel === "undefined") return;
+
+  try {
+    const channel = new BroadcastChannel(TAG_SYNC_CHANNEL_NAME);
+    channel.postMessage(event);
+    channel.close();
+  } catch (err) {
+    console.warn("BroadcastChannel error:", err);
+  }
+}
+
+/**
+ * Subscribes open application tabs to real-time tag synchronization events.
+ */
+export function subscribeTagSyncChannel(
+  callback: (event: TagSyncEventPayload) => void,
+): () => void {
+  if (typeof BroadcastChannel === "undefined") return () => {};
+
+  try {
+    const channel = new BroadcastChannel(TAG_SYNC_CHANNEL_NAME);
+    channel.onmessage = (messageEvent) => {
+      if (messageEvent.data) {
+        callback(messageEvent.data as TagSyncEventPayload);
+      }
+    };
+
+    return () => {
+      try {
+        channel.close();
+      } catch {
+        // Ignore closing errors
+      }
+    };
+  } catch {
+    return () => {};
+  }
+}
 
 export interface OfflineTagMutation {
   id?: number;
@@ -70,6 +147,7 @@ export interface OfflineTagMutation {
 
 /**
  * Pushes a target action into the client IndexedDB transaction queue.
+ * Protected by Exclusive Web Lock and broadcasts tab updates.
  */
 export async function queueFavoriteTagMutation(
   tagId: string,
@@ -77,10 +155,10 @@ export async function queueFavoriteTagMutation(
   data?: any,
   revision?: number,
 ): Promise<void> {
-  return withWebLock(async () => {
+  return withFavoriteTagWebLock(async () => {
     try {
       const db = await getDB();
-      return new Promise<void>((resolve, reject) => {
+      await new Promise<void>((resolve, reject) => {
         const tx = db.transaction(TAG_STORE_NAME, "readwrite");
         const store = tx.objectStore(TAG_STORE_NAME);
         store.add({
@@ -94,6 +172,14 @@ export async function queueFavoriteTagMutation(
         tx.oncomplete = () => resolve();
         tx.onerror = () => reject(tx.error);
       });
+
+      broadcastTagSyncEvent({
+        type: "TAG_MUTATION",
+        tagId,
+        operation,
+        data,
+        timestamp: Date.now(),
+      });
     } catch (err) {
       console.error("Failed to queue offline tag mutation:", err);
     }
@@ -101,33 +187,41 @@ export async function queueFavoriteTagMutation(
 }
 
 export async function getQueuedTagMutations(): Promise<OfflineTagMutation[]> {
-  return withWebLock(async () => {
-    try {
-      const db = await getDB();
-      return new Promise((resolve, reject) => {
-        const tx = db.transaction(TAG_STORE_NAME, "readonly");
-        const store = tx.objectStore(TAG_STORE_NAME);
-        const request = store.getAll();
-        request.onsuccess = () => resolve(request.result || []);
-        request.onerror = () => reject(request.error);
-      });
-    } catch (err) {
-      console.error("Failed to get queued tag mutations:", err);
-      return [];
-    }
-  });
+  return withFavoriteTagWebLock(
+    async () => {
+      try {
+        const db = await getDB();
+        return new Promise((resolve, reject) => {
+          const tx = db.transaction(TAG_STORE_NAME, "readonly");
+          const store = tx.objectStore(TAG_STORE_NAME);
+          const request = store.getAll();
+          request.onsuccess = () => resolve(request.result || []);
+          request.onerror = () => reject(request.error);
+        });
+      } catch (err) {
+        console.error("Failed to get queued tag mutations:", err);
+        return [];
+      }
+    },
+    { mode: "shared" },
+  );
 }
 
 export async function dequeueTagMutation(id: number): Promise<void> {
-  return withWebLock(async () => {
+  return withFavoriteTagWebLock(async () => {
     try {
       const db = await getDB();
-      return new Promise((resolve, reject) => {
+      await new Promise<void>((resolve, reject) => {
         const tx = db.transaction(TAG_STORE_NAME, "readwrite");
         const store = tx.objectStore(TAG_STORE_NAME);
         store.delete(id);
         tx.oncomplete = () => resolve();
         tx.onerror = () => reject(tx.error);
+      });
+
+      broadcastTagSyncEvent({
+        type: "TAG_DEQUEUED",
+        timestamp: Date.now(),
       });
     } catch (err) {
       console.error("Failed to dequeue tag mutation:", err);
@@ -138,7 +232,7 @@ export async function dequeueTagMutation(id: number): Promise<void> {
 export async function incrementTagMutationRetryCount(
   id: number,
 ): Promise<number | null> {
-  return withWebLock(async () => {
+  return withFavoriteTagWebLock(async () => {
     try {
       const db = await getDB();
       return new Promise((resolve, reject) => {
@@ -167,16 +261,18 @@ export async function incrementTagMutationRetryCount(
 }
 
 /**
- * Replays queued favorite tag operations sequentially.
+ * Replays queued favorite tag operations sequentially under an Exclusive Web Lock.
  * Resolves conflicts by fetching and merging state if the server reports a 409.
  */
 let isProcessing = false;
 
 export async function processTagMutationsQueue(): Promise<void> {
   if (isProcessing) return;
-  isProcessing = true;
 
-  const processQueue = async () => {
+  return withFavoriteTagWebLock(async () => {
+    if (isProcessing) return;
+    isProcessing = true;
+
     try {
       const actions = await getQueuedTagMutations();
 
@@ -213,21 +309,14 @@ export async function processTagMutationsQueue(): Promise<void> {
 
           if (res.status === 409) {
             // Conflict Resolution
-            // Tag with this name might already exist
-            // - fetch latest state
-            // - merge according to existing project strategy (apply our local updates to the existing tag if it matches)
-            // - remove successfully resolved operations from queue
-
             const fetchRes = await fetch("/api/favorites/tags");
             if (fetchRes.ok) {
               const latestTags = await fetchRes.json();
-              // Try to find the conflicting tag (same name as what we tried to sync)
               const existingTag = latestTags.find(
                 (t: any) => t.name === action.data?.name,
               );
 
               if (existingTag) {
-                // Retry sync with the correct existing ID
                 const retryRes = await fetch("/api/favorites/tags/sync", {
                   method: "POST",
                   headers: { "Content-Type": "application/json" },
@@ -249,7 +338,6 @@ export async function processTagMutationsQueue(): Promise<void> {
               }
             }
 
-            // If merge failed, or no matching tag found, treat as permanent error
             await dequeueTagMutation(action.id);
             actions.shift();
             continue;
@@ -284,27 +372,15 @@ export async function processTagMutationsQueue(): Promise<void> {
           }
         }
       }
+
+      broadcastTagSyncEvent({
+        type: "TAG_SYNC_COMPLETE",
+        timestamp: Date.now(),
+      });
     } catch (e) {
       console.error("[Tag Sync] processQueue failed:", e);
+    } finally {
+      isProcessing = false;
     }
-  };
-
-  try {
-    if (typeof navigator !== "undefined" && "locks" in navigator) {
-      await navigator.locks.request(
-        "sync-favorite-tags-queue",
-        { ifAvailable: true },
-        async (lock) => {
-          if (!lock) return;
-          await processQueue();
-        },
-      );
-    } else {
-      await processQueue();
-    }
-  } catch (error) {
-    console.error("[Tag Sync] Queue processing failed:", error);
-  } finally {
-    isProcessing = false;
-  }
+  });
 }


### PR DESCRIPTION
Closes #1382 

Summary of Implementation Details
Navigator Web Locks Integration (src/lib/favoriteTagSync.ts):

Implemented withFavoriteTagWebLock(callback, options) acquiring an Exclusive Web Lock (TAG_SYNC_LOCK_NAME = "worksphere:favorite-tags-sync-lock") via navigator.locks.request(..., { mode: "exclusive" }, callback) during IndexedDB tag queue mutations.
Wrapped queueFavoriteTagMutation, dequeueTagMutation, incrementTagMutationRetryCount, getQueuedTagMutations, and processTagMutationsQueue with withFavoriteTagWebLock to prevent multi-tab transaction race conditions and deadlocks.
Provided graceful fallback execution when running in non-supported environments or SSR contexts where navigator.locks is undefined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Favorite-tag changes now stay synchronized across open tabs.
  * Offline favorite-tag updates are coordinated to prevent duplicate or conflicting changes.
* **Bug Fixes**
  * Improved reliability when processing queued favorite-tag updates, including recovery from conflicts and temporary offline conditions.
  * Synchronization now consistently completes and refreshes tab state after queued changes are processed.
* **Tests**
  * Added coverage for cross-tab synchronization and graceful operation when browser locking is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->