### PR TITLE
fix: remove all 9 canvas event listeners in FloorPlanRenderer.destroy() (closes #1661)

### DIFF
--- a/src/__tests__/lib/webgpu/floorPlanRenderer.test.ts
+++ b/src/__tests__/lib/webgpu/floorPlanRenderer.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for WebGPUFloorPlanRenderer — event listener cleanup on destroy().
+ *
+ * Verifies that all 9 canvas interaction listeners registered in
+ * setupInteraction() are properly removed when destroy() is called,
+ * preventing cumulative memory leaks.
+ */
+
+import { WebGPUFloorPlanRenderer } from "@/lib/webgpu/floorPlanRenderer";
+
+// Stub GPUBufferUsage / GPUTextureUsage constants used at module level
+Object.defineProperty(global, "GPUBufferUsage", { value: undefined });
+Object.defineProperty(global, "GPUTextureUsage", { value: undefined });
+
+function createMockCanvas() {
+  const listeners: Record<string, EventListenerOrEventListenerObject[]> = {};
+
+  const canvas = {
+    addEventListener: jest.fn(
+      (
+        type: string,
+        handler: EventListenerOrEventListenerObject,
+        _options?: unknown,
+      ) => {
+        if (!listeners[type]) listeners[type] = [];
+        listeners[type].push(handler);
+      },
+    ),
+    removeEventListener: jest.fn(
+      (
+        type: string,
+        handler: EventListenerOrEventListenerObject,
+        _options?: unknown,
+      ) => {
+        if (listeners[type]) {
+          listeners[type] = listeners[type].filter((h) => h !== handler);
+        }
+      },
+    ),
+    getContext: jest.fn(() => null),
+    width: 800,
+    height: 600,
+    _listeners: listeners,
+  };
+
+  return canvas as unknown as HTMLCanvasElement & {
+    _listeners: typeof listeners;
+  };
+}
+
+describe("WebGPUFloorPlanRenderer — destroy() event listener cleanup", () => {
+  let canvas: ReturnType<typeof createMockCanvas>;
+  let renderer: WebGPUFloorPlanRenderer;
+
+  beforeEach(() => {
+    // Mock document.addEventListener / removeEventListener for visibility handler
+    jest.spyOn(document, "addEventListener").mockImplementation(() => {});
+    jest.spyOn(document, "removeEventListener").mockImplementation(() => {});
+
+    canvas = createMockCanvas();
+    renderer = new WebGPUFloorPlanRenderer(canvas);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const CANVAS_EVENTS = [
+    "mousedown",
+    "mousemove",
+    "mouseup",
+    "mouseleave",
+    "wheel",
+    "touchstart",
+    "touchmove",
+    "touchend",
+  ] as const;
+
+  it("registers all 8 canvas interaction listeners on construction", () => {
+    for (const event of CANVAS_EVENTS) {
+      // Some listeners are registered with an options object, others without —
+      // so we only assert on event type and handler function.
+      const calls = (canvas.addEventListener as jest.Mock).mock.calls;
+      const matched = calls.some(
+        ([type, handler]) => type === event && typeof handler === "function",
+      );
+      expect(matched).toBe(true);
+    }
+  });
+
+  it("calls removeEventListener for every canvas event type on destroy()", () => {
+    renderer.destroy();
+
+    for (const event of CANVAS_EVENTS) {
+      expect(canvas.removeEventListener).toHaveBeenCalledWith(
+        event,
+        expect.any(Function),
+      );
+    }
+  });
+
+  it("removes exactly the same handler reference that was added", () => {
+    // Each listener array should have exactly one entry after construction
+    for (const event of CANVAS_EVENTS) {
+      expect(canvas._listeners[event]).toHaveLength(1);
+    }
+
+    renderer.destroy();
+
+    // After destroy() all listener arrays should be empty (reference matched)
+    for (const event of CANVAS_EVENTS) {
+      expect(canvas._listeners[event] ?? []).toHaveLength(0);
+    }
+  });
+
+  it("removes the visibilitychange listener from document on destroy()", () => {
+    renderer.destroy();
+    expect(document.removeEventListener).toHaveBeenCalledWith(
+      "visibilitychange",
+      expect.any(Function),
+    );
+  });
+
+  it("does not throw when destroy() is called multiple times", () => {
+    expect(() => {
+      renderer.destroy();
+      renderer.destroy();
+    }).not.toThrow();
+  });
+});

--- a/src/lib/webgpu/floorPlanRenderer.ts
+++ b/src/lib/webgpu/floorPlanRenderer.ts
@@ -459,8 +459,76 @@ export class WebGPUFloorPlanRenderer {
   private currentData: FloorPlanData | null = null;
   private visibilityHandler: (() => void) | null = null;
 
+  // Named bound handlers so destroy() can call removeEventListener on them
+  private _onMouseDown: (e: MouseEvent) => void;
+  private _onMouseMove: (e: MouseEvent) => void;
+  private _onMouseUp: () => void;
+  private _onMouseLeave: () => void;
+  private _onWheel: (e: WheelEvent) => void;
+  private _onTouchStart: (e: TouchEvent) => void;
+  private _onTouchMove: (e: TouchEvent) => void;
+  private _onTouchEnd: () => void;
+
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas;
+    // Initialise bound handlers before setupInteraction() so they are
+    // available as stable references for removeEventListener in destroy().
+    this._onMouseDown = (e: MouseEvent) => {
+      this.isDragging = true;
+      this.lastMouse = { x: e.clientX, y: e.clientY };
+    };
+    this._onMouseMove = (e: MouseEvent) => {
+      if (!this.isDragging) return;
+      const dx = e.clientX - this.lastMouse.x;
+      const dy = e.clientY - this.lastMouse.y;
+      this.camera.rotationY += dx * 0.01;
+      this.camera.rotationX = Math.max(
+        -Math.PI / 2.5,
+        Math.min(-0.1, this.camera.rotationX + dy * 0.01),
+      );
+      this.lastMouse = { x: e.clientX, y: e.clientY };
+    };
+    this._onMouseUp = () => {
+      this.isDragging = false;
+    };
+    this._onMouseLeave = () => {
+      this.isDragging = false;
+    };
+    this._onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      this.camera.distance = Math.max(
+        2,
+        Math.min(20, this.camera.distance + e.deltaY * 0.01),
+      );
+    };
+    this._onTouchStart = (e: TouchEvent) => {
+      if (e.touches.length === 1) {
+        this.isDragging = true;
+        this.lastMouse = {
+          x: e.touches[0].clientX,
+          y: e.touches[0].clientY,
+        };
+      }
+    };
+    this._onTouchMove = (e: TouchEvent) => {
+      e.preventDefault();
+      if (e.touches.length === 1 && this.isDragging) {
+        const dx = e.touches[0].clientX - this.lastMouse.x;
+        const dy = e.touches[0].clientY - this.lastMouse.y;
+        this.camera.rotationY += dx * 0.01;
+        this.camera.rotationX = Math.max(
+          -Math.PI / 2.5,
+          Math.min(-0.1, this.camera.rotationX + dy * 0.01),
+        );
+        this.lastMouse = {
+          x: e.touches[0].clientX,
+          y: e.touches[0].clientY,
+        };
+      }
+    };
+    this._onTouchEnd = () => {
+      this.isDragging = false;
+    };
     this.setupInteraction();
     this.setupVisibilityHandler();
   }
@@ -483,70 +551,19 @@ export class WebGPUFloorPlanRenderer {
   }
 
   private setupInteraction(): void {
-    this.canvas.addEventListener("mousedown", (e) => {
-      this.isDragging = true;
-      this.lastMouse = { x: e.clientX, y: e.clientY };
-    });
-
-    this.canvas.addEventListener("mousemove", (e) => {
-      if (!this.isDragging) return;
-      const dx = e.clientX - this.lastMouse.x;
-      const dy = e.clientY - this.lastMouse.y;
-      this.camera.rotationY += dx * 0.01;
-      this.camera.rotationX = Math.max(
-        -Math.PI / 2.5,
-        Math.min(-0.1, this.camera.rotationX + dy * 0.01),
-      );
-      this.lastMouse = { x: e.clientX, y: e.clientY };
-    });
-
-    this.canvas.addEventListener("mouseup", () => {
-      this.isDragging = false;
-    });
-
-    this.canvas.addEventListener("mouseleave", () => {
-      this.isDragging = false;
-    });
-
-    this.canvas.addEventListener("wheel", (e) => {
-      e.preventDefault();
-      this.camera.distance = Math.max(
-        2,
-        Math.min(20, this.camera.distance + e.deltaY * 0.01),
-      );
-    });
-
+    this.canvas.addEventListener("mousedown", this._onMouseDown);
+    this.canvas.addEventListener("mousemove", this._onMouseMove);
+    this.canvas.addEventListener("mouseup", this._onMouseUp);
+    this.canvas.addEventListener("mouseleave", this._onMouseLeave);
+    this.canvas.addEventListener("wheel", this._onWheel, { passive: false });
     // Touch support
-    this.canvas.addEventListener("touchstart", (e) => {
-      if (e.touches.length === 1) {
-        this.isDragging = true;
-        this.lastMouse = {
-          x: e.touches[0].clientX,
-          y: e.touches[0].clientY,
-        };
-      }
+    this.canvas.addEventListener("touchstart", this._onTouchStart, {
+      passive: false,
     });
-
-    this.canvas.addEventListener("touchmove", (e) => {
-      e.preventDefault();
-      if (e.touches.length === 1 && this.isDragging) {
-        const dx = e.touches[0].clientX - this.lastMouse.x;
-        const dy = e.touches[0].clientY - this.lastMouse.y;
-        this.camera.rotationY += dx * 0.01;
-        this.camera.rotationX = Math.max(
-          -Math.PI / 2.5,
-          Math.min(-0.1, this.camera.rotationX + dy * 0.01),
-        );
-        this.lastMouse = {
-          x: e.touches[0].clientX,
-          y: e.touches[0].clientY,
-        };
-      }
+    this.canvas.addEventListener("touchmove", this._onTouchMove, {
+      passive: false,
     });
-
-    this.canvas.addEventListener("touchend", () => {
-      this.isDragging = false;
-    });
+    this.canvas.addEventListener("touchend", this._onTouchEnd);
   }
 
   async initialize(): Promise<boolean> {
@@ -566,18 +583,20 @@ export class WebGPUFloorPlanRenderer {
         console.error("[WebGPU] Uncaptured error detected:", event.error);
       });
 
-      this.device.lost.then(async (info: { reason: string; message: string }) => {
-        console.warn(
-          `[WebGPU] GPUDevice lost (${info.reason}): ${info.message}`,
-        );
-        this.isDeviceLost = true;
-        this.cleanupGPUResources();
-        
-        if (info.reason !== "destroyed") {
-          console.info("[WebGPU] Attempting automatic device recovery...");
-          await this.reinitialize();
-        }
-      });
+      this.device.lost.then(
+        async (info: { reason: string; message: string }) => {
+          console.warn(
+            `[WebGPU] GPUDevice lost (${info.reason}): ${info.message}`,
+          );
+          this.isDeviceLost = true;
+          this.cleanupGPUResources();
+
+          if (info.reason !== "destroyed") {
+            console.info("[WebGPU] Attempting automatic device recovery...");
+            await this.reinitialize();
+          }
+        },
+      );
 
       this.context = this.canvas.getContext(
         "webgpu",
@@ -668,13 +687,21 @@ export class WebGPUFloorPlanRenderer {
       size: mesh.vertices.byteLength,
       usage: BufferUsage.VERTEX | BufferUsage.COPY_DST,
     });
-    this.device.queue.writeBuffer(this.vertexBuffer!, 0, mesh.vertices as unknown as BufferSource);
+    this.device.queue.writeBuffer(
+      this.vertexBuffer!,
+      0,
+      mesh.vertices as unknown as BufferSource,
+    );
 
     this.indexBuffer = this.device.createBuffer({
       size: mesh.indices.byteLength,
       usage: BufferUsage.INDEX | BufferUsage.COPY_DST,
     });
-    this.device.queue.writeBuffer(this.indexBuffer!, 0, mesh.indices as unknown as BufferSource);
+    this.device.queue.writeBuffer(
+      this.indexBuffer!,
+      0,
+      mesh.indices as unknown as BufferSource,
+    );
   }
 
   render(): void {
@@ -814,6 +841,16 @@ export class WebGPUFloorPlanRenderer {
     if (this.visibilityHandler && typeof document !== "undefined") {
       document.removeEventListener("visibilitychange", this.visibilityHandler);
     }
+    // Remove all 9 canvas interaction listeners to prevent memory leaks
+    // when the floor plan viewer is mounted/unmounted multiple times.
+    this.canvas.removeEventListener("mousedown", this._onMouseDown);
+    this.canvas.removeEventListener("mousemove", this._onMouseMove);
+    this.canvas.removeEventListener("mouseup", this._onMouseUp);
+    this.canvas.removeEventListener("mouseleave", this._onMouseLeave);
+    this.canvas.removeEventListener("wheel", this._onWheel);
+    this.canvas.removeEventListener("touchstart", this._onTouchStart);
+    this.canvas.removeEventListener("touchmove", this._onTouchMove);
+    this.canvas.removeEventListener("touchend", this._onTouchEnd);
     this.cleanupGPUResources();
   }
 }


### PR DESCRIPTION
## Description

Fixes a memory leak in WebGPUFloorPlanRenderer where setupInteraction() attached **9 canvas event listeners** (mousedown, mousemove, mouseup, mouseleave, wheel, touchstart, touchmove, touchend) using anonymous arrow functions — making them impossible to remove later. The destroy() method only removed the visibilitychange listener on document, leaving all 9 canvas listeners permanently attached.

Each time the floor plan viewer component was mounted and unmounted, a new set of 9 orphaned listeners accumulated on the canvas element, causing:
- Cumulative memory leaks proportional to mount/unmount count
- Duplicated drag/zoom handlers that caused erratic camera behavior on the second and subsequent mounts

## Root Cause

setupInteraction() used anonymous arrow functions:
```ts
this.canvas.addEventListener('mousedown', (e) => { ... });
```
Anonymous functions have no stable reference, so removeEventListener cannot match and remove them.

## Fix

1. **Store each listener as a named bound class property** (_onMouseDown, _onMouseMove, etc.) initialized in the constructor before setupInteraction() is called.
2. **setupInteraction()** now registers listeners using those stable property references instead of anonymous functions. Touch listeners also correctly pass { passive: false } to allow preventDefault().
3. **destroy()** now calls removeEventListener for all 9 canvas event types using the same stable references.

## Changes

### Modified
- **src/lib/webgpu/floorPlanRenderer.ts**
  - Added 8 private named handler properties to the class.
  - Moved handler logic from anonymous closures into those properties (initialized in the constructor).
  - setupInteraction() simplified to register the named handlers.
  - destroy() removes all 9 canvas listeners before calling cleanupGPUResources().

### Added
- **src/__tests__/lib/webgpu/floorPlanRenderer.test.ts** — 5 unit tests verifying:
  - All 8 canvas listeners are registered on construction.
  - removeEventListener is called for each event type on destroy().
  - The **exact same function reference** that was added is the one removed.
  - The visibilitychange listener is removed from document on destroy().
  - Calling destroy() multiple times does not throw.

## Test Results

```
PASS src/__tests__/lib/webgpu/floorPlanRenderer.test.ts
  WebGPUFloorPlanRenderer — destroy() event listener cleanup
    ✓ registers all 8 canvas interaction listeners on construction
    ✓ calls removeEventListener for every canvas event type on destroy()
    ✓ removes exactly the same handler reference that was added
    ✓ removes the visibilitychange listener from document on destroy()
    ✓ does not throw when destroy() is called multiple times

Tests: 5 passed, 5 total
```

Fixes #1661


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved renderer cleanup by reliably removing canvas and page visibility event listeners when the renderer is destroyed.
  * Prevented errors when cleanup is triggered more than once.
  * Improved handling of unexpected graphics device loss by automatically restoring rendering when possible.
  * Preserved expected scrolling and touch interaction behavior.

* **Tests**
  * Added coverage for event registration, cleanup, handler matching, visibility changes, and repeated destruction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->