### PR TITLE
fix: prevent map pin marker re-render flicker during live telemetry updates (closes #1623)

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1150,83 +1150,96 @@ const Map = ({
             />
           );
         })}
-        {spiderfiedMarkers.map((marker) => (
-          <AccessibleMarker
-            key={marker.id}
-            position={[marker.renderedLat, marker.renderedLng]}
-            icon={marker.id.includes("dest") ? destinationIcon : venueIcon}
-            name={marker.name}
-            category={marker.category}
-            isDestination={marker.id.includes("dest")}
-          >
-            <div className="text-sm">
-              <div className="font-semibold text-white">{marker.name}</div>
-              {marker.category && (
-                <div className="text-zinc-400">{marker.category}</div>
-              )}
-              {marker.address && (
-                <div className="text-zinc-500 text-xs mt-1">
-                  {marker.address}
-                </div>
-              )}
-              {!marker.id.includes("dest") &&
-                (() => {
-                  const seat = getAvailability(marker.id);
-                  const isCheckedInHere = checkedInVenueId === marker.id;
-                  const seatTextColor =
-                    seat.status === "red"
-                      ? "text-red-400"
-                      : seat.status === "yellow"
-                        ? "text-yellow-400"
-                        : "text-green-400";
-                  return (
-                    <div className="mt-2 flex items-center justify-between gap-2 border-t border-zinc-800 pt-2">
-                      <span
-                        className={`text-[10px] font-medium ${seatTextColor}`}
-                      >
-                        {isSeatSocketConnected
-                          ? `${seat.count}/${seat.capacity} checked in`
-                          : "Connecting…"}
-                      </span>
-                      <button
-                        onClick={() =>
-                          isCheckedInHere ? checkOut() : checkIn(marker.id)
-                        }
-                        className={`rounded px-2 py-1 text-[10px] font-medium transition-colors ${
-                          isCheckedInHere
-                            ? "accent-bg text-white hover:opacity-90"
-                            : "bg-zinc-800 text-zinc-200 hover:accent-bg hover:text-white"
-                        }`}
-                      >
-                        {isCheckedInHere ? "Check out" : "Check in here"}
-                      </button>
-                    </div>
-                  );
-                })()}
-            </div>
-            <button
-              onClick={() => {
-                // Prevent duplicates in queue chain matrix
-                if (!routingQueue.some((v) => v.id === marker.id)) {
-                  const updated = [
-                    ...routingQueue,
-                    {
-                      id: marker.id,
-                      name: marker.name,
-                      latitude: Number(marker.position.lat),
-                      longitude: Number(marker.position.lng),
-                    },
-                  ];
-                  setRoutingQueue(updated);
-                  calculateOptimizedRoute(updated);
-                }
-              }}
-              className="mt-2 w-full rounded bg-zinc-800 py-1 text-[10px] font-medium text-zinc-200 hover:accent-bg hover:text-white transition-colors"
+        {spiderfiedMarkers.map((marker) => {
+          const isDest = marker.id.includes("dest");
+          const seat = !isDest ? getAvailability(marker.id) : null;
+          const isCheckedInHere = !isDest && checkedInVenueId === marker.id;
+          const telemetry = !isDest
+            ? {
+                seatCount: seat?.count,
+                seatCapacity: seat?.capacity,
+                isCheckedIn: isCheckedInHere,
+                isConnected: isSeatSocketConnected,
+              }
+            : undefined;
+
+          return (
+            <AccessibleMarker
+              key={marker.id}
+              position={[marker.renderedLat, marker.renderedLng]}
+              icon={isDest ? destinationIcon : venueIcon}
+              name={marker.name}
+              category={marker.category}
+              isDestination={isDest}
+              telemetryData={telemetry}
             >
-              ➕ Add to Workday Timeline
-            </button>
-          </AccessibleMarker>
-        ))}
+              <div className="text-sm">
+                <div className="font-semibold text-white">{marker.name}</div>
+                {marker.category && (
+                  <div className="text-zinc-400">{marker.category}</div>
+                )}
+                {marker.address && (
+                  <div className="text-zinc-500 text-xs mt-1">
+                    {marker.address}
+                  </div>
+                )}
+                {!isDest &&
+                  (() => {
+                    const seatTextColor =
+                      seat!.status === "red"
+                        ? "text-red-400"
+                        : seat!.status === "yellow"
+                          ? "text-yellow-400"
+                          : "text-green-400";
+                    return (
+                      <div className="mt-2 flex items-center justify-between gap-2 border-t border-zinc-800 pt-2">
+                        <span
+                          className={`text-[10px] font-medium ${seatTextColor}`}
+                        >
+                          {isSeatSocketConnected
+                            ? `${seat!.count}/${seat!.capacity} checked in`
+                            : "Connecting…"}
+                        </span>
+                        <button
+                          onClick={() =>
+                            isCheckedInHere ? checkOut() : checkIn(marker.id)
+                          }
+                          className={`rounded px-2 py-1 text-[10px] font-medium transition-colors ${
+                            isCheckedInHere
+                              ? "accent-bg text-white hover:opacity-90"
+                              : "bg-zinc-800 text-zinc-200 hover:accent-bg hover:text-white"
+                          }`}
+                        >
+                          {isCheckedInHere ? "Check out" : "Check in here"}
+                        </button>
+                      </div>
+                    );
+                  })()}
+              </div>
+              <button
+                onClick={() => {
+                  // Prevent duplicates in queue chain matrix
+                  if (!routingQueue.some((v) => v.id === marker.id)) {
+                    const updated = [
+                      ...routingQueue,
+                      {
+                        id: marker.id,
+                        name: marker.name,
+                        latitude: Number(marker.position.lat),
+                        longitude: Number(marker.position.lng),
+                      },
+                    ];
+                    setRoutingQueue(updated);
+                    calculateOptimizedRoute(updated);
+                  }
+                }}
+                className="mt-2 w-full rounded bg-zinc-800 py-1 text-[10px] font-medium text-zinc-200 hover:accent-bg hover:text-white transition-colors"
+              >
+                ➕ Add to Workday Timeline
+              </button>
+            </AccessibleMarker>
+          );
+        })}
 
         {/* Render OSRM Optimized Multi-Stop Routing Layer Geometry */}
         {optimizedRoute &&

--- a/src/components/ui/MapMarker.tsx
+++ b/src/components/ui/MapMarker.tsx
@@ -2,7 +2,7 @@
 
 import { Marker, Popup } from "react-leaflet";
 import type { Marker as LeafletMarker } from "leaflet";
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef, memo } from "react";
 
 interface AccessibleMarkerProps {
   position: [number, number];
@@ -11,77 +11,136 @@ interface AccessibleMarkerProps {
   category?: string;
   isDestination?: boolean;
   children?: React.ReactNode;
+  telemetryData?: {
+    seatCount?: number;
+    seatCapacity?: number;
+    isCheckedIn?: boolean;
+    isConnected?: boolean;
+  };
 }
 
-export function AccessibleMarker({
-  position,
-  icon,
-  name,
-  category,
-  isDestination,
-  children,
-}: AccessibleMarkerProps) {
-  const markerRef = useRef<LeafletMarker | null>(null);
+export const AccessibleMarker = memo(
+  function AccessibleMarker({
+    position,
+    icon,
+    name,
+    category,
+    isDestination,
+    children,
+  }: AccessibleMarkerProps) {
+    const markerRef = useRef<LeafletMarker | null>(null);
 
-  const handleKeyDown = useCallback((e: L.LeafletKeyboardEvent) => {
-    if (e.originalEvent.key === "Enter" || e.originalEvent.key === " ") {
-      e.originalEvent.preventDefault();
-      e.target.openPopup();
-    }
-    if (e.originalEvent.key === "Escape") {
-      e.target.closePopup();
-    }
-  }, []);
-
-  const handleAdd = useCallback(
-    (e: any) => {
-      const el = e.target.getElement();
-      if (!el) return;
-      const label = isDestination
-        ? `Destination: ${name}`
-        : `Venue: ${name}${category ? `, ${category}` : ""}`;
-      el.setAttribute("aria-label", label);
-      el.setAttribute("role", "button");
-      el.setAttribute("tabindex", "0");
-    },
-    [name, category, isDestination],
-  );
-
-  const handlePopupOpen = useCallback(
-    (e: any) => {
-      const popupEl = e.target.getPopup()?.getElement();
-      if (popupEl) {
-        popupEl.setAttribute("role", "dialog");
-        popupEl.setAttribute("aria-modal", "true");
-        popupEl.setAttribute("aria-label", name);
+    const handleKeyDown = useCallback((e: L.LeafletKeyboardEvent) => {
+      if (e.originalEvent.key === "Enter" || e.originalEvent.key === " ") {
+        e.originalEvent.preventDefault();
+        e.target.openPopup();
       }
-    },
-    [name],
-  );
+      if (e.originalEvent.key === "Escape") {
+        e.target.closePopup();
+      }
+    }, []);
 
-  const handlePopupClose = useCallback(() => {
-    markerRef.current?.getElement()?.focus();
-  }, []);
+    const handleAdd = useCallback(
+      (e: any) => {
+        const el = e.target.getElement();
+        if (!el) return;
+        const label = isDestination
+          ? `Destination: ${name}`
+          : `Venue: ${name}${category ? `, ${category}` : ""}`;
+        el.setAttribute("aria-label", label);
+        el.setAttribute("role", "button");
+        el.setAttribute("tabindex", "0");
+      },
+      [name, category, isDestination],
+    );
 
-  return (
-    <Marker
-      ref={markerRef}
-      position={position}
-      icon={icon}
-      keyboard={true}
-      eventHandlers={{
-        keydown: handleKeyDown,
-        add: handleAdd,
-        popupopen: handlePopupOpen,
-        popupclose: handlePopupClose,
-      }}
-    >
-      <Popup
-        autoPanPaddingTopLeft={[20, 90]}
-        autoPanPaddingBottomRight={[20, 20]}
+    const handlePopupOpen = useCallback(
+      (e: any) => {
+        const popupEl = e.target.getPopup()?.getElement();
+        if (popupEl) {
+          popupEl.setAttribute("role", "dialog");
+          popupEl.setAttribute("aria-modal", "true");
+          popupEl.setAttribute("aria-label", name);
+        }
+      },
+      [name],
+    );
+
+    const handlePopupClose = useCallback(() => {
+      markerRef.current?.getElement()?.focus();
+    }, []);
+
+    // Direct Leaflet element updates to prevent map pin flicker
+    useEffect(() => {
+      const marker = markerRef.current;
+      if (!marker) return;
+      const currentPos = marker.getLatLng();
+      if (currentPos.lat !== position[0] || currentPos.lng !== position[1]) {
+        marker.setLatLng(position);
+      }
+    }, [position]);
+
+    useEffect(() => {
+      const marker = markerRef.current;
+      if (marker && icon) {
+        marker.setIcon(icon);
+      }
+    }, [icon]);
+
+    return (
+      <Marker
+        ref={markerRef}
+        position={position}
+        icon={icon}
+        keyboard={true}
+        eventHandlers={{
+          keydown: handleKeyDown,
+          add: handleAdd,
+          popupopen: handlePopupOpen,
+          popupclose: handlePopupClose,
+        }}
       >
-        {children}
-      </Popup>
-    </Marker>
-  );
-}
+        <Popup
+          autoPanPaddingTopLeft={[20, 90]}
+          autoPanPaddingBottomRight={[20, 20]}
+        >
+          {children}
+        </Popup>
+      </Marker>
+    );
+  },
+  (prevProps, nextProps) => {
+    // Custom comparison logic to avoid unneeded re-renders
+    if (
+      prevProps.position[0] !== nextProps.position[0] ||
+      prevProps.position[1] !== nextProps.position[1]
+    ) {
+      return false;
+    }
+
+    if (
+      prevProps.icon !== nextProps.icon ||
+      prevProps.name !== nextProps.name ||
+      prevProps.category !== nextProps.category ||
+      prevProps.isDestination !== nextProps.isDestination
+    ) {
+      return false;
+    }
+
+    const prevTelemetry = prevProps.telemetryData;
+    const nextTelemetry = nextProps.telemetryData;
+    if (prevTelemetry !== nextTelemetry) {
+      if (!prevTelemetry || !nextTelemetry) return false;
+      if (
+        prevTelemetry.seatCount !== nextTelemetry.seatCount ||
+        prevTelemetry.seatCapacity !== nextTelemetry.seatCapacity ||
+        prevTelemetry.isCheckedIn !== nextTelemetry.isCheckedIn ||
+        prevTelemetry.isConnected !== nextTelemetry.isConnected
+      ) {
+        return false;
+      }
+    }
+
+    return true;
+  },
+);


### PR DESCRIPTION
closes #1623

# Description

This pull request addresses issue #1623 by preventing Leaflet map pin marker re-render flicker during rapid live WebSocket/PartySocket check-in and checkout telemetry updates.

## Key Changes

- **React.memo wrapping**: Wrapped `<AccessibleMarker>` in `src/components/ui/MapMarker.tsx` with `React.memo` using a custom comparison function that ignores array reference changes on `position` if coordinates are unchanged, and checks nested fields under the new `telemetryData` prop.
- **Direct Leaflet Element Updates**: Added `useEffect` hooks in `<AccessibleMarker>` to directly update the Leaflet Marker instance properties (`.setLatLng()` and `.setIcon()`) in place, avoiding full Leaflet DOM element tear-down and recreation.
- **Telemetry Prop Integration**: Updated the rendering loop in `src/components/Map.tsx` to compute the real-time seat availability state (`seatCount`, `seatCapacity`, `isCheckedIn`, `isConnected`) and pass it as the `telemetryData` prop to `<AccessibleMarker>`.

## Verification Plan

- [x] Run lint checks locally to ensure no syntax or formatting issues exist:
  ```bash
  npm run lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Map venue markers now display seat availability, check-in status, and connection status.
  * Venue and destination markers are differentiated more clearly in map interactions.

* **Bug Fixes**
  * Map marker position and icon updates now appear more smoothly, reducing visual flicker.
  * Improved marker rendering performance while preserving keyboard and accessibility interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->