### PR TITLE
Cache WebGPU density heatmap texture when map viewport is stationary

### DIFF
--- a/src/__tests__/lib/webgpu/crowdDensityHeatmap.test.ts
+++ b/src/__tests__/lib/webgpu/crowdDensityHeatmap.test.ts
@@ -6,7 +6,7 @@ import {
   agentVertexShader,
   agentFragmentShader,
 } from "@/lib/webgpu/crowdShaders.wgsl";
-
+import { CrowdSimulationEngine } from "@/lib/webgpu/crowdSimulation";
 describe("Crowd Density Heatmap Shaders (#1267)", () => {
   describe("densityComputeShader", () => {
     it("exports a non-empty WGSL string", () => {
@@ -116,8 +116,63 @@ describe("Crowd Density Heatmap Shaders (#1267)", () => {
         expect(s.length).toBeGreaterThan(50);
       }
 
-      // Density shader is distinct from boids compute shader
+// Density shader is distinct from boids compute shader
       expect(densityComputeShader).not.toBe(computeShader);
     });
+  });
+});
+
+describe("Adaptive density heatmap tile caching (#1557)", () => {
+  function createEngine() {
+    const canvas = { width: 100, height: 100 } as unknown as HTMLCanvasElement;
+    return new CrowdSimulationEngine(canvas, {
+      agentCount: 10,
+      worldWidth: 50,
+      worldHeight: 50,
+      exitPositions: [[25, 0]],
+      wallSegments: [],
+    });
+  }
+
+  it("keeps viewport velocity at zero when the viewport does not change", () => {
+    const engine = createEngine();
+    engine.updateViewport(10, 10, 1);
+    engine.updateViewport(10, 10, 1);
+
+    expect((engine as any).viewportVelocity).toBeCloseTo(0);
+  });
+
+  it("registers non-zero viewport velocity on pan or zoom", () => {
+    const engine = createEngine();
+    engine.updateViewport(0, 0, 1);
+    engine.updateViewport(5, 0, 1);
+
+    expect((engine as any).viewportVelocity).toBeGreaterThan(0);
+  });
+
+  it("invalidates the density texture cache when occupancy changes", () => {
+    const engine = createEngine();
+
+    (engine as any).isDensityTextureCacheValid = true;
+    (engine as any).updateOccupancyState(0);
+    expect((engine as any).isDensityTextureCacheValid).toBe(false);
+
+    (engine as any).isDensityTextureCacheValid = true;
+    (engine as any).updateOccupancyState(0);
+    expect((engine as any).isDensityTextureCacheValid).toBe(true);
+
+    (engine as any).updateOccupancyState(2);
+    expect((engine as any).isDensityTextureCacheValid).toBe(false);
+  });
+
+  it("resets cache state on reset()", () => {
+    const engine = createEngine();
+    (engine as any).isDensityTextureCacheValid = true;
+    (engine as any).lastOccupancyCount = 5;
+
+    engine.reset();
+
+    expect((engine as any).isDensityTextureCacheValid).toBe(false);
+    expect((engine as any).lastOccupancyCount).toBe(-1);
   });
 });

--- a/src/lib/webgpu/crowdSimulation.ts
+++ b/src/lib/webgpu/crowdSimulation.ts
@@ -182,10 +182,18 @@ export class CrowdSimulationEngine {
   private heatmapPipeline: GPURenderPipeline | null = null;
   private heatmapBindGroup: GPUBindGroup | null = null;
   private heatmapTexture: GPUTexture | null = null;
-  private densityBindGroup: GPUBindGroup | null = null;
+private densityBindGroup: GPUBindGroup | null = null;
   private maxDensity = 1;
   private readonly DENSITY_GRID_SIZE = 64;
 
+  // Adaptive heatmap tile caching: skip recomputing the density texture
+  // when the map viewport isn't moving and occupancy hasn't changed.
+  private lastViewportX = 0;
+  private lastViewportY = 0;
+  private lastViewportZoom = 1;
+  private viewportVelocity = 0;
+  private lastOccupancyCount = -1;
+  private isDensityTextureCacheValid = false;
   // Exit + wall buffers
   private exitBuffer: GPUBuffer | null = null;
   private wallBuffer: GPUBuffer | null = null;
@@ -1104,10 +1112,20 @@ export class CrowdSimulationEngine {
         computePass.end();
       }
 
+// Adaptive caching: only stationary viewport + unchanged occupancy
+      // counts as "safe to reuse" the existing density texture.
+      const isViewportStationary = this.viewportVelocity < 1e-4;
+      const canUseCachedDensityTexture =
+        isViewportStationary && this.isDensityTextureCacheValid;
+
       // ── Compute Pass: Density accumulation ──
       const densityPipeline = (this as unknown as { _densityPipeline: unknown })
         ._densityPipeline;
-      if (densityPipeline && this.densityBindGroup) {
+      if (
+        densityPipeline &&
+        this.densityBindGroup &&
+        !canUseCachedDensityTexture
+      ) {
         const densityPass = commandEncoder.beginComputePass();
         densityPass.setPipeline(densityPipeline as GPUComputePipeline);
         densityPass.setBindGroup(0, this.densityBindGroup);
@@ -1117,8 +1135,11 @@ export class CrowdSimulationEngine {
       }
 
       // ── Copy density buffer → density texture ──
-      if (this.densityBuffer && this.densityTexture) {
-        const gridW = this.DENSITY_GRID_SIZE;
+      if (
+        this.densityBuffer &&
+        this.densityTexture &&
+        !canUseCachedDensityTexture
+      ) {        const gridW = this.DENSITY_GRID_SIZE;
         const bytesPerRow = gridW * 4;
         const alignedBytesPerRow = Math.ceil(bytesPerRow / 256) * 256;
 
@@ -1153,11 +1174,12 @@ export class CrowdSimulationEngine {
           },
         );
 
-        // We'll destroy staging after submit
+// We'll destroy staging after submit
         (this as unknown as { _stagingBuffer: GPUBuffer })._stagingBuffer =
           stagingBuffer;
-      }
 
+        this.isDensityTextureCacheValid = true;
+      }
       // ── Render Pass: Agents ──
       const textureView = this.context.getCurrentTexture().createView();
 
@@ -1346,14 +1368,14 @@ export class CrowdSimulationEngine {
         readback.unmap();
         readback.destroy();
 
-        // Count evacuated
+// Count evacuated
         let evacuated = 0;
         for (let i = 0; i < this.config.agentCount; i++) {
           if (this.agents[i * 8 + 5] === 1) evacuated++;
         }
 
-        this.onFrameCallback?.(this.agents, evacuated);
-      });
+        this.updateOccupancyState(evacuated);
+        this.onFrameCallback?.(this.agents, evacuated);      });
     } catch {
       // Silently fail — readback is non-critical
     }
