### PR TITLE
feat: add dynamic spatial attenuation for remote listeners (#1552)

### DIFF
--- a/src/__tests__/lib/spatial/RemoteListenerInterpolator.test.ts
+++ b/src/__tests__/lib/spatial/RemoteListenerInterpolator.test.ts
@@ -1,0 +1,34 @@
+import { calculateSpatialAttenuation } from "../../../lib/spatial/RemoteListenerInterpolator";
+
+describe("Dynamic Sound Effect Spatial Attenuation", () => {
+  it("should return full gain (1.0) when distance is exactly at refDistance (1m)", () => {
+    const gain = calculateSpatialAttenuation(1);
+    expect(gain).toBe(1.0);
+  });
+
+  it("should return full gain (1.0) when distance is inside refDistance (< 1m)", () => {
+    const gain = calculateSpatialAttenuation(0.5);
+    expect(gain).toBe(1.0);
+  });
+
+  it("should return 0.0 gain when distance is exactly at maxDistance (30m)", () => {
+    const gain = calculateSpatialAttenuation(30);
+    expect(gain).toBe(0.0);
+  });
+
+  it("should return 0.0 gain when distance exceeds maxDistance (> 30m)", () => {
+    const gain = calculateSpatialAttenuation(45);
+    expect(gain).toBe(0.0);
+  });
+
+  it("should correctly apply logarithmic inverse distance roll-off between boundaries", () => {
+    // At 2 meters: 1 / (1 + 1 * (2 - 1)) = 1/2 = 0.5
+    expect(calculateSpatialAttenuation(2)).toBe(0.5);
+
+    // At 5 meters: 1 / (1 + 1 * (5 - 1)) = 1/5 = 0.2
+    expect(calculateSpatialAttenuation(5)).toBe(0.2);
+
+    // At 11 meters: 1 / (1 + 1 * (11 - 1)) = 1/11 ≈ 0.0909
+    expect(calculateSpatialAttenuation(11)).toBe(0.0909);
+  });
+});

--- a/src/lib/spatial/RemoteListenerInterpolator.ts
+++ b/src/lib/spatial/RemoteListenerInterpolator.ts
@@ -125,3 +125,33 @@ export class RemoteListenerInterpolator {
     }
   }
 }
+
+// --- Spatial Attenuation Constants & Math ---
+export const REF_DISTANCE = 1.0; // Inner boundary (meters)
+export const MAX_DISTANCE = 30.0; // Outer boundary (meters)
+export const ROLLOFF_FACTOR = 1.0;
+
+/**
+ * Calculates the audio gain multiplier based on distance.
+ * Utilizes an inverse distance logarithmic attenuation curve.
+ * @param distance The physical distance between source and listener
+ * @returns A gain value between 0.0 and 1.0
+ */
+export function calculateSpatialAttenuation(distance: number): number {
+  // If the user is closer than the reference distance, play at full volume
+  if (distance <= REF_DISTANCE) {
+    return 1.0;
+  }
+
+  // If the user is further than the max distance, cut the sound completely
+  if (distance >= MAX_DISTANCE) {
+    return 0.0;
+  }
+
+  // Apply the inverse distance attenuation formula
+  const gain =
+    REF_DISTANCE / (REF_DISTANCE + ROLLOFF_FACTOR * (distance - REF_DISTANCE));
+
+  // Return the gain rounded to 4 decimal places for clean audio processing
+  return Number(gain.toFixed(4));
+}


### PR DESCRIPTION
## Description

This PR implements distance-based logarithmic audio attenuation for WebRTC spatial voice. It adds the `calculateSpatialAttenuation` function to `RemoteListenerInterpolator.ts` utilizing an inverse distance formula, bounded by a 1m reference distance and a 30m maximum distance. A comprehensive unit test suite has also been added to validate the gain calculations.

## Related Issue

<!--
Please link to the issue here using the standard keywords.
Example: Fixes #123 or Closes #123
-->
Fixes #1552

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added distance-based spatial audio attenuation.
  * Sounds play at full volume within the reference distance, gradually decrease with distance, and become silent beyond the maximum range.

* **Tests**
  * Added coverage for boundary conditions, intermediate distances, and logarithmic volume roll-off behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->