### PR TITLE
fix: audio level indicator

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -9,28 +9,13 @@ if (typeof global.TextEncoder === "undefined") {
   global.TextDecoder = TextDecoder;
 }
 
- feat/1629-ambient-noise-meter
-const { ReadableStream, TransformStream } = require("stream/web");
-
 const { ReadableStream, TransformStream, WritableStream } = require("stream/web");
-main
 if (typeof global.ReadableStream === "undefined") {
   global.ReadableStream = ReadableStream;
 }
 if (typeof global.TransformStream === "undefined") {
   global.TransformStream = TransformStream;
 }
- feat/1629-ambient-noise-meter
-const { MessageChannel, MessagePort } = require("worker_threads");
-if (typeof global.MessageChannel === "undefined") {
-  global.MessageChannel = MessageChannel;
-}
-if (typeof global.MessagePort === "undefined") {
-  global.MessagePort = MessagePort;
-}
-
-
-
 if (typeof global.WritableStream === "undefined") {
   global.WritableStream = WritableStream;
 }
@@ -40,7 +25,7 @@ if (typeof global.MessageChannel === "undefined") {
   global.MessageChannel = MessageChannel;
   global.MessagePort = MessagePort;
 }
- main
+
 /* eslint-disable @typescript-eslint/no-require-imports */
 const {
   Request: UndiciRequest,

--- a/src/__tests__/hooks/useWebRTCMesh.test.ts
+++ b/src/__tests__/hooks/useWebRTCMesh.test.ts
@@ -51,13 +51,21 @@ Object.defineProperty(global.navigator, "mediaDevices", {
 });
 
 // Mock window.AudioContext
+const mockDisconnect = jest.fn();
 class MockAudioContext {
   state = "running";
-  createMediaStreamSource = jest.fn().mockReturnValue({ connect: jest.fn() });
+  createMediaStreamSource = jest.fn().mockReturnValue({
+    connect: jest.fn(),
+    disconnect: mockDisconnect,
+  });
   createAnalyser = jest.fn().mockReturnValue({
     fftSize: 256,
     frequencyBinCount: 128,
     getByteFrequencyData: jest.fn(),
+    getFloatTimeDomainData: jest.fn((array: Float32Array) => {
+      array.fill(0);
+    }),
+    disconnect: mockDisconnect,
   });
   close = jest.fn();
   resume = jest.fn().mockResolvedValue(undefined);
@@ -77,7 +85,7 @@ describe("useWebRTCMesh Bandwidth Probing", () => {
 
   it("sends ping telemetry and updates network quality based on RTT", async () => {
     const { result } = renderHook(() =>
-      useWebRTCMesh({ roomId: "test-room", userId: "user-1" })
+      useWebRTCMesh({ roomId: "test-room", userId: "user-1" }),
     );
 
     // Needs to toggle audio to ensure local stream is created
@@ -93,10 +101,11 @@ describe("useWebRTCMesh Bandwidth Probing", () => {
     act(() => {
       jest.advanceTimersByTime(2000);
     });
-    
+
     // Expect send to be called with ping
     expect(mockSocketSend).toHaveBeenCalled();
-    const lastSendCall = mockSocketSend.mock.calls[mockSocketSend.mock.calls.length - 1][0];
+    const lastSendCall =
+      mockSocketSend.mock.calls[mockSocketSend.mock.calls.length - 1][0];
     expect(JSON.parse(lastSendCall).type).toBe("ping");
     const pingTimestamp = JSON.parse(lastSendCall).timestamp;
 
@@ -121,9 +130,9 @@ describe("useWebRTCMesh Bandwidth Probing", () => {
       act(() => {
         jest.advanceTimersByTime(2000);
       });
-      
+
       const pingTime = Date.now();
-      
+
       act(() => {
         jest.setSystemTime(pingTime + 20); // very fast now
         mockSocketOnMessage({
@@ -135,5 +144,67 @@ describe("useWebRTCMesh Bandwidth Probing", () => {
     // Now it should be good
     expect(result.current.networkQuality).toBe("good");
     expect(mockApplyConstraints).toHaveBeenCalledWith({ sampleRate: 48000 });
+  });
+});
+
+describe("useWebRTCMesh Audio Level EMA Smoothing & Node Cleanup", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("smooths decibel readings using EMA (alpha = 0.2) and cleans up audio nodes on unmount", async () => {
+    let floatDataFn: ((arr: Float32Array) => void) | null = null;
+    const localDisconnect = jest.fn();
+
+    (global as any).AudioContext = class extends MockAudioContext {
+      createMediaStreamSource = jest.fn().mockReturnValue({
+        connect: jest.fn(),
+        disconnect: localDisconnect,
+      });
+      createAnalyser = jest.fn().mockReturnValue({
+        fftSize: 256,
+        frequencyBinCount: 128,
+        getFloatTimeDomainData: jest.fn((arr: Float32Array) => {
+          if (floatDataFn) floatDataFn(arr);
+          else arr.fill(0);
+        }),
+        disconnect: localDisconnect,
+      });
+    };
+
+    const { result, unmount } = renderHook(() =>
+      useWebRTCMesh({ roomId: "test-room", userId: "user-1" }),
+    );
+
+    await act(async () => {
+      await result.current.toggleAudio();
+    });
+
+    // Provide non-zero PCM samples (rms ~0.1 -> ~80 dB -> rawLevel ~0.833)
+    floatDataFn = (arr: Float32Array) => {
+      for (let i = 0; i < arr.length; i++) {
+        arr[i] = 0.1 * Math.sin((i * 2 * Math.PI) / 10);
+      }
+    };
+
+    // Advance rAF / timers
+    act(() => {
+      jest.advanceTimersByTime(50);
+    });
+
+    // Audio level for 'local' should be smoothed (non-zero)
+    const level1 = result.current.audioLevels["local"];
+    expect(level1).toBeGreaterThan(0);
+
+    // Unmount hook
+    unmount();
+
+    // Verify audio nodes were disconnected on unmount
+    expect(localDisconnect).toHaveBeenCalled();
   });
 });

--- a/src/hooks/useWebRTCMesh.ts
+++ b/src/hooks/useWebRTCMesh.ts
@@ -116,6 +116,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useAuth } from "@clerk/nextjs";
 import usePartySocket from "partysocket/react";
 import { adaptVideoBitrate } from "@/lib/screenShareBitrate";
+import { calculateRMS, rmsToDecibels } from "@/lib/audio";
 
 const ICE_SERVERS: RTCIceServer[] = [{ urls: "stun:stun.l.google.com:19302" }];
 
@@ -183,14 +184,21 @@ export function useWebRTCMesh({ roomId, userId }: Options) {
   // Audio context for monitoring levels
   const audioContextRef = useRef<AudioContext | null>(null);
   const analysersRef = useRef<
-    Map<string, { analyser: AnalyserNode; dataArray: Uint8Array }>
+    Map<
+      string,
+      {
+        source: MediaStreamAudioSourceNode;
+        analyser: AnalyserNode;
+        dataArray: Float32Array;
+      }
+    >
   >(new Map());
+  const emaDecibelsRef = useRef<Map<string, number>>(new Map());
 
-  // Intervals
+  // Intervals / Animations
   const bitrateTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const audioLevelTimerRef = useRef<ReturnType<typeof setInterval> | null>(
-    null,
-  );
+  const audioAnimationRef = useRef<number | null>(null);
+  const lastFrameTimeRef = useRef<number>(0);
   const pingTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const rttEmaRef = useRef<number>(0);
 
@@ -235,11 +243,32 @@ export function useWebRTCMesh({ roomId, userId }: Options) {
       return next;
     });
 
-    analysersRef.current.delete(peerId);
+    const monitoring = analysersRef.current.get(peerId);
+    if (monitoring) {
+      try {
+        monitoring.source.disconnect();
+        monitoring.analyser.disconnect();
+      } catch {}
+      analysersRef.current.delete(peerId);
+    }
+    emaDecibelsRef.current.delete(peerId);
   }, []);
 
   const setupAudioMonitoring = useCallback(
     (peerId: string, stream: MediaStream) => {
+      if (stream.getAudioTracks().length === 0) {
+        const existing = analysersRef.current.get(peerId);
+        if (existing) {
+          try {
+            existing.source.disconnect();
+            existing.analyser.disconnect();
+          } catch {}
+          analysersRef.current.delete(peerId);
+        }
+        emaDecibelsRef.current.delete(peerId);
+        return;
+      }
+
       if (!audioContextRef.current) {
         audioContextRef.current = new (
           window.AudioContext || (window as any).webkitAudioContext
@@ -251,16 +280,23 @@ export function useWebRTCMesh({ roomId, userId }: Options) {
         audioCtx.resume();
       }
 
-      if (stream.getAudioTracks().length === 0) return;
+      const existing = analysersRef.current.get(peerId);
+      if (existing) {
+        try {
+          existing.source.disconnect();
+          existing.analyser.disconnect();
+        } catch {}
+        analysersRef.current.delete(peerId);
+      }
 
       try {
         const source = audioCtx.createMediaStreamSource(stream);
         const analyser = audioCtx.createAnalyser();
         analyser.fftSize = 256;
         source.connect(analyser);
-        const dataArray = new Uint8Array(analyser.frequencyBinCount);
+        const dataArray = new Float32Array(analyser.fftSize);
 
-        analysersRef.current.set(peerId, { analyser, dataArray });
+        analysersRef.current.set(peerId, { source, analyser, dataArray });
       } catch (e) {
         console.warn("Could not setup audio monitoring for peer", peerId, e);
       }
@@ -366,26 +402,53 @@ export function useWebRTCMesh({ roomId, userId }: Options) {
   }, []);
 
   const startAudioMonitoringLoop = useCallback(() => {
-    if (audioLevelTimerRef.current) clearInterval(audioLevelTimerRef.current);
-    audioLevelTimerRef.current = setInterval(() => {
-      const newLevels: Record<string, number> = {};
+    if (audioAnimationRef.current) {
+      cancelAnimationFrame(audioAnimationRef.current);
+      audioAnimationRef.current = null;
+    }
 
-      for (const [
-        peerId,
-        { analyser, dataArray },
-      ] of analysersRef.current.entries()) {
-        analyser.getByteFrequencyData(dataArray as any);
-        let sum = 0;
-        for (let i = 0; i < dataArray.length; i++) {
-          sum += dataArray[i];
+    const TARGET_FPS = 60;
+    const FRAME_INTERVAL = 1000 / TARGET_FPS; // ~16.67ms
+    const alpha = 0.2; // Exponential Moving Average smoothing factor
+
+    const tick = (timestamp: number) => {
+      const elapsed = timestamp - lastFrameTimeRef.current;
+
+      if (elapsed >= FRAME_INTERVAL) {
+        lastFrameTimeRef.current = timestamp - (elapsed % FRAME_INTERVAL);
+
+        if (analysersRef.current.size > 0) {
+          const newLevels: Record<string, number> = {};
+
+          for (const [
+            peerId,
+            { analyser, dataArray },
+          ] of analysersRef.current.entries()) {
+            analyser.getFloatTimeDomainData(dataArray);
+            const rms = calculateRMS(dataArray);
+            const rawDb = rmsToDecibels(rms); // 30 dB (silence) to 120 dB
+
+            // Apply Exponential Moving Average (EMA) with alpha = 0.2
+            const prevDb = emaDecibelsRef.current.get(peerId);
+            const emaDb =
+              prevDb === undefined
+                ? rawDb
+                : alpha * rawDb + (1 - alpha) * prevDb;
+            emaDecibelsRef.current.set(peerId, emaDb);
+
+            // Convert decibels (30..90 dB range) to normalized 0..1 scale
+            const normalizedLevel = Math.max(0, Math.min(1, (emaDb - 30) / 60));
+            newLevels[peerId] = normalizedLevel;
+          }
+
+          setAudioLevels(newLevels);
         }
-        const average = sum / dataArray.length;
-        // Normalize 0-1
-        newLevels[peerId] = Math.min(1, average / 128);
       }
 
-      setAudioLevels(newLevels);
-    }, 100);
+      audioAnimationRef.current = requestAnimationFrame(tick);
+    };
+
+    audioAnimationRef.current = requestAnimationFrame(tick);
   }, []);
 
   const startPingLoop = useCallback(() => {
@@ -508,16 +571,28 @@ export function useWebRTCMesh({ roomId, userId }: Options) {
     startAudioMonitoringLoop();
     startPingLoop();
     const peersMap = peersRef.current;
+    const analysersMap = analysersRef.current;
+    const emaDecibelsMap = emaDecibelsRef.current;
 
     return () => {
       if (bitrateTimerRef.current) clearInterval(bitrateTimerRef.current);
-      if (audioLevelTimerRef.current) clearInterval(audioLevelTimerRef.current);
+      if (audioAnimationRef.current)
+        cancelAnimationFrame(audioAnimationRef.current);
       if (pingTimerRef.current) clearInterval(pingTimerRef.current);
 
       const currentPeers = Array.from(peersMap.keys());
       for (const id of currentPeers) {
         cleanupPeer(id);
       }
+
+      for (const [, { source, analyser }] of analysersMap.entries()) {
+        try {
+          source.disconnect();
+          analyser.disconnect();
+        } catch {}
+      }
+      analysersMap.clear();
+      emaDecibelsMap.clear();
 
       localStreamRef.current?.getTracks().forEach((t) => t.stop());
       localScreenStreamRef.current?.getTracks().forEach((t) => t.stop());


### PR DESCRIPTION
Key Accomplishments
Exponential Moving Average (EMA) Decibel Smoothing (alpha = 0.2):
Updated useWebRTCMesh.ts to compute RMS values and convert time-domain PCM samples into decibels via rmsToDecibels(calculateRMS(dataArray)).
Applied EMA smoothing with alpha = 0.2 (emaDb = 0.2 * rawDb + 0.8 * prevDb) before normalizing to the 0–1 audio level scale used by AudioLevelIndicator.
60fps Throttled Animation Loop:
Replaced unthrottled loop logic with a requestAnimationFrame loop throttled to ~60fps (16.67ms frame interval).
Web Audio API Context & Node Cleanup:
Updated analysersRef to retain references to both MediaStreamAudioSourceNode and AnalyserNode.
Explicitly called source.disconnect() and analyser.disconnect() when peer tracks unmount, when peers disconnect, and on component unmount.


closes #1643

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved audio level monitoring with smoother, more responsive readings.
  * Added more reliable handling of audio processing during stream changes and cleanup.
  * Preserved existing WebRTC connection and signaling behavior while improving network quality and bandwidth probing validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->