### PR TITLE
fix: restore WebGL canvas buffer with devicePixelRatio on retina

### DIFF
--- a/src/__tests__/components/MapWebGLContextLost.test.tsx
+++ b/src/__tests__/components/MapWebGLContextLost.test.tsx
@@ -50,6 +50,7 @@ describe("WebGL Context Lost & Restoration Manager (#909)", () => {
       createBuffer: jest.fn().mockReturnValue({}),
       bindBuffer: jest.fn(),
       bufferData: jest.fn(),
+      viewport: jest.fn(),
       ARRAY_BUFFER: 0x8892,
       STATIC_DRAW: 0x88e4,
     } as unknown as WebGLRenderingContext;
@@ -65,5 +66,37 @@ describe("WebGL Context Lost & Restoration Manager (#909)", () => {
     expect(mockGl.bindBuffer).toHaveBeenCalled();
     expect(mockGl.bufferData).toHaveBeenCalled();
     expect(buffers.positionBuffer).toBeDefined();
+  });
+
+  it("reallocates retina drawing buffer when canvas is passed on restore", () => {
+    Object.defineProperty(window, "devicePixelRatio", {
+      configurable: true,
+      value: 2,
+    });
+
+    const canvas = document.createElement("canvas");
+    Object.defineProperty(canvas, "clientWidth", {
+      configurable: true,
+      value: 400,
+    });
+    Object.defineProperty(canvas, "clientHeight", {
+      configurable: true,
+      value: 300,
+    });
+
+    const mockGl = {
+      createBuffer: jest.fn().mockReturnValue({}),
+      bindBuffer: jest.fn(),
+      bufferData: jest.fn(),
+      viewport: jest.fn(),
+      ARRAY_BUFFER: 0x8892,
+      STATIC_DRAW: 0x88e4,
+    } as unknown as WebGLRenderingContext;
+
+    reinitializeWebGLBuffers(mockGl, [[1, 2, 0.5]], canvas);
+
+    expect(canvas.width).toBe(800);
+    expect(canvas.height).toBe(600);
+    expect(mockGl.viewport).toHaveBeenCalledWith(0, 0, 800, 600);
   });
 });

