### PR TITLE
Fix: web worker venue layout calculation race condition during window resize

### DIFF
--- a/src/__tests__/hooks/useLayoutOptimizer.test.ts
+++ b/src/__tests__/hooks/useLayoutOptimizer.test.ts
@@ -102,7 +102,7 @@ describe("useLayoutOptimizer", () => {
     act(() => {
       worker.emitMessage({
         type: "SUCCESS",
-        requestId: request.requestId,
+        sequenceId: request.sequenceId,
         payload: {
           deskCoordinatesBuffer: desks.buffer,
           quietZoneCoordinatesBuffer: quietZones.buffer,
@@ -146,7 +146,7 @@ describe("useLayoutOptimizer", () => {
     act(() => {
       worker.emitMessage({
         type: "ERROR",
-        requestId: request.requestId,
+        sequenceId: request.sequenceId,
         error: "Invalid floor-plan dimensions.",
       });
     });
@@ -184,12 +184,60 @@ describe("useLayoutOptimizer", () => {
     act(() => {
       worker.emitMessage({
         type: "ERROR",
-        requestId: firstRequest.requestId,
+        sequenceId: firstRequest.sequenceId,
         error: "Stale error",
       });
     });
 
     expect(result.current.error).toBeNull();
+    expect(result.current.isOptimizing).toBe(true);
+  });
+
+  it("ignores out-of-order SUCCESS layout messages", () => {
+    const { result } = renderHook(() => useLayoutOptimizer());
+    const worker = MockWorker.instances[0];
+
+    act(() => {
+      // First request (sequenceId 1)
+      result.current.optimize({
+        floorPlanGrid: [0],
+        width: 1,
+        height: 1,
+        deskCount: 1,
+        powerOutlets: [],
+      });
+
+      // Second request (sequenceId 2)
+      result.current.optimize({
+        floorPlanGrid: [0, 0, 0, 0],
+        width: 2,
+        height: 2,
+        deskCount: 1,
+        powerOutlets: [],
+      });
+    });
+
+    const firstRequest = worker.postMessage.mock
+      .calls[0][0] as LayoutWorkerRequest;
+
+    act(() => {
+      // Respond to the first request (out-of-order because we already sent request 2)
+      const desks = new Float32Array([1, 2, 0]);
+      const quietZones = new Float32Array([5, 6, 2]);
+
+      worker.emitMessage({
+        type: "SUCCESS",
+        sequenceId: firstRequest.sequenceId,
+        payload: {
+          deskCoordinatesBuffer: desks.buffer,
+          quietZoneCoordinatesBuffer: quietZones.buffer,
+          score: 0.8,
+        },
+      });
+    });
+
+    // Should ignore the first request's SUCCESS and still be optimizing the second one
+    expect(result.current.recommendation).toBeNull();
     expect(result.current.isOptimizing).toBe(true);
   });
 });

--- a/src/components/chat/VenueDetailDialog.tsx
+++ b/src/components/chat/VenueDetailDialog.tsx
@@ -434,7 +434,7 @@ export function VenueDetailDialog({
           setLeaderboard(lbData.leaderboard || []);
         }
         if (metricsRes.ok) {
-          const data = await response.json();
+          const data = await metricsRes.json();
           setVoteMetrics(() => ({
             wifi: {
               confidenceScore: 100,
@@ -1685,14 +1685,24 @@ export function VenueDetailDialog({
                   </h4>
                   <div className="space-y-1.5">
                     {leaderboard.map((entry: any, idx: number) => (
-                      <div key={entry.userId} className="flex items-center justify-between text-xs">
+                      <div
+                        key={entry.userId}
+                        className="flex items-center justify-between text-xs"
+                      >
                         <div className="flex items-center gap-2">
-                          <span className="w-4 text-center text-[10px] font-mono text-zinc-500">{idx + 1}.</span>
-                          <span className="font-medium text-zinc-300">{entry.name || "Anonymous"}</span>
-                          {entry.accurateVotes >= 10 && <BadgeCheck className="w-3 h-3 text-amber-400" />}
+                          <span className="w-4 text-center text-[10px] font-mono text-zinc-500">
+                            {idx + 1}.
+                          </span>
+                          <span className="font-medium text-zinc-300">
+                            {entry.name || "Anonymous"}
+                          </span>
+                          {entry.accurateVotes >= 10 && (
+                            <BadgeCheck className="w-3 h-3 text-amber-400" />
+                          )}
                         </div>
                         <span className="font-mono text-zinc-500 text-[10px]">
-                          {entry.totalVotes} vote{entry.totalVotes !== 1 ? "s" : ""}
+                          {entry.totalVotes} vote
+                          {entry.totalVotes !== 1 ? "s" : ""}
                         </span>
                       </div>
                     ))}

--- a/src/hooks/useLayoutOptimizer.ts
+++ b/src/hooks/useLayoutOptimizer.ts
@@ -47,8 +47,8 @@ export function useLayoutOptimizer() {
   const [isOptimizing, setIsOptimizing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const workerRef = useRef<Worker | null>(null);
-  const requestIdRef = useRef(0);
-  const activeRequestIdRef = useRef<number | null>(null);
+  const sequenceIdRef = useRef(0);
+  const activeSequenceIdRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (typeof Worker === "undefined") {
@@ -66,7 +66,10 @@ export function useLayoutOptimizer() {
     worker.onmessage = (event: MessageEvent<LayoutWorkerResponse>) => {
       const message = event.data;
 
-      if (message.requestId !== activeRequestIdRef.current) {
+      if (
+        activeSequenceIdRef.current !== null &&
+        message.sequenceId < activeSequenceIdRef.current
+      ) {
         return;
       }
 
@@ -77,20 +80,20 @@ export function useLayoutOptimizer() {
         setError(message.error);
       }
 
-      activeRequestIdRef.current = null;
+      activeSequenceIdRef.current = null;
       setIsOptimizing(false);
     };
 
     worker.onerror = () => {
       setError("The layout optimization worker stopped unexpectedly.");
-      activeRequestIdRef.current = null;
+      activeSequenceIdRef.current = null;
       setIsOptimizing(false);
     };
 
     return () => {
       worker.terminate();
       workerRef.current = null;
-      activeRequestIdRef.current = null;
+      activeSequenceIdRef.current = null;
     };
   }, []);
 
@@ -107,14 +110,14 @@ export function useLayoutOptimizer() {
         ? new Float32Array(request.floorPlanGrid)
         : Float32Array.from(request.floorPlanGrid);
 
-    const requestId = ++requestIdRef.current;
-    activeRequestIdRef.current = requestId;
+    const sequenceId = ++sequenceIdRef.current;
+    activeSequenceIdRef.current = sequenceId;
     setIsOptimizing(true);
     setError(null);
 
     const message: LayoutWorkerRequest = {
       type: "OPTIMIZE",
-      requestId,
+      sequenceId,
       payload: {
         floorPlanGridBuffer: floorPlanGrid.buffer as ArrayBuffer,
         width: request.width,

--- a/src/workers/layoutOptimizer.worker.ts
+++ b/src/workers/layoutOptimizer.worker.ts
@@ -16,7 +16,7 @@ export type LayoutRecommendation = {
 
 export type LayoutWorkerRequest = {
   type: "OPTIMIZE";
-  requestId: number;
+  sequenceId: number;
   payload: Omit<LayoutRequest, "floorPlanGrid"> & {
     floorPlanGridBuffer: ArrayBuffer;
   };
@@ -24,7 +24,7 @@ export type LayoutWorkerRequest = {
 
 export type LayoutWorkerSuccess = {
   type: "SUCCESS";
-  requestId: number;
+  sequenceId: number;
   payload: {
     deskCoordinatesBuffer: ArrayBuffer;
     quietZoneCoordinatesBuffer: ArrayBuffer;
@@ -34,7 +34,7 @@ export type LayoutWorkerSuccess = {
 
 export type LayoutWorkerFailure = {
   type: "ERROR";
-  requestId: number;
+  sequenceId: number;
   error: string;
 };
 
@@ -219,7 +219,7 @@ self.addEventListener(
 
       const response: LayoutWorkerSuccess = {
         type: "SUCCESS",
-        requestId: message.requestId,
+        sequenceId: message.sequenceId,
         payload: {
           deskCoordinatesBuffer: deskCoordinates.buffer as ArrayBuffer,
           quietZoneCoordinatesBuffer:
@@ -237,7 +237,7 @@ self.addEventListener(
     } catch (error) {
       const response: LayoutWorkerFailure = {
         type: "ERROR",
-        requestId: message.requestId,
+        sequenceId: message.sequenceId,
         error:
           error instanceof Error
             ? error.message


### PR DESCRIPTION
- closes #1809

### **Description**:

This PR addresses two main issues:

1. **Layout Optimizer WebWorker Race Conditions**:
    - **Problem**: Rapidly resizing the browser window caused out-of-order `postMessage` responses from the `layoutOptimizer` worker, sometimes overriding the latest calculations with stale data.
    - **Solution**: 
      - Replaced `requestId` with an auto-incrementing `sequenceId` across worker types and the client hook.
      - Updated `useLayoutOptimizer.ts` to strictly validate `message.sequenceId < activeSequenceIdRef.current`, discarding any obsolete worker responses immediately.
      - Added new unit test to explicitly verify that out-of-order `SUCCESS` responses are ignored without mutating the state.

2. **Build Type Error**:
    - **Problem**: A typo (`response.json()` instead of `metricsRes.json()`) inside the `VenueDetailDialog.tsx` chat component was causing a typescript validation failure and preventing the production build from succeeding.
    - **Solution**: Fixed the missing reference to successfully unblock `npm run build`.

### **Testing**:
- All test suites in `src/__tests__/hooks/useLayoutOptimizer.test.ts` pass successfully.
- `npm run build` succeeds locally without type errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed venue amenity vote metrics so they load and display correctly.
  * Improved the Top Voters leaderboard’s rank, names, badges, and vote-count formatting.
  * Prevented outdated layout optimization results from replacing newer optimization progress or recommendations.
  * Improved handling of optimization errors and responses when multiple requests are processed close together.

* **Tests**
  * Added coverage to verify that out-of-order optimization responses are safely ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->