### PR TITLE
feat: add student verification tooltip and renewal badge

### DIFF
--- a/src/__tests__/components/StudentVerificationBadge.test.tsx
+++ b/src/__tests__/components/StudentVerificationBadge.test.tsx
@@ -1,10 +1,16 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { StudentVerificationBadge } from "@/components/student/StudentVerificationBadge";
 
 beforeEach(() => {
   jest.clearAllMocks();
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date("2026-07-24T12:00:00.000Z"));
+});
+
+afterEach(() => {
+  jest.useRealTimers();
 });
 
 it("renders nothing while loading", () => {
@@ -23,7 +29,9 @@ it("shows verified badge when API returns verified=true", async () => {
   await waitFor(() => {
     expect(screen.getByText("Verified Student")).toBeInTheDocument();
   });
-  expect(screen.getByText("Verified Student").closest("div")).toHaveClass("bg-green-500/10");
+  expect(screen.getByText("Verified Student").closest("div")).toHaveClass(
+    "bg-green-500/10",
+  );
 });
 
 it("shows unverified badge when API returns verified=false", async () => {
@@ -59,4 +67,128 @@ it("shows unverified badge on fetch error", async () => {
   await waitFor(() => {
     expect(screen.getByText("Student Not Verified")).toBeInTheDocument();
   });
+});
+
+it("shows tooltip on hover when verification info is present", async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    json: async () => ({
+      verified: true,
+      expiresAt: "2027-01-01T00:00:00.000Z",
+      commitmentHash: "0x84fae75891cd",
+    }),
+  });
+
+  render(<StudentVerificationBadge />);
+
+  await waitFor(() => {
+    expect(screen.getByText("Verified Student")).toBeInTheDocument();
+  });
+
+  const badge = screen.getByText("Verified Student").closest("div");
+  fireEvent.mouseEnter(badge!);
+
+  await waitFor(() => {
+    expect(screen.getByText(/Expires:/)).toBeInTheDocument();
+  });
+});
+
+it("shows expiration date and shortened hash in tooltip", async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    json: async () => ({
+      verified: true,
+      expiresAt: "2027-01-01T00:00:00.000Z",
+      commitmentHash: "0x84fae75891cd22223333444455556666",
+    }),
+  });
+
+  render(<StudentVerificationBadge />);
+
+  await waitFor(() => {
+    expect(screen.getByText("Verified Student")).toBeInTheDocument();
+  });
+
+  const badgeDiv = screen.getByText("Verified Student").closest("div")!;
+  fireEvent.mouseEnter(badgeDiv);
+
+  await waitFor(() => {
+    expect(screen.getByText("Expires: Jan 1, 2027")).toBeInTheDocument();
+  });
+  expect(screen.getByText("Proof: 0x84fa...6666")).toBeInTheDocument();
+});
+
+it("shows 'Renew Soon' badge when expiration is within 14 days", async () => {
+  // Current time is set to 2026-07-24T12:00:00.000Z via fake timers
+  global.fetch = jest.fn().mockResolvedValue({
+    json: async () => ({
+      verified: true,
+      expiresAt: "2026-08-01T00:00:00.000Z", // 8 days away
+    }),
+  });
+
+  render(<StudentVerificationBadge />);
+
+  await waitFor(() => {
+    expect(screen.getByText("Renew Soon")).toBeInTheDocument();
+  });
+});
+
+it("shows expired styling when verification has expired", async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    json: async () => ({
+      verified: true,
+      expiresAt: "2026-07-01T00:00:00.000Z", // Past date
+    }),
+  });
+
+  render(<StudentVerificationBadge />);
+
+  await waitFor(() => {
+    expect(screen.getByText("Student Not Verified")).toBeInTheDocument();
+  });
+});
+
+it("handles missing expiration gracefully", async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    json: async () => ({
+      verified: true,
+      commitmentHash: "0x1234567890abcdef",
+    }),
+  });
+
+  render(<StudentVerificationBadge />);
+
+  await waitFor(() => {
+    expect(screen.getByText("Verified Student")).toBeInTheDocument();
+  });
+
+  const badgeDiv2 = screen.getByText("Verified Student").closest("div")!;
+  fireEvent.mouseEnter(badgeDiv2);
+
+  await waitFor(() => {
+    expect(screen.getByText("Proof: 0x1234...cdef")).toBeInTheDocument();
+  });
+  expect(screen.queryByText(/Expires:/)).not.toBeInTheDocument();
+});
+
+it("handles missing commitment hash gracefully", async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    json: async () => ({
+      verified: true,
+      expiresAt: "2027-01-01T00:00:00.000Z",
+    }),
+  });
+
+  render(<StudentVerificationBadge />);
+
+  await waitFor(() => {
+    expect(screen.getByText("Verified Student")).toBeInTheDocument();
+  });
+
+  const badgeDiv3 = screen.getByText("Verified Student").closest("div")!;
+  fireEvent.mouseEnter(badgeDiv3);
+
+  await waitFor(() => {
+    expect(screen.getByText("Expires: Jan 1, 2027")).toBeInTheDocument();
+  });
+  expect(screen.queryByText(/Proof:/)).not.toBeInTheDocument();
 });

--- a/src/components/student/StudentVerificationBadge.tsx
+++ b/src/components/student/StudentVerificationBadge.tsx
@@ -8,10 +8,33 @@ interface StudentVerificationBadgeProps {
   refreshKey?: number;
 }
 
