### PR TITLE
feat: partition push notification logs by month

### DIFF
--- a/prisma/migrations/20260723000000_partition_push_notification_log/migration.sql
+++ b/prisma/migrations/20260723000000_partition_push_notification_log/migration.sql
@@ -1,52 +1,107 @@
--- CreateTable
-CREATE TABLE "PushNotificationLog_Partitioned" (
-    "id" TEXT NOT NULL,
-    "userId" TEXT NOT NULL,
-    "venueId" TEXT,
-    "title" TEXT NOT NULL,
-    "body" TEXT NOT NULL,
-    "status" TEXT NOT NULL,
-    "error" TEXT,
-    "read" BOOLEAN NOT NULL DEFAULT false,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+-- Issue #1571: range-partition PushNotificationLog by createdAt (monthly).
+--
+-- Prisma models the composite primary key in schema.prisma, while the native
+-- PostgreSQL partitioning DDL remains in this migration.
 
-    CONSTRAINT "PushNotificationLog_Partitioned_pkey" PRIMARY KEY ("id", "createdAt")
-) PARTITION BY RANGE ("createdAt");
-
--- AddForeignKey
-ALTER TABLE "PushNotificationLog_Partitioned" ADD CONSTRAINT "PushNotificationLog_Partitioned_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
--- Create monthly partitions for June, July, August, September, October 2026
-CREATE TABLE IF NOT EXISTS "PushNotificationLog_y2026m06" PARTITION OF "PushNotificationLog_Partitioned"
-    FOR VALUES FROM ('2026-06-01 00:00:00') TO ('2026-07-01 00:00:00');
-
-CREATE TABLE IF NOT EXISTS "PushNotificationLog_y2026m07" PARTITION OF "PushNotificationLog_Partitioned"
-    FOR VALUES FROM ('2026-07-01 00:00:00') TO ('2026-08-01 00:00:00');
-
-CREATE TABLE IF NOT EXISTS "PushNotificationLog_y2026m08" PARTITION OF "PushNotificationLog_Partitioned"
-    FOR VALUES FROM ('2026-08-01 00:00:00') TO ('2026-09-01 00:00:00');
-
-CREATE TABLE IF NOT EXISTS "PushNotificationLog_y2026m09" PARTITION OF "PushNotificationLog_Partitioned"
-    FOR VALUES FROM ('2026-09-01 00:00:00') TO ('2026-10-01 00:00:00');
-
-CREATE TABLE IF NOT EXISTS "PushNotificationLog_y2026m10" PARTITION OF "PushNotificationLog_Partitioned"
-    FOR VALUES FROM ('2026-10-01 00:00:00') TO ('2026-11-01 00:00:00');
-
--- Migrate any existing records if table exists
 DO $$
+DECLARE
+    existing_kind "char";
+    month_start DATE;
+    month_end DATE;
+    partition_name TEXT;
 BEGIN
-    IF EXISTS (SELECT FROM pg_tables WHERE schemaname = 'public' AND tablename = 'PushNotificationLog') THEN
-        INSERT INTO "PushNotificationLog_Partitioned" ("id", "userId", "venueId", "title", "body", "status", "error", "read", "createdAt")
-        SELECT "id", "userId", "venueId", "title", "body", "status", "error", "read", "createdAt"
-        FROM "PushNotificationLog";
-        
-        DROP TABLE "PushNotificationLog" CASCADE;
+    SELECT c.relkind
+      INTO existing_kind
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE n.nspname = 'public'
+       AND c.relname = 'PushNotificationLog';
+
+    -- When an unpartitioned table already exists, preserve it temporarily.
+    IF existing_kind IS NOT NULL AND existing_kind <> 'p' THEN
+        ALTER TABLE "PushNotificationLog"
+          RENAME TO "PushNotificationLog_unpartitioned_1571";
     END IF;
-END $$;
 
