### PR TITLE
[Security] Fix Unvalidated Presence Broadcast in PartyKit - Prevent User Impersonation

### DIFF
--- a/party/multiRegionServer.ts
+++ b/party/multiRegionServer.ts
@@ -206,12 +206,18 @@ export default class MultiRegionWorkspaceServer implements Party.Server {
     // Handle presence/cursor messages with cross-region sync
     conn.addEventListener("message", (event) => {
       try {
-        const data = JSON.parse(event.data as string);
+        const raw = event.data as string;
+        if (raw.length > 10_240) return;
+
+        const data = JSON.parse(raw);
 
         if (data.type === "presence" || data.type === "cursor") {
-          this.room.broadcast(event.data as string, [conn.id]);
+          const state = conn.state as { userId?: string } | null;
+          if (!state?.userId || data.userId !== state.userId) return;
+          if (typeof data.venueId !== "string") return;
 
-          // Update cross-region state
+          this.room.broadcast(raw, [conn.id]);
+
           if (data.type === "cursor" && data.venueId) {
             this.stateSync.updatePresence(
               conn.id,
@@ -222,6 +228,8 @@ export default class MultiRegionWorkspaceServer implements Party.Server {
         }
 
         if (data.type === "cross_region_sync") {
+          if (!data.sourceRegion || typeof data.sourceRegion !== "string")
+            return;
           const remoteState = this.stateSync.deserializeState(
             data.state as string,
           );

--- a/party/server.ts
+++ b/party/server.ts
@@ -109,10 +109,16 @@ export default class WorkspaceServer implements Party.Server {
     // Also handle simple presence via standard WebSockets
     conn.addEventListener("message", (event) => {
       try {
-        const data = JSON.parse(event.data as string);
+        const raw = event.data as string;
+        if (raw.length > 10_240) return;
+
+        const data = JSON.parse(raw);
         if (data.type === "presence" || data.type === "cursor") {
-          // Broadcast presence/cursor to everyone else in the room
-          this.room.broadcast(event.data as string, [conn.id]);
+          const state = conn.state as { userId?: string } | null;
+          if (!state?.userId || data.userId !== state.userId) return;
+          if (typeof data.venueId !== "string") return;
+
+          this.room.broadcast(raw, [conn.id]);
         }
       } catch {
         // Not JSON or other error, handled by Yjs


### PR DESCRIPTION
﻿Fixes #1594

Add sender identity verification and safeguards to PartyKit room presence/cursor WebSocket handlers.

Changes:
- party/server.ts and party/multiRegionServer.ts: addEventListener now verifies data.userId matches conn.state.userId before broadcasting
- Added 10KB payload size limit to prevent memory DoS
- Added minimal structure validation (venueId must be a string)
- Added sourceRegion validation for cross_region_sync messages in multiRegionServer
- VIEWER role can no longer bypass the onMessage authorization gate via the event listener


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for presence and cursor updates.
  * Added safeguards against oversized or malformed messages.
  * Prevented unauthorized or incomplete updates from being broadcast.
  * Strengthened cross-region synchronization checks to improve reliability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->