### PR TITLE
[Bug] Fix Unhandled Promise Rejection in pdfWorker - Orphaned Timeout Crash

### DIFF
--- a/worker/pdfWorker.ts
+++ b/worker/pdfWorker.ts
@@ -222,18 +222,26 @@ async function startWorker() {
         activeJobStartTime = Date.now();
 
         try {
-          const timeoutPromise = new Promise<never>((_, reject) =>
-            setTimeout(
+          let timeoutId: ReturnType<typeof setTimeout> | undefined;
+          const timeoutPromise = new Promise<never>((_, reject) => {
+            timeoutId = setTimeout(
               () => reject(new Error("Worker job timeout exceeded")),
               JOB_TIMEOUT_MS,
-            ),
-          );
-          await Promise.race([processJob(jobStr as string), timeoutPromise]);
+            );
+          });
+          try {
+            await Promise.race([processJob(jobStr as string), timeoutPromise]);
+          } finally {
+            clearTimeout(timeoutId);
+          }
         } catch (err: any) {
           const failedId = activeJobId;
           if (failedId) {
             console.error(`[Worker] Job ${failedId} failed:`, err.message);
-            await updateJobStatus(failedId, { status: "FAILED", error: err.message });
+            await updateJobStatus(failedId, {
+              status: "FAILED",
+              error: err.message,
+            });
           }
         } finally {
           await redis.lrem("pdf:jobs:processing", 1, jobStr);


### PR DESCRIPTION
﻿Fixes #1596

Fix an unhandled promise rejection in the PDF worker timeout mechanism.

Problem: The timeout promise was created with Promise.race([processJob(), timeoutPromise]), but the timeout callback was never cleared when the job completed first. The setTimeout would still fire and call reject() on the already-settled promise, producing an unhandled rejection that can crash the worker process.

Fix: Wrapped the Promise.race in a try/finally that clears the timeout regardless of outcome. The timeoutId is now properly captured and cleared on job completion.