--- Rename partitioned table to standard table name
-ALTER TABLE "PushNotificationLog_Partitioned" RENAME TO "PushNotificationLog";
+    -- Create the partitioned parent for a new database or a converted table.
+    IF existing_kind IS NULL OR existing_kind <> 'p' THEN
+        CREATE TABLE "PushNotificationLog" (
+            "id" TEXT NOT NULL,
+            "userId" TEXT NOT NULL,
+            "venueId" TEXT,
+            "title" TEXT NOT NULL,
+            "body" TEXT NOT NULL,
+            "status" TEXT NOT NULL,
+            "error" TEXT,
+            "read" BOOLEAN NOT NULL DEFAULT false,
+            "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            CONSTRAINT "PushNotificationLog_pkey"
+              PRIMARY KEY ("id", "createdAt"),
+            CONSTRAINT "PushNotificationLog_userId_fkey"
+              FOREIGN KEY ("userId") REFERENCES "User"("id")
+              ON DELETE CASCADE ON UPDATE CASCADE
+        ) PARTITION BY RANGE ("createdAt");
 
--- Rename indexes or constraints
-CREATE INDEX "PushNotificationLog_createdAt_idx" ON "PushNotificationLog" ("createdAt");
-CREATE INDEX "PushNotificationLog_status_idx" ON "PushNotificationLog" ("status");
+        CREATE INDEX "PushNotificationLog_createdAt_idx"
+          ON "PushNotificationLog" ("createdAt");
+        CREATE INDEX "PushNotificationLog_status_idx"
+          ON "PushNotificationLog" ("status");
+
+        -- Create partitions covering six historical months and twelve future
+        -- months relative to migration time. Runtime maintenance creates more.
+        FOR month_start IN
+            SELECT generate_series(
+                date_trunc('month', CURRENT_DATE) - INTERVAL '6 months',
+                date_trunc('month', CURRENT_DATE) + INTERVAL '12 months',
+                INTERVAL '1 month'
+            )::date
+        LOOP
+            month_end := (month_start + INTERVAL '1 month')::date;
+            partition_name := format(
+                'PushNotificationLog_y%sm%s',
+                to_char(month_start, 'YYYY'),
+                to_char(month_start, 'MM')
+            );
+
+            EXECUTE format(
+                'CREATE TABLE IF NOT EXISTS %I PARTITION OF "PushNotificationLog" FOR VALUES FROM (%L) TO (%L)',
+                partition_name,
+                month_start,
+                month_end
+            );
+        END LOOP;
+
+        -- The default partition guarantees that legacy or unexpected dates do
+        -- not make the data-copy step fail. It can later be drained safely.
+        CREATE TABLE IF NOT EXISTS "PushNotificationLog_default"
+          PARTITION OF "PushNotificationLog" DEFAULT;
+
+        IF to_regclass('public."PushNotificationLog_unpartitioned_1571"') IS NOT NULL THEN
+            INSERT INTO "PushNotificationLog" (
+                "id",
+                "userId",
+                "venueId",
+                "title",
+                "body",
+                "status",
+                "error",
+                "read",
+                "createdAt"
+            )
+            SELECT
+                "id",
+                "userId",
+                "venueId",
+                "title",
+                "body",
+                "status",
+                "error",
+                "read",
+                "createdAt"
+            FROM "PushNotificationLog_unpartitioned_1571";
+
+            DROP TABLE "PushNotificationLog_unpartitioned_1571";
+        END IF;
+    END IF;
+END
+$$;

--- a/src/__tests__/lib/partitionMaintenance.test.ts
+++ b/src/__tests__/lib/partitionMaintenance.test.ts
@@ -1,56 +1,184 @@
-import { autoCreateUpcomingPartitions } from "../../lib/partitionMaintenance";
 import { prisma } from "@/lib/prisma";
+import {
+  archiveExpiredPushNotificationPartitions,
+  autoCreateUpcomingPartitions,
+  getPartitionRetentionCutoff,
+  getPushNotificationPartitionName,
+  isPartitionExpired,
+  listPushNotificationPartitions,
+  parsePushNotificationPartitionMonth,
+} from "@/lib/partitionMaintenance";
+
+const executeRawUnsafe = jest.fn();
+const queryRawUnsafe = jest.fn();
+const transactionExecuteRawUnsafe = jest.fn();
 
 jest.mock("@/lib/prisma", () => ({
   prisma: {
-    $executeRawUnsafe: jest.fn(),
+    $executeRawUnsafe: (...args: unknown[]) => executeRawUnsafe(...args),
+    $queryRawUnsafe: (...args: unknown[]) => queryRawUnsafe(...args),
+    $transaction: jest.fn(
+      async (
+        callback: (transaction: {
+          $executeRawUnsafe: (...args: unknown[]) => Promise<number>;
+        }) => Promise<unknown>,
+      ) =>
+        callback({
+          $executeRawUnsafe: (...args: unknown[]) =>
+            transactionExecuteRawUnsafe(...args),
+        }),
+    ),
   },
 }));
 
