### PR TITLE
fix: handle Yjs CRDT document

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -9,28 +9,13 @@ if (typeof global.TextEncoder === "undefined") {
   global.TextDecoder = TextDecoder;
 }
 
- feat/1629-ambient-noise-meter
-const { ReadableStream, TransformStream } = require("stream/web");
-
 const { ReadableStream, TransformStream, WritableStream } = require("stream/web");
-main
 if (typeof global.ReadableStream === "undefined") {
   global.ReadableStream = ReadableStream;
 }
 if (typeof global.TransformStream === "undefined") {
   global.TransformStream = TransformStream;
 }
- feat/1629-ambient-noise-meter
-const { MessageChannel, MessagePort } = require("worker_threads");
-if (typeof global.MessageChannel === "undefined") {
-  global.MessageChannel = MessageChannel;
-}
-if (typeof global.MessagePort === "undefined") {
-  global.MessagePort = MessagePort;
-}
-
-
-
 if (typeof global.WritableStream === "undefined") {
   global.WritableStream = WritableStream;
 }
@@ -40,7 +25,7 @@ if (typeof global.MessageChannel === "undefined") {
   global.MessageChannel = MessageChannel;
   global.MessagePort = MessagePort;
 }
- main
+
 /* eslint-disable @typescript-eslint/no-require-imports */
 const {
   Request: UndiciRequest,

--- a/src/__tests__/lib/scratchpadSync.test.ts
+++ b/src/__tests__/lib/scratchpadSync.test.ts
@@ -1,0 +1,92 @@
+import * as Y from "yjs";
+import { CryptoManager } from "@/lib/e2ee/CryptoManager";
+
+describe("Yjs CRDT Document Reconnection & Delta Sync (#1428)", () => {
+  it("reconciles state drift after connection drop using state vectors and Y.applyUpdate", async () => {
+    // Initialize Doc A and Doc B
+    const docA = new Y.Doc();
+    const textA = docA.getText("scratchpad");
+
+    const docB = new Y.Doc();
+    const textB = docB.getText("scratchpad");
+
+    // Initial synchronized state
+    docA.transact(() => {
+      textA.insert(0, "Hello World!");
+    });
+    const initialUpdate = Y.encodeStateAsUpdate(docA);
+    Y.applyUpdate(docB, initialUpdate);
+
+    expect(textA.toString()).toBe("Hello World!");
+    expect(textB.toString()).toBe("Hello World!");
+
+    // Simulate sleep mode / network disconnection: both clients make offline edits
+    docA.transact(() => {
+      textA.insert(12, " Client A edit.");
+    });
+
+    docB.transact(() => {
+      textB.insert(0, "Header: ");
+    });
+
+    // Before sync, docs have drifted
+    expect(textA.toString()).toBe("Hello World! Client A edit.");
+    expect(textB.toString()).toBe("Header: Hello World!");
+
+    // Reconnection trigger: Device A wakes up and sends its state vector to Device B
+    const vectorA = Y.encodeStateVector(docA);
+
+    // Device B receives vectorA and calculates the missing delta for Device A
+    const deltaForA = Y.encodeStateAsUpdate(docB, vectorA);
+
+    // Device A applies the delta from Device B
+    Y.applyUpdate(docA, deltaForA);
+
+    // Device B sends its state vector to Device A
+    const vectorB = Y.encodeStateVector(docB);
+    const deltaForB = Y.encodeStateAsUpdate(docA, vectorB);
+    Y.applyUpdate(docB, deltaForB);
+
+    // Assert that both CRDT docs converge losslessly to the exact same text
+    expect(textA.toString()).toBe(textB.toString());
+    expect(textA.toString()).toBe("Header: Hello World! Client A edit.");
+
+    docA.destroy();
+    docB.destroy();
+  });
+
+  it("encrypts and decrypts state vectors and deltas over simulated E2EE channel", async () => {
+    const rawKey = window.crypto.getRandomValues(new Uint8Array(32));
+    const cryptoKey = await window.crypto.subtle.importKey(
+      "raw",
+      rawKey,
+      { name: "AES-GCM", length: 256 },
+      true,
+      ["encrypt", "decrypt"],
+    );
+
+    const docLocal = new Y.Doc();
+    const textLocal = docLocal.getText("scratchpad");
+    docLocal.transact(() => {
+      textLocal.insert(0, "Encrypted CRDT Sync");
+    });
+
+    // Encode and encrypt state vector
+    const vector = Y.encodeStateVector(docLocal);
+    const encryptedVector = await CryptoManager.encryptPayload(
+      cryptoKey,
+      vector,
+    );
+
+    // Decrypt state vector
+    const decryptedVector = await CryptoManager.decryptPayload(
+      cryptoKey,
+      encryptedVector.ciphertext,
+      encryptedVector.iv,
+    );
+
+    expect(decryptedVector).toEqual(vector);
+
+    docLocal.destroy();
+  });
+});

--- a/src/components/sessions/Scratchpad.tsx
+++ b/src/components/sessions/Scratchpad.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import * as Y from "yjs";
 import usePartySocket from "partysocket/react";
 import { CryptoManager } from "@/lib/e2ee/CryptoManager";
 import { KeyStore } from "@/lib/e2ee/KeyStore";
-import { Lock, Unlock, Key, Loader2, Share2 } from "lucide-react";
+import { Unlock, Key, Loader2, Share2 } from "lucide-react";
 import { useToast } from "@/components/ui/Toast";
 import {
   generateKeyPair,
@@ -34,9 +34,12 @@ export default function Scratchpad({ sessionId }: Props) {
   const yTextRef = useRef<Y.Text | null>(null);
   const cryptoKeyRef = useRef<CryptoKey | null>(null);
   const isLocalUpdateRef = useRef(false);
-  const processedUpdatesRef = useRef<Set<string>>(new Set());
   const updateQueueRef = useRef<Uint8Array[]>([]);
   const isApplyingRef = useRef(false);
+  const socketRef = useRef<{
+    send: (data: string) => void;
+    readyState: number;
+  } | null>(null);
 
   const processQueue = () => {
     if (isApplyingRef.current || !docRef.current) return;
@@ -55,6 +58,37 @@ export default function Scratchpad({ sessionId }: Props) {
       isApplyingRef.current = false;
     }
   };
+
+  // Helper to send sync request with local state vector
+  const sendSyncRequest = useCallback(async () => {
+    const currentSocket = socketRef.current;
+    if (
+      !docRef.current ||
+      !cryptoKeyRef.current ||
+      !currentSocket ||
+      currentSocket.readyState !== WebSocket.OPEN
+    ) {
+      return;
+    }
+
+    try {
+      const stateVector = Y.encodeStateVector(docRef.current);
+      const encryptedVector = await CryptoManager.encryptPayload(
+        cryptoKeyRef.current,
+        stateVector,
+      );
+
+      currentSocket.send(
+        JSON.stringify({
+          type: "sync-request",
+          clientId: clientId.current,
+          payload: encryptedVector,
+        }),
+      );
+    } catch (err) {
+      console.error("Failed to send sync request", err);
+    }
+  }, []);
 
   // Initialize Y.Doc
   useEffect(() => {
@@ -90,9 +124,65 @@ export default function Scratchpad({ sessionId }: Props) {
 
   const socket = usePartySocket({
     room: `session-scratchpad-${sessionId}`,
+    onOpen: () => {
+      sendSyncRequest();
+    },
     onMessage: async (e) => {
       try {
         const msg = JSON.parse(e.data);
+
+        // Handle incoming sync-request from a peer
+        if (
+          msg.type === "sync-request" &&
+          cryptoKeyRef.current &&
+          docRef.current
+        ) {
+          if (msg.clientId === clientId.current) return;
+
+          const { ciphertext, iv } = msg.payload;
+          const remoteVector = await CryptoManager.decryptPayload(
+            cryptoKeyRef.current,
+            ciphertext,
+            iv,
+          );
+
+          // Compute delta missing from remote peer's state vector
+          const delta = Y.encodeStateAsUpdate(docRef.current, remoteVector);
+          const encryptedDelta = await CryptoManager.encryptPayload(
+            cryptoKeyRef.current,
+            delta,
+          );
+
+          socket.send(
+            JSON.stringify({
+              type: "sync-response",
+              targetClientId: msg.clientId,
+              payload: encryptedDelta,
+            }),
+          );
+          return;
+        }
+
+        // Handle incoming sync-response from a peer
+        if (
+          msg.type === "sync-response" &&
+          msg.targetClientId === clientId.current &&
+          cryptoKeyRef.current &&
+          docRef.current
+        ) {
+          const { ciphertext, iv } = msg.payload;
+          const decryptedDelta = await CryptoManager.decryptPayload(
+            cryptoKeyRef.current,
+            ciphertext,
+            iv,
+          );
+
+          updateQueueRef.current.push(decryptedDelta);
+          isLocalUpdateRef.current = true;
+          processQueue();
+          isLocalUpdateRef.current = false;
+          return;
+        }
 
         // Handle incoming E2EE delta updates
         if (
@@ -106,7 +196,8 @@ export default function Scratchpad({ sessionId }: Props) {
             ciphertext,
             iv,
           );
-          
+
+          updateQueueRef.current.push(decryptedUpdate);
           isLocalUpdateRef.current = true;
           processQueue();
           isLocalUpdateRef.current = false;
@@ -180,6 +271,10 @@ export default function Scratchpad({ sessionId }: Props) {
     },
   });
 
+  useEffect(() => {
+    socketRef.current = socket;
+  }, [socket]);
+
   // Start negotiation when socket is open
   useEffect(() => {
     if (
@@ -227,11 +322,16 @@ export default function Scratchpad({ sessionId }: Props) {
       if (isLocalUpdateRef.current || !cryptoKeyRef.current) return;
 
       try {
-        const encrypted = await CryptoManager.encryptPayload(cryptoKeyRef.current, update);
-        socket.send(JSON.stringify({
-          type: "e2ee-delta",
-          payload: encrypted
-        }));
+        const encrypted = await CryptoManager.encryptPayload(
+          cryptoKeyRef.current,
+          update,
+        );
+        socket.send(
+          JSON.stringify({
+            type: "e2ee-delta",
+            payload: encrypted,
+          }),
+        );
       } catch (err) {
         console.error("Failed to encrypt/send update", err);
       }
@@ -242,6 +342,27 @@ export default function Scratchpad({ sessionId }: Props) {
       doc.off("update", handleUpdate);
     };
   }, [socket, hasKey]);
+
+  // Re-sync on window focus or network reconnection (e.g. waking from sleep mode)
+  useEffect(() => {
+    const handleReconnect = () => {
+      sendSyncRequest();
+    };
+
+    window.addEventListener("focus", handleReconnect);
+    window.addEventListener("online", handleReconnect);
+
+    return () => {
+      window.removeEventListener("focus", handleReconnect);
+      window.removeEventListener("online", handleReconnect);
+    };
+  }, [sendSyncRequest]);
+
+  useEffect(() => {
+    if (hasKey) {
+      sendSyncRequest();
+    }
+  }, [hasKey, sendSyncRequest]);
   const handleShare = async () => {
     try {
       await navigator.clipboard.writeText(window.location.href);


### PR DESCRIPTION
Key Accomplishments
Yjs State Vector Exchange (sync-request / sync-response):
Implemented sendSyncRequest() in 

Scratchpad.tsx
 to encode the local Yjs document state vector (Y.encodeStateVector(docRef.current)), encrypt it with AES-GCM, and emit a sync-request message.
Added sync-request message handler: Decrypts the remote state vector, computes missing delta updates (Y.encodeStateAsUpdate(docRef.current, remoteVector)), encrypts the delta, and replies with sync-response.
Added sync-response message handler: Decrypts the incoming delta update and applies it to the document using Y.applyUpdate.
Reconnection & Window Focus Event Triggers:
Invoked sendSyncRequest() upon WebSocket re-open (onOpen in usePartySocket).
Attached window focus and online event listeners to automatically trigger sendSyncRequest() when a device wakes up from laptop sleep mode or reconnects to the network.
Automated Verification:
Created unit test suite in 

scratchpadSync.test.ts
 testing state vector generation, E2EE state vector encryption, delta computation, and conflict resolution merging. All tests pass (2/2 passed).
Verified ESLint on Scratchpad.tsx (0 errors, 0 warnings).


closes  #1644

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved encrypted scratchpad synchronization across reconnects and offline periods.
  * Automatically resynchronizes scratchpad content when reconnecting, returning online, refocusing the browser, or obtaining an encryption key.
  * Enhanced peer-to-peer updates to help devices converge on the latest shared content.

* **Tests**
  * Added coverage for offline reconciliation and encrypted synchronization behavior.

* **Bug Fixes**
  * Improved compatibility for test environments requiring web stream support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->