### PR TITLE
Fix: Clear PartySocket backoff timer and reconnect instantly on network regain

### DIFF
--- a/src/__tests__/lib/partySocketReconnect.test.ts
+++ b/src/__tests__/lib/partySocketReconnect.test.ts
@@ -133,10 +133,47 @@ describe("attachJitteredBackoff", () => {
     // Verify waitPromise did not resolve yet because the timeout was cleared by _disconnect
     // Since waitPromise resolves inside setTimeout which was cleared, it remains pending.
     // If we trigger _connect, it also clears any pending timeouts.
+jest.useRealTimers();
+  });
+
+  it("clears the pending backoff timer and reconnects immediately on online event", async () => {
+    jest.useFakeTimers();
+
+    let onlineHandler: (() => void) | undefined;
+    const originalAddEventListener = window.addEventListener;
+    window.addEventListener = jest.fn((event: string, cb: any) => {
+      if (event === "online") {
+        onlineHandler = cb;
+      }
+    }) as any;
+
+    const socket = {
+      _retryCount: 3,
+      _getNextDelay: () => 30_000,
+      _connect: jest.fn(),
+      _disconnect: jest.fn(),
+      _clearTimeouts: jest.fn(),
+      addEventListener: jest.fn(),
+    } as any;
+
+    attachJitteredBackoff(socket);
+
+    let resolved = false;
+    const waitPromise = socket._wait().then(() => {
+      resolved = true;
+    });
+
+    // Simulate the browser regaining network connection
+    onlineHandler?.();
+    await Promise.resolve();
+    await waitPromise;
+
+    expect(resolved).toBe(true);
+
+    window.addEventListener = originalAddEventListener;
     jest.useRealTimers();
   });
 });
-
 import { PartySocketReconnectManager } from "@/lib/partySocketReconnect";
 
 describe("PartySocketReconnectManager", () => {

--- a/src/lib/partySocketReconnect.ts
+++ b/src/lib/partySocketReconnect.ts
@@ -85,57 +85,73 @@ type DelaySocket = {
     event: string,
     callback: (...args: any[]) => void,
   ) => void;
-  __worksphereJitter?: boolean;
+__worksphereJitter?: boolean;
   __worksphereState?: ConnectionState;
+  __worksphereForceReconnect?: () => void;
 };
-
 /** Swap in jittered backoff on a live PartySocket instance (idempotent). */
 export function attachJitteredBackoff<T extends object>(socket: T): T {
   const s = socket as T & DelaySocket;
   if (s.__worksphereJitter) return socket;
 
-  let pendingTimeoutId: any = null;
+let pendingTimeoutId: any = null;
+  let pendingResolve: (() => void) | null = null;
   s.__worksphereState = ConnectionState.CLOSED;
-
   s._getNextDelay = function (this: DelaySocket) {
     return jitteredReconnectDelay(this._retryCount);
   };
 
-  s._wait = function (this: any) {
+s._wait = function (this: any) {
     if (pendingTimeoutId) {
       clearTimeout(pendingTimeoutId);
     }
     return new Promise<void>((resolve) => {
+      pendingResolve = resolve;
       pendingTimeoutId = setTimeout(() => {
         pendingTimeoutId = null;
+        pendingResolve = null;
         resolve();
       }, this._getNextDelay());
     });
   };
 
-  const originalClearTimeouts = s._clearTimeouts;
+  /** Skip any pending backoff sleep and reconnect right now. */
+  s.__worksphereForceReconnect = function (this: any) {
+    if (pendingTimeoutId) {
+      clearTimeout(pendingTimeoutId);
+      pendingTimeoutId = null;
+    }
+    if (pendingResolve) {
+      const resolve = pendingResolve;
+      pendingResolve = null;
+      resolve();
+    } else if (typeof this._connect === "function") {
+      this._connect();
+    }
+  };
+const originalClearTimeouts = s._clearTimeouts;
   s._clearTimeouts = function (this: any) {
     if (pendingTimeoutId) {
       clearTimeout(pendingTimeoutId);
       pendingTimeoutId = null;
     }
+    pendingResolve = null;
     if (originalClearTimeouts) {
       originalClearTimeouts.call(this);
     }
   };
-
-  const originalDisconnect = s._disconnect;
+const originalDisconnect = s._disconnect;
   s._disconnect = function (this: any, code?: number, reason?: string) {
     s.__worksphereState = ConnectionState.CLOSED;
     if (pendingTimeoutId) {
       clearTimeout(pendingTimeoutId);
       pendingTimeoutId = null;
     }
+    pendingResolve = null;
     if (originalDisconnect) {
       originalDisconnect.call(this, code, reason);
     }
   };
-
   const originalConnect = s._connect;
   if (originalConnect) {
     s._connect = function (this: any) {
@@ -154,7 +170,7 @@ export function attachJitteredBackoff<T extends object>(socket: T): T {
     };
   }
 
-  if (typeof s.addEventListener === "function") {
+if (typeof s.addEventListener === "function") {
     s.addEventListener("open", () => {
       s.__worksphereState = ConnectionState.CONNECTED;
     });
@@ -168,6 +184,13 @@ export function attachJitteredBackoff<T extends object>(socket: T): T {
     });
   }
 
+  if (typeof window !== "undefined") {
+    window.addEventListener("online", () => {
+      if (s.__worksphereState !== ConnectionState.CONNECTED) {
+        (s as any).__worksphereForceReconnect?.();
+      }
+    });
+  }
   s.__worksphereJitter = true;
   return socket;
 }


### PR DESCRIPTION
## Summary
Fixes #1435 — PartySocket was still waiting out its exponential backoff delay even after the browser's `online` event fired, causing a delayed reconnect instead of an immediate one.

## Changes
- Added an internal `__worksphereForceReconnect` method in `partySocketReconnect.ts` that clears any pending backoff timeout/promise and resolves it immediately (or calls `_connect()` directly if no timer is pending).
- Registered a `window` `online` event listener inside `attachJitteredBackoff` that calls `__worksphereForceReconnect` when the socket isn't already connected.
- Ensured `pendingResolve` is cleared alongside `pendingTimeoutId` in `_clearTimeouts` and `_disconnect` to avoid stale resolves.
- Added a unit test verifying that firing the `online` event resolves the pending `_wait()` immediately instead of waiting for the full backoff delay.

## Testing
- Added `it("clears the pending backoff timer and reconnects immediately on online event", ...)` in `partySocketReconnect.test.ts`.
- Ran existing test suite to confirm no regressions.

I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.

Hi @SatyamPandey-07 , could you please review this PR for a potential bonus label based on the metrics below? Thanks!
<img width="662" height="301" alt="labels" src="https://github.com/user-attachments/assets/85a9208b-ed39-494d-96fd-8653e67b1869" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved socket reconnection behavior when network connectivity is restored.
  - Pending reconnect delays are now canceled, allowing connections to resume promptly after the browser comes back online.
  - Prevented stale reconnection waits from completing after connection state changes.
- **Tests**
  - Added coverage verifying immediate reconnection when the browser’s online event fires.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->