-describe("autoCreateUpcomingPartitions", () => {
+describe("partition naming and retention helpers", () => {
+  it("formats and parses canonical monthly partition names", () => {
+    const date = new Date("2026-07-15T10:00:00.000Z");
+
+    expect(getPushNotificationPartitionName(date)).toBe(
+      "PushNotificationLog_y2026m07",
+    );
+    expect(
+      parsePushNotificationPartitionMonth("PushNotificationLog_y2026m07"),
+    ).toEqual(new Date("2026-07-01T00:00:00.000Z"));
+  });
+
+  it("rejects malformed or unrelated partition names", () => {
+    expect(
+      parsePushNotificationPartitionMonth("PushNotificationLog_y2026m13"),
+    ).toBeNull();
+    expect(parsePushNotificationPartitionMonth("User_y2026m07")).toBeNull();
+  });
+
+  it("keeps the current month and previous five months for six-month retention", () => {
+    const now = new Date("2026-07-25T00:00:00.000Z");
+
+    expect(getPartitionRetentionCutoff(now, 6)).toEqual(
+      new Date("2026-02-01T00:00:00.000Z"),
+    );
+    expect(isPartitionExpired("PushNotificationLog_y2026m01", now, 6)).toBe(
+      true,
+    );
+    expect(isPartitionExpired("PushNotificationLog_y2026m02", now, 6)).toBe(
+      false,
+    );
+  });
+
+  it("validates the configured retention period", () => {
+    expect(() =>
+      getPartitionRetentionCutoff(new Date("2026-07-25T00:00:00.000Z"), 0),
+    ).toThrow("retentionMonths must be a positive integer");
+  });
+});
+
+describe("listPushNotificationPartitions", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it("executes partition creation query 3 times with monthly intervals", async () => {
-    (prisma.$executeRawUnsafe as jest.Mock).mockResolvedValue(1);
+  it("returns attached monthly child partitions", async () => {
+    queryRawUnsafe.mockResolvedValue([
+      { name: "PushNotificationLog_y2026m01" },
+      { name: "PushNotificationLog_y2026m02" },
+    ]);
 
-    const now = new Date();
-    const result = await autoCreateUpcomingPartitions();
+    await expect(listPushNotificationPartitions()).resolves.toEqual([
+      "PushNotificationLog_y2026m01",
+      "PushNotificationLog_y2026m02",
+    ]);
+    expect(queryRawUnsafe).toHaveBeenCalledTimes(1);
+  });
+});
 
-    // Verify it generated 3 partitions
-    expect(result).toHaveLength(3);
-    expect(prisma.$executeRawUnsafe).toHaveBeenCalledTimes(3);
-
-    // Verify the query format on the first partition
-    const firstQuery = (prisma.$executeRawUnsafe as jest.Mock).mock.calls[0][0];
-    expect(firstQuery).toContain("CREATE TABLE IF NOT EXISTS");
-    expect(firstQuery).toContain('PARTITION OF "PushNotificationLog"');
-    expect(firstQuery).toContain("FOR VALUES FROM");
-
-    // Verify the months match the current, next, and following month sequence
-    const year = now.getFullYear();
-    const month = now.getMonth() + 1;
-
-    const currentPartition = `PushNotificationLog_y${year}m${String(month).padStart(2, "0")}`;
-    expect(result[0]).toBe(currentPartition);
-
-    const nextDate = new Date(year, month, 1);
-    const nextPartition = `PushNotificationLog_y${nextDate.getFullYear()}m${String(nextDate.getMonth() + 1).padStart(2, "0")}`;
-    expect(result[1]).toBe(nextPartition);
-
-    const afterNextDate = new Date(year, month + 1, 1);
-    const afterNextPartition = `PushNotificationLog_y${afterNextDate.getFullYear()}m${String(afterNextDate.getMonth() + 1).padStart(2, "0")}`;
-    expect(result[2]).toBe(afterNextPartition);
+describe("archiveExpiredPushNotificationPartitions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    transactionExecuteRawUnsafe.mockResolvedValue(0);
   });
 
-  it("propagates database execution errors", async () => {
-    const dbError = new Error("Connection failed");
-    (prisma.$executeRawUnsafe as jest.Mock).mockRejectedValueOnce(dbError);
+  it("detaches expired partitions and moves them to the archive schema", async () => {
+    queryRawUnsafe.mockResolvedValue([
+      { name: "PushNotificationLog_y2025m12" },
+      { name: "PushNotificationLog_y2026m01" },
+      { name: "PushNotificationLog_y2026m02" },
+      { name: "PushNotificationLog_y2026m07" },
+    ]);
 
-    await expect(autoCreateUpcomingPartitions()).rejects.toThrow(
-      "Connection failed",
+    const result = await archiveExpiredPushNotificationPartitions({
+      now: new Date("2026-07-25T00:00:00.000Z"),
+      retentionMonths: 6,
+    });
+
+    expect(result.archived).toEqual([
+      {
+        name: "PushNotificationLog_y2025m12",
+        archivedSchema: "push_notification_archive",
+      },
+      {
+        name: "PushNotificationLog_y2026m01",
+        archivedSchema: "push_notification_archive",
+      },
+    ]);
+    expect(result.retained).toEqual([
+      "PushNotificationLog_y2026m02",
+      "PushNotificationLog_y2026m07",
+    ]);
+
+    expect(transactionExecuteRawUnsafe).toHaveBeenCalledWith(
+      'CREATE SCHEMA IF NOT EXISTS "push_notification_archive"',
     );
-    expect(prisma.$executeRawUnsafe).toHaveBeenCalledTimes(1);
+    expect(transactionExecuteRawUnsafe).toHaveBeenCalledWith(
+      'ALTER TABLE "PushNotificationLog" DETACH PARTITION "PushNotificationLog_y2026m01"',
+    );
+    expect(transactionExecuteRawUnsafe).toHaveBeenCalledWith(
+      'ALTER TABLE "PushNotificationLog_y2026m01" SET SCHEMA "push_notification_archive"',
+    );
+  });
+
+  it("does not open a transaction when no partition has expired", async () => {
+    queryRawUnsafe.mockResolvedValue([
+      { name: "PushNotificationLog_y2026m02" },
+      { name: "PushNotificationLog_y2026m07" },
+    ]);
+
+    await expect(
+      archiveExpiredPushNotificationPartitions({
+        now: new Date("2026-07-25T00:00:00.000Z"),
+      }),
+    ).resolves.toEqual({
+      archived: [],
+      retained: [
+        "PushNotificationLog_y2026m02",
+        "PushNotificationLog_y2026m07",
+      ],
+    });
+
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+});
+
+describe("autoCreateUpcomingPartitions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    executeRawUnsafe.mockResolvedValue(0);
+  });
+
+  it("creates current and next two monthly partitions", async () => {
+    const result = await autoCreateUpcomingPartitions(
+      new Date("2026-12-15T00:00:00.000Z"),
+    );
+
+    expect(result).toEqual([
+      "PushNotificationLog_y2026m12",
+      "PushNotificationLog_y2027m01",
+      "PushNotificationLog_y2027m02",
+    ]);
+    expect(executeRawUnsafe).toHaveBeenCalledTimes(3);
+    expect(executeRawUnsafe.mock.calls[1][0]).toContain(
+      'PARTITION OF "PushNotificationLog"',
+    );
+    expect(executeRawUnsafe.mock.calls[1][0]).toContain(
+      "2027-01-01T00:00:00.000Z",
+    );
   });
 });

--- a/src/lib/partitionMaintenance.ts
+++ b/src/lib/partitionMaintenance.ts
@@ -1,50 +1,23 @@
 import { prisma } from "@/lib/prisma";
 
-/**
- * Automates time-based declarative table partitioning for PushNotificationLog.
- * Checks and creates monthly range partitions for the current month, next month,
- * and the month after next, ensuring no partition gaps exist.
- */
-export async function autoCreateUpcomingPartitions(): Promise<string[]> {
-  const now = new Date();
-  const createdPartitions: string[] = [];
+const PARTITION_PREFIX = "PushNotificationLog_y";
+const ARCHIVE_SCHEMA = "push_notification_archive";
+const DEFAULT_RETENTION_MONTHS = 6;
 
-  // Pre-create partitions for offset 0 (current month), 1 (next month), and 2 (month after next)
-  for (let offset = 0; offset <= 2; offset++) {
-    const targetDate = new Date(now.getFullYear(), now.getMonth() + offset, 1);
-    const year = targetDate.getFullYear();
-    const month = String(targetDate.getMonth() + 1).padStart(2, "0");
-
-    const nextTargetDate = new Date(
-      targetDate.getFullYear(),
-      targetDate.getMonth() + 1,
-      1,
-    );
-    const nextYear = nextTargetDate.getFullYear();
-    const nextMonth = String(nextTargetDate.getMonth() + 1).padStart(2, "0");
-
-    const partitionName = `PushNotificationLog_y${year}m${month}`;
-    const rangeStart = `${year}-${month}-01 00:00:00`;
-    const rangeEnd = `${nextYear}-${nextMonth}-01 00:00:00`;
-
-    const query = `
-      CREATE TABLE IF NOT EXISTS "${partitionName}" 
-      PARTITION OF "PushNotificationLog"
-      FOR VALUES FROM ('${rangeStart}') TO ('${rangeEnd}')
-    `;
-
-    try {
-      await prisma.$executeRawUnsafe(query);
-      createdPartitions.push(partitionName);
-      console.log(`Ensured partition exists: ${partitionName}`);
-    } catch (error) {
-      console.error(`Failed to create partition ${partitionName}:`, error);
-      throw error;
-    }
-  }
-
-  return createdPartitions;
+export interface PushNotificationPartition {
+  name: string;
 }
+
+export interface ArchivedPartition {
+  name: string;
+  archivedSchema: string;
+}
+
+export interface PartitionArchiveResult {
+  archived: ArchivedPartition[];
+  retained: string[];
+}
+
 export interface PartitionHealthReport {
   status: "HEALTHY" | "CRITICAL";
   checkedAt: string;
@@ -55,49 +28,219 @@ export interface PartitionHealthReport {
   }[];
 }
 
+/**
+ * Returns the canonical monthly partition name used by PostgreSQL.
+ */
+export function getPushNotificationPartitionName(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  return `${PARTITION_PREFIX}${year}m${month}`;
+}
+
+/**
+ * Parses a canonical monthly partition name and returns its UTC month start.
+ * Invalid or unrelated table names return `null`.
+ */
+export function parsePushNotificationPartitionMonth(
+  partitionName: string,
+): Date | null {
+  const match = /^PushNotificationLog_y(\d{4})m(0[1-9]|1[0-2])$/.exec(
+    partitionName,
+  );
+
+  if (!match) {
+    return null;
+  }
+
+  return new Date(Date.UTC(Number(match[1]), Number(match[2]) - 1, 1));
+}
+
+/**
+ * Returns the first UTC day of the month that must still be retained.
+ * A six-month policy keeps the current month and the previous five months.
+ */
+export function getPartitionRetentionCutoff(
+  now: Date,
+  retentionMonths = DEFAULT_RETENTION_MONTHS,
+): Date {
+  if (!Number.isInteger(retentionMonths) || retentionMonths < 1) {
+    throw new RangeError("retentionMonths must be a positive integer");
+  }
+
+  return new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth() - (retentionMonths - 1),
+      1,
+    ),
+  );
+}
+
+/**
+ * Returns true when a monthly partition falls completely outside retention.
+ */
+export function isPartitionExpired(
+  partitionName: string,
+  now: Date,
+  retentionMonths = DEFAULT_RETENTION_MONTHS,
+): boolean {
+  const partitionMonth = parsePushNotificationPartitionMonth(partitionName);
+  if (!partitionMonth) {
+    return false;
+  }
+
+  return partitionMonth < getPartitionRetentionCutoff(now, retentionMonths);
+}
+
+function assertSafePartitionName(partitionName: string): void {
+  if (!parsePushNotificationPartitionMonth(partitionName)) {
+    throw new Error(`Unsafe or invalid partition name: ${partitionName}`);
+  }
+}
+
+/**
+ * Lists monthly partitions attached to the PushNotificationLog parent table.
+ */
+export async function listPushNotificationPartitions(): Promise<string[]> {
+  const rows = await prisma.$queryRawUnsafe<PushNotificationPartition[]>(`
+    SELECT child.relname AS "name"
+    FROM pg_inherits
+    JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
+    JOIN pg_class child ON pg_inherits.inhrelid = child.oid
+    JOIN pg_namespace parent_ns ON parent.relnamespace = parent_ns.oid
+    WHERE parent_ns.nspname = 'public'
+      AND parent.relname = 'PushNotificationLog'
+      AND child.relname ~ '^PushNotificationLog_y[0-9]{4}m(0[1-9]|1[0-2])$'
+    ORDER BY child.relname;
+  `);
+
+  return rows.map(({ name }) => name);
+}
+
+/**
+ * Detaches monthly PushNotificationLog partitions older than the configured
+ * retention window and moves them into a dedicated archive schema.
+ *
+ * Detaching preserves the data while removing it from normal notification
+ * queries. The operation is idempotent because only currently attached
+ * partitions are discovered.
+ */
+export async function archiveExpiredPushNotificationPartitions(options?: {
+  now?: Date;
+  retentionMonths?: number;
+}): Promise<PartitionArchiveResult> {
+  const now = options?.now ?? new Date();
+  const retentionMonths = options?.retentionMonths ?? DEFAULT_RETENTION_MONTHS;
+
+  // Validate before performing any database work.
+  getPartitionRetentionCutoff(now, retentionMonths);
+
+  const partitions = await listPushNotificationPartitions();
+  const expired = partitions.filter((name) =>
+    isPartitionExpired(name, now, retentionMonths),
+  );
+  const retained = partitions.filter(
+    (name) => !isPartitionExpired(name, now, retentionMonths),
+  );
+
+  if (expired.length === 0) {
+    return { archived: [], retained };
+  }
+
+  const archived = await prisma.$transaction(async (transaction) => {
+    await transaction.$executeRawUnsafe(
+      `CREATE SCHEMA IF NOT EXISTS "${ARCHIVE_SCHEMA}"`,
+    );
+
+    const results: ArchivedPartition[] = [];
+
+    for (const partitionName of expired) {
+      assertSafePartitionName(partitionName);
+
+      await transaction.$executeRawUnsafe(
+        `ALTER TABLE "PushNotificationLog" DETACH PARTITION "${partitionName}"`,
+      );
+      await transaction.$executeRawUnsafe(
+        `ALTER TABLE "${partitionName}" SET SCHEMA "${ARCHIVE_SCHEMA}"`,
+      );
+
+      results.push({
+        name: partitionName,
+        archivedSchema: ARCHIVE_SCHEMA,
+      });
+    }
+
+    return results;
+  });
+
+  return { archived, retained };
+}
+
+/**
+ * Ensures monthly range partitions exist for the current and next two months.
+ */
+export async function autoCreateUpcomingPartitions(
+  now = new Date(),
+): Promise<string[]> {
+  const createdPartitions: string[] = [];
+
+  for (let offset = 0; offset <= 2; offset += 1) {
+    const rangeStart = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + offset, 1),
+    );
+    const rangeEnd = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + offset + 1, 1),
+    );
+    const partitionName = getPushNotificationPartitionName(rangeStart);
+
+    assertSafePartitionName(partitionName);
+
+    await prisma.$executeRawUnsafe(`
+      CREATE TABLE IF NOT EXISTS "${partitionName}"
+      PARTITION OF "PushNotificationLog"
+      FOR VALUES FROM ('${rangeStart.toISOString()}') TO ('${rangeEnd.toISOString()}')
+    `);
+
+    createdPartitions.push(partitionName);
+  }
+
+  return createdPartitions;
+}
+
 export async function checkPartitionHealth(): Promise<PartitionHealthReport> {
   const now = new Date();
-  const partitionsReport: any[] = [];
+  const partitions: PartitionHealthReport["partitions"] = [];
   let isCritical = false;
 
-  // Track the current month (offset 0) and the next month (offset 1)
-  for (let offset = 0; offset <= 1; offset++) {
-    const targetDate = new Date(now.getFullYear(), now.getMonth() + offset, 1);
-    const year = targetDate.getFullYear();
-    const month = String(targetDate.getMonth() + 1).padStart(2, "0");
-    const partitionName = `PushNotificationLog_y${year}m${month}`;
+  for (let offset = 0; offset <= 1; offset += 1) {
+    const targetDate = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + offset, 1),
+    );
+    const partitionName = getPushNotificationPartitionName(targetDate);
 
-    try {
-      // Query PostgreSQL system catalogs to verify if the partition sub-table exists
-      const result = await prisma.$queryRawUnsafe<{ relname: string; n_live_tup: number }[]>(`
-        SELECT relname, n_live_tup::int as n_live_tup
-        FROM pg_stat_user_tables 
-        WHERE relname = '${partitionName}'
-        LIMIT 1;
-      `);
+    const result = await prisma.$queryRawUnsafe<
+      { relname: string; n_live_tup: number }[]
+    >(`
+      SELECT relname, n_live_tup::int AS n_live_tup
+      FROM pg_stat_user_tables
+      WHERE schemaname = 'public'
+        AND relname = '${partitionName}'
+      LIMIT 1;
+    `);
 
-      const exists = result && result.length > 0;
-      const rowCount = exists ? (result[0] as any).n_live_tup : 0;
+    const exists = result.length > 0;
+    const rowCount = exists ? result[0].n_live_tup : 0;
 
-      // If next month's partition (offset 1) is missing, mark the state as CRITICAL
-      if (offset === 1 && !exists) {
-        isCritical = true;
-      }
-
-      partitionsReport.push({
-        name: partitionName,
-        exists,
-        rowCount,
-      });
-    } catch (error) {
-      console.error(`Error checking status for table partition ${partitionName}:`, error);
+    if (offset === 1 && !exists) {
       isCritical = true;
     }
+
+    partitions.push({ name: partitionName, exists, rowCount });
   }
 
   return {
     status: isCritical ? "CRITICAL" : "HEALTHY",
     checkedAt: new Date().toISOString(),
-    partitions: partitionsReport,
+    partitions,
   };
 }