+interface VerificationResponse {
+  verified: boolean;
+  expiresAt?: string;
+  commitmentHash?: string;
+}
+
+function shortenHash(hash?: string) {
+  if (!hash || hash.length < 10) return hash;
+  return `${hash.slice(0, 6)}...${hash.slice(-4)}`;
+}
+
+function formatDate(isoStr?: string) {
+  if (!isoStr) return "";
+  const d = new Date(isoStr);
+  if (isNaN(d.getTime())) return "";
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(d);
+}
+
 export function StudentVerificationBadge({
   refreshKey,
 }: StudentVerificationBadgeProps) {
-  const [verified, setVerified] = useState<boolean | null>(null);
+  const [data, setData] = useState<VerificationResponse | null>(null);
+  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -19,10 +42,10 @@ export function StudentVerificationBadge({
     async function fetchStatus() {
       try {
         const res = await fetch("/api/user/verify-student");
-        const data = await res.json();
-        if (!cancelled) setVerified(data.verified);
+        const json = await res.json();
+        if (!cancelled) setData(json);
       } catch {
-        if (!cancelled) setVerified(false);
+        if (!cancelled) setData({ verified: false });
       }
     }
 
@@ -32,21 +55,85 @@ export function StudentVerificationBadge({
     };
   }, [refreshKey]);
 
-  if (verified === null) return null;
+  if (!data) return null;
 
-  if (verified) {
-    return (
-      <div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-green-500/10 border border-green-500/20 text-green-700 dark:text-green-400 text-xs font-semibold">
-        <BadgeCheck className="w-3.5 h-3.5" />
-        <span>Verified Student</span>
-      </div>
-    );
+  let isExpired = false;
+  let isExpiringSoon = false;
+
+  if (data.expiresAt) {
+    const expires = new Date(data.expiresAt);
+    if (!isNaN(expires.getTime())) {
+      const now = new Date();
+      const diffTime = expires.getTime() - now.getTime();
+      const diffDays = diffTime / (1000 * 60 * 60 * 24);
+
+      if (diffDays < 0) {
+        isExpired = true;
+      } else if (diffDays <= 14) {
+        isExpiringSoon = true;
+      }
+    }
   }
 
-  return (
+  const unverifiedBadge = (
     <div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400 text-xs font-medium">
       <GraduationCap className="w-3.5 h-3.5" />
       <span>Student Not Verified</span>
+    </div>
+  );
+
+  if (!data.verified || isExpired) {
+    return unverifiedBadge;
+  }
+
+  const badgeContent = (
+    <div
+      className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-green-500/10 border border-green-500/20 text-green-700 dark:text-green-400 text-xs font-semibold cursor-help"
+      tabIndex={0}
+      onMouseEnter={() => setIsTooltipOpen(true)}
+      onMouseLeave={() => setIsTooltipOpen(false)}
+      onFocus={() => setIsTooltipOpen(true)}
+      onBlur={() => setIsTooltipOpen(false)}
+      aria-describedby="student-verification-tooltip"
+    >
+      <BadgeCheck className="w-3.5 h-3.5" />
+      <span>Verified Student</span>
+    </div>
+  );
+
+  const hasTooltipInfo = !!(data.expiresAt || data.commitmentHash);
+
+  return (
+    <div className="relative flex items-center gap-2">
+      {badgeContent}
+
+      {hasTooltipInfo && isTooltipOpen && (
+        <div
+          id="student-verification-tooltip"
+          role="tooltip"
+          className="absolute top-full mt-2 left-1/2 -translate-x-1/2 z-50 px-3 py-2 text-sm text-zinc-700 dark:text-zinc-300 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-md shadow-md w-max flex flex-col gap-1"
+        >
+          <span className="font-semibold text-zinc-900 dark:text-zinc-100">
+            Verified Student
+          </span>
+          {data.expiresAt && (
+            <span className="text-xs">
+              Expires: {formatDate(data.expiresAt)}
+            </span>
+          )}
+          {data.commitmentHash && (
+            <span className="text-xs font-mono">
+              Proof: {shortenHash(data.commitmentHash)}
+            </span>
+          )}
+        </div>
+      )}
+
+      {isExpiringSoon && (
+        <div className="px-2 py-1 rounded-full bg-amber-500/10 border border-amber-500/20 text-amber-700 dark:text-amber-400 text-[10px] font-semibold whitespace-nowrap">
+          Renew Soon
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Description

This PR enhances the `StudentVerificationBadge` component by providing additional verification details through an accessible tooltip and introducing a renewal indicator for proofs approaching expiration.

### Changes

- Added a tooltip displaying the student verification expiration date.
- Displayed a shortened Zero-Knowledge (ZK) proof commitment hash within the tooltip.
- Added a **Renew Soon** badge when the verification proof expires within 14 days.
- Gracefully handled missing or invalid verification metadata without affecting the existing badge behavior.
- Added/updated unit tests covering tooltip rendering, expiration countdown logic, and edge cases.

## Related Issue

- Fixes #1560

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (not required)
- [ ] I have made corresponding changes to the documentation (not required)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (not applicable)

## Screenshots / Screen Recordings (if applicable)

### Verified Badge
Include a screenshot of the normal verified student badge.

### Tooltip
Include a screenshot showing:
- Verification expiration date
- Shortened ZK proof commitment hash

### Renew Soon Badge
Include a screenshot where the verification expires within 14 days and the **Renew Soon** badge is displayed.

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Student verification badges now show expiration status, including a “Renew Soon” indicator for verifications nearing expiration.
  * Hovering or focusing a verified badge displays available expiration and proof details.
  * Proof hashes are presented in a shortened, readable format.

* **Bug Fixes**
  * Expired verifications are now displayed as unverified.
  * Missing expiration or proof details are handled gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->