### PR TITLE
fix: prevent NaN velocity on initial hover movement 

### DIFF
--- a/src/__tests__/hooks/useHoverPredictor.test.tsx
+++ b/src/__tests__/hooks/useHoverPredictor.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { render, act, fireEvent } from "@testing-library/react";
+import { useHoverPredictor } from "../../hooks/useHoverPredictor";
+
+function TestComponent({ onPredict }: { onPredict: () => void }) {
+  const ref = useHoverPredictor({
+    onPredict,
+    hoverTimeThreshold: 100,
+  });
+
+  return <div data-testid="target" ref={ref} />;
+}
+
+describe("useHoverPredictor", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("does not predict on the initial mouse movement event", () => {
+    const onPredict = jest.fn();
+
+    const { getByTestId } = render(<TestComponent onPredict={onPredict} />);
+
+    const target = getByTestId("target");
+
+    act(() => {
+      fireEvent.mouseEnter(target);
+    });
+
+    act(() => {
+      fireEvent.mouseMove(target, {
+        clientX: 100,
+        clientY: 100,
+      });
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    expect(onPredict).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useHoverPredictor.ts
+++ b/src/hooks/useHoverPredictor.ts
@@ -36,7 +36,19 @@ export function useHoverPredictor({
     (e: MouseEvent) => {
       if (hasPredictedRef.current) return;
 
-      const newPoint = { x: e.clientX, y: e.clientY, time: Date.now() };
+      const newPoint = {
+        x: e.clientX,
+        y: e.clientY,
+        time: Date.now(),
+      };
+
+      // First mouse movement: initialize previous point and exit.
+      // No velocity can be calculated yet.
+      if (pointsRef.current.length === 0) {
+        pointsRef.current = [newPoint];
+        return;
+      }
+
       pointsRef.current.push(newPoint);
 
       // Keep only last 5 points


### PR DESCRIPTION
## Summary
- Initialize the previous mouse position on the first `mousemove` event.
- Prevent velocity calculation on the initial movement.
- Preserve existing behavior for subsequent events.
- Add a unit test to verify that the initial mouse movement does not trigger prediction.

Fixes  #1394

## Testing

- [x] Unit test added for the initial mouse movement event.
- [x] Verified no prediction occurs on the first `mousemove`.
- [x] Ran `npm test -- useHoverPredictor`. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hover movement tracking by safely handling the first mouse movement before calculating hover predictions.

* **Tests**
  * Added automated coverage to verify that predictions are not triggered prematurely during initial hover movement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->