### PR DESCRIPTION
## Summary

Implements native PostgreSQL monthly range partitioning for `PushNotificationLog` and adds six-month archival maintenance.

## Changes Made

- Added a safe migration that converts the existing notification log table into a range-partitioned parent without dropping existing rows.
- Added monthly partitions around the migration date plus a default partition for out-of-range legacy records.
- Added reusable partition naming, parsing, retention, discovery, creation, health-check, detach, and archive helpers.
- Added transactional archival that moves expired partitions into `push_notification_archive`.
- Added deterministic unit tests covering boundaries, naming, discovery, partition creation, retention, and archival SQL.

## Related Issue

Closes #1571

## Type of Change

- [x] Feature
- [x] Database migration
- [x] Tests

## Validation

- [x] `npm test -- src/__tests__/lib/partitionMaintenance.test.ts --runInBand`
- [x] `npx eslint src/lib/partitionMaintenance.ts src/__tests__/lib/partitionMaintenance.test.ts --max-warnings=0`
- [x] `npx tsc --noEmit`
- [x] Migration applied against a disposable PostgreSQL database
- [x] Existing notification rows preserved after migration
- [x] Parent table confirmed as `relkind = 'p'`
- [x] Monthly child partitions confirmed through `pg_inherits`


## Breaking Changes

- [ ] Yes (please describe below)
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Push notification logs now use monthly date-based partitioning for improved scalability and more consistent performance.
  - Upcoming partitions are created automatically using UTC-based date handling.
  - Expired notification log partitions can be archived while retaining recent data.
  - Partition health monitoring now identifies missing upcoming partitions and surfaces database errors more reliably.

- **Bug Fixes**
  - Existing notification log data is preserved during partitioning and migration.
  - Partition creation is safer and repeatable, avoiding duplicate partition errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->