### PR TITLE
fix: prevent PDF export text overlap for venues with extremely long multilingual names (closes #1624)

### DIFF
--- a/src/__tests__/lib/multiCityPdfExport.test.ts
+++ b/src/__tests__/lib/multiCityPdfExport.test.ts
@@ -70,4 +70,29 @@ describe("MultiCity PDF Export Utility (src/lib/multiCityPdfExport.ts)", () => {
     const doc = await PDFDocument.load(pdfBytes);
     expect(doc.getPageCount()).toBeGreaterThanOrEqual(1);
   });
+
+  it("handles extremely long multilingual names (100+ characters) without throwing exceptions", async () => {
+    const longMultilingualVenue: Venue = {
+      id: "v-multilingual-long",
+      name: "Tokyo Super Multilingual Creative Space 東京コワーキングスペース & Tech Cafe & Innovation Hub - Shibuya Branch Center - ゲートウェイ 渋谷区 شيبويا",
+      address: "Shibuya, Tokyo",
+      lat: 35.6762,
+      lng: 139.6503,
+      category: "coworking",
+      wifiSpeed: 250,
+      hasOutlets: true,
+      noiseLevel: "quiet",
+    };
+
+    const pdfBytes = await generateMultiCityPdfReport({
+      selectedCities: ["Tokyo"],
+      venues: [...mockVenues, longMultilingualVenue],
+    });
+
+    expect(pdfBytes).toBeInstanceOf(Uint8Array);
+    expect(pdfBytes.length).toBeGreaterThan(100);
+
+    const doc = await PDFDocument.load(pdfBytes);
+    expect(doc.getPageCount()).toBeGreaterThanOrEqual(1);
+  });
 });

--- a/src/lib/multiCityPdfExport.ts
+++ b/src/lib/multiCityPdfExport.ts
@@ -2,6 +2,57 @@ import { PDFDocument, StandardFonts, rgb } from "pdf-lib";
 import { drawSafeText, safeText } from "@/lib/pdfHelpers";
 import { Venue } from "@/components/chat/ChatMessages";
 
+function safeWidthOfTextAtSize(text: string, font: any, size: number): number {
+  try {
+    return font.widthOfTextAtSize(text, size);
+  } catch {
+    const asciiText = text.replace(/[^\x20-\x7E]/g, "");
+    try {
+      return font.widthOfTextAtSize(asciiText, size);
+    } catch {
+      return asciiText.length * size * 0.6;
+    }
+  }
+}
+
+function truncateText(
+  text: string,
+  font: any,
+  size: number,
+  maxWidth: number,
+): string {
+  const sanitized = safeText(text);
+  if (safeWidthOfTextAtSize(sanitized, font, size) <= maxWidth) {
+    return sanitized;
+  }
+
+  const ellipsis = "...";
+  const ellipsisWidth = safeWidthOfTextAtSize(ellipsis, font, size);
+
+  if (maxWidth <= ellipsisWidth) {
+    return ellipsis;
+  }
+
+  let low = 0;
+  let high = sanitized.length;
+  let result = "";
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const substring = sanitized.slice(0, mid) + ellipsis;
+    const width = safeWidthOfTextAtSize(substring, font, size);
+
+    if (width <= maxWidth) {
+      result = substring;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  return result || ellipsis;
+}
+
 export interface CityMetricSummary {
   city: string;
   totalVenues: number;
@@ -267,8 +318,16 @@ export async function generateMultiCityPdfReport(options: {
             borderWidth: 0.75,
           });
 
-          // Venue Name
-          drawSafeText(page, safeText(venue.name).slice(0, 32), {
+          // Venue Name (truncated dynamically to fit column width minus padding)
+          const maxNameWidth = colWidth - 16;
+          const truncatedName = truncateText(
+            venue.name,
+            bold,
+            8.5,
+            maxNameWidth,
+          );
+
+          drawSafeText(page, truncatedName, {
             x: colX + 8,
             y: rowY + 22,
             size: 8.5,


### PR DESCRIPTION
closes #1624

# Description

This pull request fixes issue #1624 by preventing text overlap in multi-city PDF column exports when venues have extremely long or multilingual names (such as mixed English, Japanese, and Arabic script).

## Key Changes

- **Dynamic Font-Width Calculation**: Implemented `safeWidthOfTextAtSize` inside `src/lib/multiCityPdfExport.ts` to calculate the actual horizontal space occupied by the text in the embedded Helvetica font. This includes try-catch blocks to fallback gracefully (to ASCII representation or character-count estimations) if character layouts fail.
- **Ellipsis Truncation**: Added the `truncateText` helper which dynamically limits the length of the venue name using a binary search approach, appending `...` only if the text width exceeds the designated cell column width (minus margin/padding).
- **Automated Tests**: Added a test case in `src/__tests__/lib/multiCityPdfExport.test.ts` verifying that exporting reports with 100+ character multilingual names resolves correctly without throwing layout exceptions.

## Verification Plan

- [x] Run ESLint checks locally:
  ```bash
  npm run lint
