### PR TITLE
[Bug] Fix DurableStateSync.startSync() Never Called - Multi-Region Presence Broken

### DIFF
--- a/party/multiRegionServer.ts
+++ b/party/multiRegionServer.ts
@@ -106,6 +106,7 @@ export default class MultiRegionWorkspaceServer implements Party.Server {
     this.stateSync.setBroadcastFn((message) => {
       this.room.broadcast(message);
     });
+    this.stateSync.startSync();
   }
 
   async onConnect(conn: Party.Connection, ctx: Party.ConnectionContext) {


### PR DESCRIPTION
﻿Fixes #1595

One-line fix: add this.stateSync.startSync() call in multiRegionServer.ts constructor after setBroadcastFn.

This fix enables two critical periodic tasks:
1. cleanupStale() runs every 5 seconds, evicting presence entries older than 30 seconds - preventing unbounded memory growth
2. cross_region_sync broadcasts every 5 seconds, enabling other regions to receive presence updates from this region

Without this fix, the entire multi-region presence feature silently degrades to single-region behavior while stale entries accumulate indefinitely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-region state synchronization by starting synchronization automatically when the server is initialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->