### PR TITLE
 improve floor plan muted text dark mode contrast ratio for WCAG AA compliance

### DIFF
--- a/src/components/venue/floorplan/FloorPlan3D.tsx
+++ b/src/components/venue/floorplan/FloorPlan3D.tsx
@@ -184,22 +184,22 @@ export function FloorPlan3D({ venueId: _venueId, data }: FloorPlan3DProps) {
                   })`,
                 }}
               />
-              <span className="text-[9px] text-zinc-400">{label}</span>
+              <span className="text-[9px] text-zinc-200">{label}</span>
             </div>
           ))}
           <div className="flex items-center gap-1.5">
             <Power className="w-2.5 h-2.5 text-yellow-400" />
-            <span className="text-[9px] text-zinc-400">Power Outlet</span>
+            <span className="text-[9px] text-zinc-200">Power Outlet</span>
           </div>
         </div>
 
         {/* Stats overlay */}
         <div className="absolute top-3 right-3 bg-zinc-900/90 backdrop-blur-sm rounded-lg p-2 space-y-1">
-          <p className="text-[9px] text-zinc-400">
+          <p className="text-[9px] text-zinc-200">
             <span className="text-white font-bold">{powerSeats}</span> seats
             with power
           </p>
-          <p className="text-[9px] text-zinc-400">
+          <p className="text-[9px] text-zinc-200">
             <span className="text-white font-bold">{quietSeats}</span> quiet
             zone seats
           </p>
@@ -207,7 +207,7 @@ export function FloorPlan3D({ venueId: _venueId, data }: FloorPlan3DProps) {
       </div>
 
       <div className="p-3 text-center">
-        <p className="text-[10px] text-zinc-400">
+        <p className="text-[10px] text-zinc-200">
           Drag to rotate • Scroll to zoom •{" "}
           {useWebGPU
             ? "Hardware-accelerated via WebGPU"


### PR DESCRIPTION
Closes #1198

# Pull Request

## Description

This PR improves the dark mode contrast for muted labels/text rendered on the WebGPU floor plan canvas controls by replacing the `text-zinc-400` Tailwind CSS utility class with `text-zinc-200` to exceed a 4.5:1 contrast ratio.

### Changes
- **Client Components**: Changed text utility class from `text-zinc-400` to `text-zinc-200` for floor plan legend labels, stats labels, and instruction/footer text inside [FloorPlan3D.tsx](file:///d:/OpenSorce/WorkSphere/WorkSphere/src/components/venue/floorplan/FloorPlan3D.tsx).

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #1198

## Testing

Verified by running the Jest tests for the WebGPU floor plan renderer:
```bash
npm test webgpuFloorPlanRenderer.test.ts
```

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A - Minor UI/Layout contrast enhancement

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the contrast and readability of floor plan legend labels, statistics, and on-screen instructions in the 3D view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->