@@ -1381,19 +1403,48 @@ export class CrowdSimulationEngine {
     }
   }
 
-  onFrame(callback: (agents: Float32Array, evacuated: number) => void): void {
+onFrame(callback: (agents: Float32Array, evacuated: number) => void): void {
     this.onFrameCallback = callback;
   }
 
-  reset(): void {
+  /**
+   * Report the current map viewport (pan position + zoom level) so the
+   * engine can detect when the view is stationary and skip recomputing
+   * the density heatmap texture that frame.
+   */
+  updateViewport(x: number, y: number, zoom: number): void {
+    const dx = x - this.lastViewportX;
+    const dy = y - this.lastViewportY;
+    const dz = zoom - this.lastViewportZoom;
+    this.viewportVelocity = Math.hypot(dx, dy) + Math.abs(dz);
+
+    this.lastViewportX = x;
+    this.lastViewportY = y;
+    this.lastViewportZoom = zoom;
+  }
+
+  /**
+   * Tell the engine how many agents currently occupy the venue. When this
+   * changes, the cached density texture is invalidated even if the
+   * viewport is otherwise stationary.
+   */
+  private updateOccupancyState(evacuated: number): void {
+    const occupancyCount = this.config.agentCount - evacuated;
+    if (occupancyCount !== this.lastOccupancyCount) {
+      this.lastOccupancyCount = occupancyCount;
+      this.isDensityTextureCacheValid = false;
+    }
+  }
+reset(): void {
     this.spawnAgents();
     if (this.device && this.agentBufferA) {
       this.device.queue.writeBuffer(this.agentBufferA, 0, this.agents as any);
     }
     this.currentReadBuffer = 0;
     this.time = 0;
+    this.lastOccupancyCount = -1;
+    this.isDensityTextureCacheValid = false;
   }
-
   private cleanupGPUResources(): void {
     this.agentBufferA?.destroy();
     this.agentBufferB?.destroy();


### PR DESCRIPTION
## Summary
fixes  #1557 — `CrowdSimulationEngine` was recomputing the density compute pass and rebuilding the density texture every single frame, even when the map viewport wasn't panning or zooming and occupancy hadn't changed.

## Changes
- Added viewport tracking (`updateViewport(x, y, zoom)`) that computes a `viewportVelocity` from the delta between the last and current pan/zoom state.
- Added occupancy tracking (`updateOccupancyState`) that invalidates the density texture cache whenever the number of agents still in the venue changes, called from the existing agent readback path.
- In `renderFrame`, the density compute pass and the buffer→texture copy are now skipped whenever the viewport is stationary (`viewportVelocity` ~0) and the cached texture is still valid — the previous frame's texture is reused as-is.
- The cache is marked valid right after a texture rebuild, and explicitly invalidated in `reset()` so a fresh simulation never reuses a stale heatmap.

## Testing
- Added `src/__tests__/lib/webgpu/crowdDensityHeatmap.test.ts` coverage (new `describe` block, existing shader tests untouched) for:
  - Zero viewport velocity when pan/zoom doesn't change.
  - Non-zero velocity on pan/zoom.
  - Cache invalidation on occupancy change vs. staying valid when occupancy is unchanged.
  - Cache reset behavior on `reset()`.

I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.

Hi @SatyamPandey-07 , could you please review this PR for a potential bonus label based on the metrics below? Thanks!
<img width="662" height="301" alt="labels" src="https://github.com/user-attachments/assets/85a9208b-ed39-494d-96fd-8653e67b1869" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved density heatmap rendering by reusing cached results when the viewport is stationary and occupancy is unchanged.
  - Automatically refreshes the heatmap after viewport movement, zooming, or occupancy changes.

- **Bug Fixes**
  - Reset operations now correctly clear cached heatmap state.
  - Improved tracking of evacuated agents for more accurate heatmap updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->