### PR TITLE
feat: implement audio equalizer band preset switcher (#1547)

### DIFF
--- a/src/__tests__/hooks/useAudioEqualizerMemoryLeak.test.ts
+++ b/src/__tests__/hooks/useAudioEqualizerMemoryLeak.test.ts
@@ -1,5 +1,21 @@
-import { renderHook } from "@testing-library/react";
+import { renderHook, act } from "@testing-library/react";
 import { useAudioEqualizer } from "../../hooks/useAudioEqualizer";
+
+// Mock dependencies to avoid actual Web Audio API/WASM instantiation in test environments
+jest.mock("@/lib/wasm/audioEqualizer", () => ({
+  initEqualizer: jest.fn().mockResolvedValue(undefined),
+  updateBand: jest.fn().mockResolvedValue(undefined),
+  processAudioBlock: jest.fn(),
+  getFrequencyResponse: jest.fn().mockResolvedValue({}),
+  resetEqualizer: jest.fn(),
+  DEFAULT_BANDS: [
+    { frequency: 60, q: 1.4, gain: 0 },
+    { frequency: 250, q: 1.4, gain: 0 },
+    { frequency: 1000, q: 1.4, gain: 0 },
+    { frequency: 4000, q: 1.4, gain: 0 },
+    { frequency: 12000, q: 1.4, gain: 0 },
+  ],
+}));
 
 describe("useAudioEqualizer Memory Leak & Cleanup Suite (#1285)", () => {
   let mockDisconnect: jest.Mock;
@@ -27,5 +43,42 @@ describe("useAudioEqualizer Memory Leak & Cleanup Suite (#1285)", () => {
     unmount();
 
     expect(mockClose).toHaveBeenCalled();
+  });
+});
+
+describe("useAudioEqualizer Preset Logic (#1547)", () => {
+  beforeEach(() => {
+    // Clear localStorage before each test to ensure a clean slate
+    window.localStorage.clear();
+  });
+
+  it("should initialize with Flat preset or fallback to localStorage", async () => {
+    window.localStorage.setItem("eq_preset", "Bass Boost");
+
+    const { result } = renderHook(() => useAudioEqualizer());
+
+    expect(result.current.state.activePreset).toBe("Bass Boost");
+  });
+
+  it("should update state and save to localStorage when applyPreset is called", async () => {
+    const { result } = renderHook(() => useAudioEqualizer());
+
+    await act(async () => {
+      await result.current.applyPreset("Voice Clarity");
+    });
+
+    expect(result.current.state.activePreset).toBe("Voice Clarity");
+    expect(window.localStorage.getItem("eq_preset")).toBe("Voice Clarity");
+  });
+
+  it("should switch to Custom preset when a manual band adjustment is made", async () => {
+    const { result } = renderHook(() => useAudioEqualizer());
+
+    await act(async () => {
+      await result.current.setBand(0, 5);
+    });
+
+    expect(result.current.state.activePreset).toBe("Custom");
+    expect(window.localStorage.getItem("eq_preset")).toBe("Custom");
   });
 });

--- a/src/components/audio/AudioEqualizer.tsx
+++ b/src/components/audio/AudioEqualizer.tsx
@@ -18,7 +18,8 @@ export type EqPresetName =
   | "bass-boost"
   | "vocal-enhancer"
   | "treble-boost"
-  | "warm";
+  | "warm"
+  | "custom";
 
 export interface EqPreset {
   label: string;
@@ -54,6 +55,10 @@ export const EQ_PRESETS: Record<EqPresetName, EqPreset> = {
   warm: {
     label: "Warm",
     gains: [3, 2, 1, -1, -2],
+  },
+  custom: {
+    label: "Custom",
+    gains: [0, 0, 0, 0, 0],
   },
 };
 
@@ -148,6 +153,26 @@ export function AudioEqualizer({
     }
   }, []);
 
+  // Load from Local Storage on Mount
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const savedPreset = window.localStorage.getItem("webrtc_eq_preset") as EqPresetName;
+      const savedGains = window.localStorage.getItem("webrtc_eq_gains");
+      
+      if (savedPreset && EQ_PRESETS[savedPreset]) {
+        setEqPreset(savedPreset);
+      }
+      
+      if (savedGains) {
+        try {
+          setBandGains(JSON.parse(savedGains));
+        } catch (e) {}
+      } else if (savedPreset && savedPreset !== "custom") {
+        setBandGains(EQ_PRESETS[savedPreset].gains);
+      }
+    }
+  }, []);
+
   // Initialize Audio Context and BiquadFilterNode EQ chain on demand
   const initAudio = useCallback(() => {
     if (audioContextRef.current) return;
@@ -230,9 +255,17 @@ export function AudioEqualizer({
 
   // Handle Real-Time Gain Slider Drag with Smooth Audio Parameter Ramping
   const handleBandGainChange = (index: number, newGain: number) => {
+    setEqPreset("custom");
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("webrtc_eq_preset", "custom");
+    }
+
     setBandGains((prev) => {
       const next = [...prev];
       next[index] = newGain;
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem("webrtc_eq_gains", JSON.stringify(next));
+      }
       return next;
     });
 
@@ -257,21 +290,32 @@ export function AudioEqualizer({
 
   const handleEqPresetChange = (presetName: EqPresetName) => {
     setEqPreset(presetName);
-    const gains = EQ_PRESETS[presetName].gains;
-    setBandGains(gains);
+    
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("webrtc_eq_preset", presetName);
+    }
 
-    if (audioContextRef.current) {
-      const now = audioContextRef.current.currentTime;
-      eqFiltersRef.current.forEach((filter, i) => {
-        if (filter && filter.gain) {
-          const targetGain = gains[i] ?? 0;
-          if (typeof filter.gain.setTargetAtTime === "function") {
-            filter.gain.setTargetAtTime(targetGain, now, 0.015);
-          } else if (typeof filter.gain.setValueAtTime === "function") {
-            filter.gain.setValueAtTime(targetGain, now);
+    if (presetName !== "custom") {
+      const gains = EQ_PRESETS[presetName].gains;
+      setBandGains(gains);
+
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem("webrtc_eq_gains", JSON.stringify(gains));
+      }
+
+      if (audioContextRef.current) {
+        const now = audioContextRef.current.currentTime;
+        eqFiltersRef.current.forEach((filter, i) => {
+          if (filter && filter.gain) {
+            const targetGain = gains[i] ?? 0;
+            if (typeof filter.gain.setTargetAtTime === "function") {
+              filter.gain.setTargetAtTime(targetGain, now, 0.015);
+            } else if (typeof filter.gain.setValueAtTime === "function") {
+              filter.gain.setValueAtTime(targetGain, now);
+            }
           }
-        }
-      });
+        });
+      }
     }
   };
 

--- a/src/hooks/useAudioEqualizer.ts
+++ b/src/hooks/useAudioEqualizer.ts
@@ -12,12 +12,21 @@ import {
   type FrequencyResponse,
 } from "@/lib/wasm/audioEqualizer";
 
+// Standard preset gain configurations (assuming 10-band EQ)
+export const AUDIO_PRESETS: Record<string, number[]> = {
+  "Flat": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  "Voice Clarity": [-4, -2, 0, 2, 4, 4, 3, 1, 0, -2],
+  "Noise Suppression": [-6, -6, -3, 0, 2, 2, 0, -3, -6, -6],
+  "Bass Boost": [6, 5, 4, 2, 0, 0, 0, 0, 0, 0],
+};
+
 export type EqState = {
   bands: EqBand[];
   bypass: boolean;
   isReady: boolean;
   isProcessing: boolean;
   error: string | null;
+  activePreset: string;
 };
 
 export type UseAudioEqualizerReturn = {
@@ -29,6 +38,7 @@ export type UseAudioEqualizerReturn = {
     q: number,
     gain: number,
   ) => Promise<void>;
+  applyPreset: (presetName: string) => Promise<void>;
   toggleBypass: () => void;
   resetBands: () => Promise<void>;
   frequencyResponse: FrequencyResponse | null;
@@ -46,9 +56,12 @@ export function useAudioEqualizer(
     isReady: false,
     isProcessing: false,
     error: null,
+    activePreset: "Flat",
   });
+  
   const [frequencyResponse, setFrequencyResponse] =
     useState<FrequencyResponse | null>(null);
+  
   const bandsRef = useRef(initialBands);
   const sampleRateRef = useRef(sampleRate);
   const audioContextRef = useRef<AudioContext | null>(null);
@@ -70,10 +83,35 @@ export function useAudioEqualizer(
           }
         }
 
-        await initEqualizer(initialBands, sampleRate);
+        // Load preset from localStorage
+        let setupBands = initialBands;
+        let savedPreset = "Flat";
+        if (typeof window !== "undefined") {
+          savedPreset = window.localStorage.getItem("eq_preset") || "Flat";
+          if (AUDIO_PRESETS[savedPreset]) {
+            const gains = AUDIO_PRESETS[savedPreset];
+            setupBands = initialBands.map((b, i) => ({
+              ...b,
+              gain: gains[i] ?? 0,
+            }));
+          }
+        }
+
+        bandsRef.current = setupBands;
+        
+        if (mounted) {
+          setState((prev) => ({ 
+            ...prev, 
+            bands: setupBands, 
+            activePreset: savedPreset 
+          }));
+        }
+
+        await initEqualizer(setupBands, sampleRate);
+        
         if (mounted) {
           setState((prev) => ({ ...prev, isReady: true }));
-          const resp = await getFrequencyResponse(initialBands, sampleRate);
+          const resp = await getFrequencyResponse(setupBands, sampleRate);
           if (mounted) setFrequencyResponse(resp);
         }
       } catch (err) {
@@ -120,6 +158,46 @@ export function useAudioEqualizer(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const applyPreset = useCallback(async (presetName: string) => {
+    const gains = AUDIO_PRESETS[presetName];
+    if (!gains) return;
+
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("eq_preset", presetName);
+    }
+
+    const currentBands = bandsRef.current;
+    const updated = currentBands.map((b, i) => ({
+      ...b,
+      gain: gains[i] ?? 0,
+    }));
+
+    bandsRef.current = updated;
+    setState((prev) => ({ 
+      ...prev, 
+      bands: updated, 
+      isProcessing: true, 
+      activePreset: presetName 
+    }));
+
+    try {
+      // Sequentially update all nodes
+      for (let i = 0; i < updated.length; i++) {
+        await updateBand(i, updated[i].frequency, updated[i].q, updated[i].gain);
+      }
+      
+      const resp = await getFrequencyResponse(updated, sampleRateRef.current);
+      setFrequencyResponse(resp);
+    } catch (err) {
+      setState((prev) => ({
+        ...prev,
+        error: `Failed to apply preset: ${err instanceof Error ? err.message : String(err)}`,
+      }));
+    } finally {
+      setState((prev) => ({ ...prev, isProcessing: false }));
+    }
+  }, []);
+
   const setBand = useCallback(async (index: number, gain: number) => {
     const bands = bandsRef.current;
     if (index < 0 || index >= bands.length) return;
@@ -127,7 +205,16 @@ export function useAudioEqualizer(
     const updated = bands.map((b, i) => (i === index ? { ...b, gain } : b));
     bandsRef.current = updated;
 
-    setState((prev) => ({ ...prev, bands: updated, isProcessing: true }));
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("eq_preset", "Custom");
+    }
+
+    setState((prev) => ({ 
+      ...prev, 
+      bands: updated, 
+      isProcessing: true, 
+      activePreset: "Custom" 
+    }));
 
     try {
       await updateBand(index, bands[index].frequency, bands[index].q, gain);
@@ -151,7 +238,16 @@ export function useAudioEqualizer(
       );
       bandsRef.current = updated;
 
-      setState((prev) => ({ ...prev, bands: updated, isProcessing: true }));
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem("eq_preset", "Custom");
+      }
+
+      setState((prev) => ({ 
+        ...prev, 
+        bands: updated, 
+        isProcessing: true,
+        activePreset: "Custom" 
+      }));
 
       try {
         await updateBand(index, frequency, q, gain);
@@ -173,7 +269,17 @@ export function useAudioEqualizer(
 
   const resetBands = useCallback(async () => {
     bandsRef.current = DEFAULT_BANDS;
-    setState((prev) => ({ ...prev, bands: DEFAULT_BANDS, isProcessing: true }));
+    
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("eq_preset", "Flat");
+    }
+    
+    setState((prev) => ({ 
+      ...prev, 
+      bands: DEFAULT_BANDS, 
+      isProcessing: true,
+      activePreset: "Flat"
+    }));
 
     try {
       await initEqualizer(DEFAULT_BANDS, sampleRateRef.current);
@@ -211,6 +317,7 @@ export function useAudioEqualizer(
     state,
     setBand,
     setBandFull,
+    applyPreset,
     toggleBypass,
     resetBands,
     frequencyResponse,


### PR DESCRIPTION
## Description

This PR introduces an audio equalizer band preset switcher to `AudioEqualizer.tsx`, allowing users to select standard frequency profiles (e.g., 'Voice Clarity', 'Bass Boost'). The selected presets are wired to update the BiquadFilterNode gains in `useAudioEqualizer.ts` and are persisted to `localStorage` across sessions. Manual slider adjustments automatically switch the active preset to "Custom". Unit tests have also been expanded to validate preset initialization and state updates without memory leaks.

## Related Issue

<!--
Please link to the issue here using the standard keywords.
Example: Fixes #123 or Closes #123
-->
Fixes #1547

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting and applying audio equalizer presets.
  * Preset selections and custom band adjustments are now remembered between sessions.
  * Added a Custom preset that activates automatically when individual bands are adjusted.
  * Resetting the equalizer restores the Flat preset and default band levels.

* **Bug Fixes**
  * Improved preset initialization and fallback behavior when saved settings are unavailable or invalid.

* **Tests**
  * Added coverage for preset loading, persistence, custom adjustments, and default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->