### PR TITLE
[Bug] Fix Missing Cascading Deletes in Prisma Schema - FK Violations on Delete

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -129,7 +129,7 @@ model VenueRating {
   userId             String
   user               User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   venueId            String
-  venue              Venue    @relation(fields: [venueId], references: [id])
+  venue              Venue    @relation(fields: [venueId], references: [id], onDelete: Cascade)
   wifiQuality        Int // 1-5
   hasOutlets         Boolean
   singleOriginBeans  Boolean  @default(false)
@@ -168,7 +168,7 @@ model Favorite {
   userId    String
   user      User          @relation(fields: [userId], references: [id], onDelete: Cascade)
   venueId   String
-  venue     Venue         @relation(fields: [venueId], references: [id])
+  venue     Venue         @relation(fields: [venueId], references: [id], onDelete: Cascade)
   notes     String?
   createdAt DateTime      @default(now())
   updatedAt DateTime      @updatedAt
@@ -220,7 +220,7 @@ model Booking {
   userId             String
   user               User           @relation(fields: [userId], references: [id], onDelete: Cascade)
   venueId            String
-  venue              Venue          @relation(fields: [venueId], references: [id])
+  venue              Venue          @relation(fields: [venueId], references: [id], onDelete: Cascade)
   date               String
   time               String
   customerEmail      String
@@ -470,7 +470,7 @@ model FlaggedItem {
   reason       String
   status       FlagStatus @default(PENDING)
   reportedById String
-  reportedBy   User       @relation(fields: [reportedById], references: [id])
+  reportedBy   User       @relation(fields: [reportedById], references: [id], onDelete: Cascade)
   createdAt    DateTime   @default(now())
   updatedAt    DateTime   @updatedAt
 
@@ -481,7 +481,7 @@ model FlaggedItem {
 model AdminAuditLog {
   id         String   @id @default(cuid())
   adminId    String
-  admin      User     @relation(fields: [adminId], references: [id])
+  admin      User     @relation(fields: [adminId], references: [id], onDelete: Cascade)
   action     String
   entityType String
   entityId   String


### PR DESCRIPTION
﻿Fixes #1597

Add onDelete: Cascade to 5 Prisma relations that were missing it, preventing foreign-key constraint violations when parent records are deleted.

Changes:
- VenueRating.venue (line 132)
- Favorite.venue (line 171)
- Booking.venue (line 223)
- FlaggedItem.reportedBy (line 473)
- AdminAuditLog.admin (line 484)

Without these cascades, deleting a Venue with ratings, favorites, or bookings would throw a FK constraint error. Same for deleting a User with flagged items or audit logs.
