### PR TITLE
feat: pause toast auto-dismiss on hover

### DIFF
--- a/src/__tests__/components/Toast.test.tsx
+++ b/src/__tests__/components/Toast.test.tsx
@@ -1,0 +1,149 @@
+import React from "react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ToastProvider, useToast } from "@/components/ui/Toast";
+
+function TestButton() {
+  const { toast } = useToast();
+  return (
+    <button onClick={() => toast("Test message", "success")}>
+      Show Toast
+    </button>
+  );
+}
+
+function ErrorToastButton() {
+  const { toast } = useToast();
+  return (
+    <button onClick={() => toast("Error occurred", "error")}>
+      Show Error
+    </button>
+  );
+}
+
+function ActionToastButton() {
+  const { toast } = useToast();
+  return (
+    <button
+      onClick={() =>
+        toast("Undo?", "warning", { label: "Undo", onClick: jest.fn() })
+      }
+    >
+      Show Action
+    </button>
+  );
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return <ToastProvider>{children}</ToastProvider>;
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("Toast pause-on-hover", () => {
+  it("auto-dismisses after 4 seconds when not hovered", async () => {
+    render(
+      <Wrapper>
+        <TestButton />
+      </Wrapper>,
+    );
+
+    fireEvent.click(screen.getByText("Show Toast"));
+    expect(screen.getByText("Test message")).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(4000);
+    });
+
+    expect(screen.queryByText("Test message")).not.toBeInTheDocument();
+  });
+
+  it("pauses dismissal on mouseenter and resumes on mouseleave", async () => {
+    render(
+      <Wrapper>
+        <TestButton />
+      </Wrapper>,
+    );
+
+    fireEvent.click(screen.getByText("Show Toast"));
+    const toast = screen.getByText("Test message").closest("[role='status']")!;
+
+    // Advance partway, then hover
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    fireEvent.mouseEnter(toast);
+
+    // Advance past original 4s mark — should still be visible
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+    expect(screen.getByText("Test message")).toBeInTheDocument();
+
+    // Leave hover, new 4s timer starts
+    fireEvent.mouseLeave(toast);
+    act(() => {
+      jest.advanceTimersByTime(4000);
+    });
+    expect(screen.queryByText("Test message")).not.toBeInTheDocument();
+  });
+
+  it("dismisses immediately when dismiss button is clicked", async () => {
+    render(
+      <Wrapper>
+        <TestButton />
+      </Wrapper>,
+    );
+
+    fireEvent.click(screen.getByText("Show Toast"));
+    const dismissBtn = screen.getByLabelText("Dismiss notification");
+    fireEvent.click(dismissBtn);
+
+    expect(screen.queryByText("Test message")).not.toBeInTheDocument();
+  });
+
+  it("renders success toast with correct icon color", async () => {
+    render(
+      <Wrapper>
+        <TestButton />
+      </Wrapper>,
+    );
+
+    fireEvent.click(screen.getByText("Show Toast"));
+    const icon = screen.getByText("Test message")
+      .closest("[role='status']")!
+      .querySelector(".text-green-500");
+    expect(icon).toBeInTheDocument();
+  });
+
+  it("renders error toast with correct icon color", async () => {
+    render(
+      <Wrapper>
+        <ErrorToastButton />
+      </Wrapper>,
+    );
+
+    fireEvent.click(screen.getByText("Show Error"));
+    const icon = screen.getByText("Error occurred")
+      .closest("[role='status']")!
+      .querySelector(".text-red-500");
+    expect(icon).toBeInTheDocument();
+  });
+
+  it("renders action button when action is provided", async () => {
+    render(
+      <Wrapper>
+        <ActionToastButton />
+      </Wrapper>,
+    );
+
+    fireEvent.click(screen.getByText("Show Action"));
+    expect(screen.getByText("Undo")).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -96,12 +96,23 @@ function ToastItem({
   toast: Toast;
   onRemove: (id: string) => void;
 }) {
+  const [isHovered, setIsHovered] = useState(false);
+  const timerRef = useState(() => ({ current: null as ReturnType<typeof setTimeout> | null }))[0];
+
   useEffect(() => {
-    const timer = setTimeout(() => {
+    if (isHovered) {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      return;
+    }
+
+    timerRef.current = setTimeout(() => {
       onRemove(toast.id);
     }, 4000);
-    return () => clearTimeout(timer);
-  }, [toast.id, onRemove]);
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [toast.id, onRemove, isHovered]);
 
   const Icon =
     toast.type === "success"
@@ -119,6 +130,8 @@ function ToastItem({
   return (
     <div
       role="status"
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
       className={cn(
         "pointer-events-auto flex items-center gap-3 px-4 py-3 rounded-xl border shadow-lg backdrop-blur-md min-w-[280px] max-w-[380px]",
         "bg-white/90 dark:bg-zinc-900/90 border-zinc-200 dark:border-zinc-800",


### PR DESCRIPTION
## Summary

Pauses the toast auto-dismiss timer on mouse hover so users can read long messages or click action buttons without the notification disappearing prematurely.

### What changed

- **`src/components/ui/Toast.tsx`**: Added `isHovered` state to `ToastItem`. The 4-second dismiss timer is cleared on `mouseEnter` and restarted on `mouseLeave`. A ref-based timer ensures cleanup on unmount.
- **`src/__tests__/components/Toast.test.tsx`** (new): 6 tests covering auto-dismiss, hover pause/resume, manual dismiss, success/error icon colors, and action button rendering.

### Testing

All **6 tests** pass (`npx jest Toast`).

### Related

Closes #455

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Toast notifications now pause auto-dismissal while hovered and resume when the pointer leaves.
  * Toasts can still be dismissed immediately using the dismiss button.

* **Tests**
  * Added coverage for auto-dismiss timing, hover behavior, dismissal actions, status icons, and optional action buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->