--- a/src/__tests__/lib/WebGLContextRecoveryManager.test.ts
+++ b/src/__tests__/lib/WebGLContextRecoveryManager.test.ts
@@ -50,8 +50,22 @@ describe("WebGLContextRecoveryManager", () => {
 
   it("should execute onRestore callback when webglcontextrestored is fired and show success state", () => {
     // Mock getContext to avoid throwing in jsdom environment
-    const mockContext = {} as any;
+    const mockContext = {
+      viewport: jest.fn(),
+    } as any;
     jest.spyOn(canvas, "getContext").mockReturnValue(mockContext);
+    Object.defineProperty(canvas, "clientWidth", {
+      configurable: true,
+      value: 800,
+    });
+    Object.defineProperty(canvas, "clientHeight", {
+      configurable: true,
+      value: 450,
+    });
+    Object.defineProperty(window, "devicePixelRatio", {
+      configurable: true,
+      value: 2,
+    });
 
     const manager = new WebGLContextRecoveryManager(canvas, { onRestore });
 
@@ -68,6 +82,9 @@ describe("WebGLContextRecoveryManager", () => {
     });
     canvas.dispatchEvent(restoreEvent);
 
+    expect(mockContext.viewport).toHaveBeenCalledWith(0, 0, 1600, 900);
+    expect(canvas.width).toBe(1600);
+    expect(canvas.height).toBe(900);
     expect(onRestore).toHaveBeenCalledWith(mockContext);
 
     const banner = document.getElementById("webgl-recovery-banner");

--- a/src/__tests__/lib/canvasBufferSize.test.ts
+++ b/src/__tests__/lib/canvasBufferSize.test.ts
@@ -1,0 +1,78 @@
+import { allocateCanvasDrawingBuffer } from "../../lib/webgl/canvasBufferSize";
+
+describe("allocateCanvasDrawingBuffer (#1030)", () => {
+  const originalDpr = window.devicePixelRatio;
+
+  afterEach(() => {
+    Object.defineProperty(window, "devicePixelRatio", {
+      configurable: true,
+      value: originalDpr,
+    });
+  });
+
+  it("multiplies CSS size by devicePixelRatio on high-DPI displays", () => {
+    Object.defineProperty(window, "devicePixelRatio", {
+      configurable: true,
+      value: 2,
+    });
+
+    const canvas = document.createElement("canvas");
+    Object.defineProperty(canvas, "clientWidth", {
+      configurable: true,
+      value: 800,
+    });
+    Object.defineProperty(canvas, "clientHeight", {
+      configurable: true,
+      value: 450,
+    });
+
+    const result = allocateCanvasDrawingBuffer(canvas);
+
+    expect(result.dpr).toBe(2);
+    expect(result.width).toBe(1600);
+    expect(result.height).toBe(900);
+    expect(canvas.width).toBe(1600);
+    expect(canvas.height).toBe(900);
+  });
+
+  it("uses explicit CSS dimensions when provided", () => {
+    Object.defineProperty(window, "devicePixelRatio", {
+      configurable: true,
+      value: 2.5,
+    });
+
+    const canvas = document.createElement("canvas");
+    const result = allocateCanvasDrawingBuffer(canvas, 400, 300);
+
+    expect(result.width).toBe(1000);
+    expect(result.height).toBe(750);
+    expect(canvas.width).toBe(1000);
+    expect(canvas.height).toBe(750);
+  });
+
+  it("does not double-scale when client size is unavailable", () => {
+    Object.defineProperty(window, "devicePixelRatio", {
+      configurable: true,
+      value: 2,
+    });
+
+    const canvas = document.createElement("canvas");
+    canvas.width = 1600;
+    canvas.height = 900;
+    Object.defineProperty(canvas, "clientWidth", {
+      configurable: true,
+      value: 0,
+    });
+    Object.defineProperty(canvas, "clientHeight", {
+      configurable: true,
+      value: 0,
+    });
+
+    const result = allocateCanvasDrawingBuffer(canvas);
+
+    expect(result.width).toBe(1600);
+    expect(result.height).toBe(900);
+    expect(canvas.width).toBe(1600);
+    expect(canvas.height).toBe(900);
+  });
+});

--- a/src/components/venue/floorplan/FloorPlan3D.tsx
+++ b/src/components/venue/floorplan/FloorPlan3D.tsx
@@ -13,6 +13,8 @@ import {
   WebGPUFloorPlanRenderer,
   type FloorPlanData,
 } from "@/lib/webgpu/floorPlanRenderer";
+import { allocateCanvasDrawingBuffer } from "@/lib/webgl/canvasBufferSize";
+import { attachWebGLContextRecovery } from "@/lib/webgl/contextManager";
 
 interface FloorPlan3DProps {
   venueId: string;
@@ -31,6 +33,7 @@ export function FloorPlan3D({ venueId: _venueId, data }: FloorPlan3DProps) {
     const canvas = canvasRef.current;
     const renderer = new WebGPUFloorPlanRenderer(canvas);
     rendererRef.current = renderer;
+    let detachRecovery: (() => void) | null = null;
 
     renderer.initialize().then((success) => {
       if (success) {
@@ -39,10 +42,15 @@ export function FloorPlan3D({ venueId: _venueId, data }: FloorPlan3DProps) {
         renderer.startRenderLoop();
       } else {
         renderWebGLFallback(canvas, data);
+        // Reallocate DPR-correct buffers after context loss on Retina (#1030)
+        detachRecovery = attachWebGLContextRecovery(canvas, () => {
+          renderWebGLFallback(canvas, data);
+        });
       }
     });
 
     return () => {
+      detachRecovery?.();
       renderer.destroy();
     };
   }, [data]);
@@ -224,6 +232,14 @@ function renderWebGLFallback(
 ): void {
   const gl = canvas.getContext("webgl2");
   if (!gl) return;
+
+  // CSS size × devicePixelRatio so Retina restores are sharp (#1030)
+  const { width, height } = allocateCanvasDrawingBuffer(
+    canvas,
+    canvas.clientWidth || 800,
+    canvas.clientHeight || 450,
+  );
+  gl.viewport(0, 0, width, height);
 
   gl.clearColor(0.08, 0.08, 0.1, 1.0);
   gl.enable(gl.DEPTH_TEST);

--- a/src/lib/webgl/WebGLContextRecoveryManager.ts
+++ b/src/lib/webgl/WebGLContextRecoveryManager.ts
@@ -6,6 +6,8 @@
  * and displaying a premium, non-intrusive recovery progress banner to the user.
  */
 
+import { allocateCanvasDrawingBuffer } from "./canvasBufferSize";
+
 export interface WebGLContextRecoveryOptions {
   onLost?: () => void;
   onRestore: (gl: WebGLRenderingContext | WebGL2RenderingContext) => void;
@@ -104,6 +106,10 @@ export class WebGLContextRecoveryManager {
 
     if (gl) {
       try {
+        // Retina / high-DPI: rebuild the drawing buffer at CSS size × dpr
+        // before shaders/buffers are reallocated (#1030).
+        const { width, height } = allocateCanvasDrawingBuffer(this.canvas);
+        gl.viewport(0, 0, width, height);
         this.onRestore(gl);
       } catch (err) {
         console.error(

--- a/src/lib/webgl/canvasBufferSize.ts
+++ b/src/lib/webgl/canvasBufferSize.ts
@@ -1,0 +1,62 @@
+/**
+ * High-DPI (Retina) canvas drawing-buffer sizing for WebGL recovery (#1030).
+ *
+ * After a context-lost restore, browsers may leave the drawing buffer at CSS
+ * pixel size. Multiplying by devicePixelRatio reallocates the correct buffer
+ * so the viewport is not blurry / quarter-sized on dpr >= 2 displays.
+ */
+
+export type CanvasBufferSize = {
+  width: number;
+  height: number;
+  dpr: number;
+};
+
+/**
+ * Reallocate the canvas backing store as CSS size × devicePixelRatio.
+ * Returns the buffer dimensions used for gl.viewport / uniforms.
+ */
+export function allocateCanvasDrawingBuffer(
+  canvas: HTMLCanvasElement,
+  cssWidth?: number,
+  cssHeight?: number,
+): CanvasBufferSize {
+  const dpr =
+    typeof window !== "undefined" && window.devicePixelRatio > 0
+      ? window.devicePixelRatio
+      : 1;
+
+  const hasExplicitW = cssWidth != null && cssWidth > 0;
+  const hasExplicitH = cssHeight != null && cssHeight > 0;
+  const hasClientW = canvas.clientWidth > 0;
+  const hasClientH = canvas.clientHeight > 0;
+
+  // Not laid out and no explicit CSS size — keep current buffer; do not
+  // multiply an already-scaled buffer by dpr again on a second restore.
+  if (!hasExplicitW && !hasClientW && !hasExplicitH && !hasClientH) {
+    return {
+      width: Math.max(1, canvas.width || 1),
+      height: Math.max(1, canvas.height || 1),
+      dpr,
+    };
+  }
+
+  const displayWidth = Math.max(
+    1,
+    Math.round(hasExplicitW ? cssWidth! : hasClientW ? canvas.clientWidth : 1),
+  );
+  const displayHeight = Math.max(
+    1,
+    Math.round(
+      hasExplicitH ? cssHeight! : hasClientH ? canvas.clientHeight : 1,
+    ),
+  );
+
+  const width = Math.max(1, Math.round(displayWidth * dpr));
+  const height = Math.max(1, Math.round(displayHeight * dpr));
+
+  if (canvas.width !== width) canvas.width = width;
+  if (canvas.height !== height) canvas.height = height;
+
+  return { width, height, dpr };
+}

--- a/src/lib/webgl/contextManager.ts
+++ b/src/lib/webgl/contextManager.ts
@@ -6,6 +6,9 @@
  * WebGL buffer attributes upon context restoration.
  */
 
+import { allocateCanvasDrawingBuffer } from "./canvasBufferSize";
+import { WebGLContextRecoveryManager } from "./WebGLContextRecoveryManager";
+
 export interface WebGLBufferAttributes {
   positionBuffer?: WebGLBuffer | null;
   colorBuffer?: WebGLBuffer | null;
@@ -15,7 +18,14 @@ export interface WebGLBufferAttributes {
 export function reinitializeWebGLBuffers(
   gl: WebGLRenderingContext | WebGL2RenderingContext,
   points: Array<[number, number, number?]>,
+  canvas?: HTMLCanvasElement,
 ): WebGLBufferAttributes {
+  // High-DPI recovery: size the drawing buffer with devicePixelRatio (#1030)
+  if (canvas) {
+    const { width, height } = allocateCanvasDrawingBuffer(canvas);
+    gl.viewport(0, 0, width, height);
+  }
+
   const positionBuffer = gl.createBuffer();
   gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
 
@@ -26,8 +36,6 @@ export function reinitializeWebGLBuffers(
 
   return { positionBuffer };
 }
-
-import { WebGLContextRecoveryManager } from "./WebGLContextRecoveryManager";
 
 export function attachWebGLContextRecovery(
   canvas: HTMLCanvasElement,


### PR DESCRIPTION
## Summary
- Reallocate the canvas drawing buffer as CSS size × `window.devicePixelRatio` on WebGL context restore so Retina/high-DPI viewports are not blurry or quarter-sized
- Wire the same sizing into the floor-plan WebGL fallback and attach context recovery
- Add unit coverage for DPR buffer sizing and restore viewport
## Test plan
- [ ] Open floor plan visualizer on a Retina / `devicePixelRatio >= 2` display
- [ ] Trigger WebGL context loss and confirm restore is sharp and full-size
- [ ] `npx jest src/__tests__/lib/canvasBufferSize.test.ts src/__tests__/lib/WebGLContextRecoveryManager.test.ts src/__tests__/components/MapWebGLContextLost.test.tsx --no-coverage`
Closes #1030
I am attaching the screenshot showing all test are passing
<img width="648" height="143" alt="Screenshot 2026-07-24 at 11 19 43 PM" src="https://github.com/user-attachments/assets/9e50d330-3dbc-406f-a614-da2e9a2e84f8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved WebGL rendering on high-DPI displays with correctly scaled canvas buffers and viewports.
  * Added automatic WebGL context recovery for 3D floor plans, restoring rendering after context loss.

* **Bug Fixes**
  * Prevented incorrect canvas sizing and double-scaling during WebGL restoration.
  * Ensured rendering resumes with the correct dimensions after recovery.

* **Tests**
  * Added coverage for high-DPI sizing, viewport updates, and WebGL context restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->