### PR TITLE
feat(backend): implement partition maintenance health monitor api and test coverage

### DIFF
--- a/src/_tests_/_lib/partitionMaintenance.test.ts
+++ b/src/_tests_/_lib/partitionMaintenance.test.ts
@@ -1,0 +1,31 @@
+import { checkPartitionHealth } from "../../lib/partitionMaintenance";
+import { prisma } from "../../lib/prisma";
+
+jest.mock("../prisma", () => ({
+  prisma: {
+    $queryRawUnsafe: jest.fn(),
+  },
+}));
+
+describe("checkPartitionHealth()", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return HEALTHY when all upcoming partitions exist", async () => {
+    (prisma.$queryRawUnsafe as jest.Mock).mockResolvedValue([
+      { relname: "PushNotificationLog_y2026m08", n_live_tup: 100 }
+    ]);
+
+    const report = await checkPartitionHealth();
+    expect(report.status).toBe("HEALTHY");
+    expect(report.partitions[0].exists).toBe(true);
+  });
+
+  it("should return CRITICAL when an upcoming partition is missing", async () => {
+    (prisma.$queryRawUnsafe as jest.Mock).mockResolvedValue([]);
+
+    const report = await checkPartitionHealth();
+    expect(report.status).toBe("CRITICAL");
+  });
+});

--- a/src/app/api/admin/system/partitions/route.ts
+++ b/src/app/api/admin/system/partitions/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { checkPartitionHealth } from "../../../../../lib/partitionMaintenance";
+
+export async function GET() {
+  try {
+    const healthReport = await checkPartitionHealth();
+    
+    const statusCode = healthReport.status === "CRITICAL" ? 500 : 200;
+    
+    return NextResponse.json(healthReport, { status: statusCode });
+  } catch (error) {
+    console.error("Failed to fetch partition health report:", error);
+    return NextResponse.json(
+      { error: "Internal Server Error monitoring partitions" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/partitionMaintenance.ts
+++ b/src/lib/partitionMaintenance.ts
@@ -45,3 +45,59 @@ export async function autoCreateUpcomingPartitions(): Promise<string[]> {
 
   return createdPartitions;
 }
+export interface PartitionHealthReport {
+  status: "HEALTHY" | "CRITICAL";
+  checkedAt: string;
+  partitions: {
+    name: string;
+    exists: boolean;
+    rowCount: number;
+  }[];
+}
+
+export async function checkPartitionHealth(): Promise<PartitionHealthReport> {
+  const now = new Date();
+  const partitionsReport: any[] = [];
+  let isCritical = false;
+
+  // Track the current month (offset 0) and the next month (offset 1)
+  for (let offset = 0; offset <= 1; offset++) {
+    const targetDate = new Date(now.getFullYear(), now.getMonth() + offset, 1);
+    const year = targetDate.getFullYear();
+    const month = String(targetDate.getMonth() + 1).padStart(2, "0");
+    const partitionName = `PushNotificationLog_y${year}m${month}`;
+
+    try {
+      // Query PostgreSQL system catalogs to verify if the partition sub-table exists
+      const result = await prisma.$queryRawUnsafe<{ relname: string; n_live_tup: number }[]>(`
+        SELECT relname, n_live_tup::int as n_live_tup
+        FROM pg_stat_user_tables 
+        WHERE relname = '${partitionName}'
+        LIMIT 1;
+      `);
+
+      const exists = result && result.length > 0;
+      const rowCount = exists ? (result[0] as any).n_live_tup : 0;
+
+      // If next month's partition (offset 1) is missing, mark the state as CRITICAL
+      if (offset === 1 && !exists) {
+        isCritical = true;
+      }
+
+      partitionsReport.push({
+        name: partitionName,
+        exists,
+        rowCount,
+      });
+    } catch (error) {
+      console.error(`Error checking status for table partition ${partitionName}:`, error);
+      isCritical = true;
+    }
+  }
+
+  return {
+    status: isCritical ? "CRITICAL" : "HEALTHY",
+    checkedAt: new Date().toISOString(),
+    partitions: partitionsReport,
+  };
+}


### PR DESCRIPTION
## Description
Implements a partition maintenance health monitoring utility function and pairs it with an admin system API endpoint at `/api/admin/system/partitions` to assess database readiness for upcoming months.

## Related Issue
Fixes #1553

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint for monitoring notification log partition health.
  * Reports partition status, existence, row counts, and the time of the health check.
  * Returns a critical status when the upcoming partition is missing or monitoring fails.

* **Tests**
  * Added coverage for healthy and critical partition health scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->