### PR TITLE
docs: add JSDoc to failover sync utilities (Fixes #1544)

### DIFF
--- a/src/lib/edge/failoverSync.ts
+++ b/src/lib/edge/failoverSync.ts
@@ -38,6 +38,21 @@ export const secondaryNodes = [
   "https://backup-c.example.com",
 ];
 
+/**
+ * Pings a specific node endpoint to check its health and availability.
+ * Uses a 3-second abort timeout to prevent hanging on unresponsive nodes.
+ *
+ * @param url - The fully qualified URL of the endpoint to ping.
+ * @returns A promise that resolves to `true` if the node responds with a 2xx status, otherwise `false`.
+ *
+ * @example
+ * ```ts
+ * const isNodeAlive = await pingEndpoint("[https://backup-a.example.com](https://backup-a.example.com)");
+ * if (!isNodeAlive) {
+ *   console.warn("Node is down!");
+ * }
+ * ```
+ */
 export async function pingEndpoint(url: string): Promise<boolean> {
   try {
     const res = await fetch(`${url}/health`, {
@@ -51,6 +66,21 @@ export async function pingEndpoint(url: string): Promise<boolean> {
   }
 }
 
+/**
+ * Iterates through a provided list of failover nodes to find the first healthy one.
+ * Retries pinging each node up to 3 times before moving to the next.
+ *
+ * @param nodes - Array of fallback node URLs. Defaults to `secondaryNodes`.
+ * @returns A promise resolving to the URL string of the first healthy node, or `null` if all fail.
+ *
+ * @example
+ * ```ts
+ * const activeNode = await getHealthyNode(["[https://node1.com](https://node1.com)", "[https://node2.com](https://node2.com)"]);
+ * if (activeNode) {
+ *   connectTo(activeNode);
+ * }
+ * ```
+ */
 export async function getHealthyNode(
   nodes: string[] = secondaryNodes,
 ): Promise<string | null> {
@@ -65,6 +95,23 @@ export async function getHealthyNode(
   return null;
 }
 
+/**
+ * Attempts to switch the current synchronization endpoint to a new healthy failover node.
+ *
+ * @param _currentEndpoint - The current failing endpoint (currently unused, reserved for future logic).
+ * @returns A promise resolving to the new healthy endpoint URL.
+ * @throws {Error} If no healthy failover nodes are available across the network.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   const newUrl = await switchSyncEndpoint(currentUrl);
+ *   console.log(`Successfully switched to ${newUrl}`);
+ * } catch (error) {
+ *   console.error("Critical: Network partition, all nodes down.");
+ * }
+ * ```
+ */
 export async function switchSyncEndpoint(
   _currentEndpoint?: string,
 ): Promise<string> {
@@ -103,10 +150,28 @@ export class FailoverSyncManager<T = unknown> {
     this.onEndpointSwitch = options.onEndpointSwitch;
   }
 
+  /**
+   * Retrieves the current synchronization phase of the failover manager.
+   *
+   * @returns The current `SyncState` (e.g., 'idle', 'syncing_snapshot', 'synced').
+   *
+   * @example
+   * ```ts
+   * const state = syncManager.getStatus();
+   * if (state === 'synced') {
+   *   renderUI();
+   * }
+   * ```
+   */
   public getStatus(): SyncState {
     return this.syncState;
   }
 
+  /**
+   * Checks if the manager is currently actively awaiting or processing a snapshot.
+   *
+   * @returns `true` if state is 'syncing_snapshot', otherwise `false`.
+   */
   public isSyncing(): boolean {
     return this.syncState === "syncing_snapshot";
   }
@@ -155,7 +220,8 @@ export class FailoverSyncManager<T = unknown> {
   }
 
   /**
-   * Called when WebSocket connection disconnects or fails over
+   * Called when WebSocket connection disconnects or fails over.
+   * Prepares the manager for a full snapshot request upon the next connection.
    */
   public handleDisconnect(): void {
     if (this.hasConnectedOnce) {


### PR DESCRIPTION
## Description

Added comprehensive JSDoc/TSDoc comments and usage examples to the failover synchronization utility functions in `src/lib/edge/failoverSync.ts`. 

*Note for reviewers:* The original issue description mentioned `syncFailoverQueue`, `persistPendingDelta`, and `getFailoverStatus`, but those functions appear to have been refactored. I documented the actual existing functions in the file (`pingEndpoint`, `getHealthyNode`, `switchSyncEndpoint`, and `FailoverSyncManager`) to achieve the intended goal of the issue.

## Related Issue

<!--
Please link to the issue here using the standard keywords.
Example: Fixes #123 or Closes #123
-->
Fixes #1544

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded developer documentation for failover synchronization helpers and manager methods.
  * Added clearer descriptions of synchronization status, endpoint switching, health checks, and disconnect handling.
  * Included usage examples and details about parameters and return behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->