### PR TITLE
bug: fix spatial audio listener position interpolation lag during room movement (closes #1716)

### DIFF
--- a/src/__tests__/lib/spatialAudio.test.ts
+++ b/src/__tests__/lib/spatialAudio.test.ts
@@ -196,7 +196,7 @@ describe("RemoteListenerInterpolator", () => {
     expect(history).toHaveLength(1);
   });
 
-  it("interpolates position linearly between timestamps", () => {
+  it("interpolates position using cubic Hermite spline for smooth transitions", () => {
     const interpolator = new RemoteListenerInterpolator(4);
 
     const update1: SpatialListenerUpdate = {
@@ -211,17 +211,54 @@ describe("RemoteListenerInterpolator", () => {
     const update2: SpatialListenerUpdate = {
       type: "spatial_listener_update",
       userId: "user-1",
-      position: { x: 10, y: 0, z: 20 },
-      forward: { x: 0, y: 0, z: 1 },
+      position: { x: 10, y: 0, z: 10 },
+      forward: { x: 0, y: 0, z: -1 },
       up: { x: 0, y: 1, z: 0 },
       timestamp: 2000,
     };
 
+    const update3: SpatialListenerUpdate = {
+      type: "spatial_listener_update",
+      userId: "user-1",
+      position: { x: 30, y: 0, z: 30 },
+      forward: { x: 0, y: 0, z: -1 },
+      up: { x: 0, y: 1, z: 0 },
+      timestamp: 3000,
+    };
+
     interpolator.applyUpdate(update1, mockRouter);
     interpolator.applyUpdate(update2, mockRouter);
+    interpolator.applyUpdate(update3, mockRouter);
 
+    // Hermite spline at midpoint 1500 accounts for acceleration/velocities
     const mid = interpolator.interpolate("user-1", 1500);
-    expect(mid?.position).toEqual({ x: 5, y: 0, z: 10 });
+    expect(mid?.position.x).toBeCloseTo(4.375);
+    expect(mid?.position.z).toBeCloseTo(4.375);
+  });
+
+  it("clamps spatial position and orientation values within safe limits", () => {
+    const interpolator = new RemoteListenerInterpolator(4);
+
+    const update: SpatialListenerUpdate = {
+      type: "spatial_listener_update",
+      userId: "user-1",
+      position: { x: 250, y: -150, z: 10 },
+      forward: { x: 1.5, y: -2.0, z: 0 },
+      up: { x: 0, y: 1, z: 0 },
+      timestamp: 1000,
+    };
+
+    interpolator.applyUpdate(update, mockRouter);
+
+    expect(mockRouter.updatePeerPosition).toHaveBeenCalledWith(
+      "user-1",
+      100,
+      -100,
+      10,
+    );
+
+    const history = interpolator.getHistory("user-1");
+    expect(history?.[0].position).toEqual({ x: 100, y: -100, z: 10 });
   });
 
   it("registers window resize listener on setup and removes it on dispose", () => {

--- a/src/lib/spatial/RemoteListenerInterpolator.ts
+++ b/src/lib/spatial/RemoteListenerInterpolator.ts
@@ -15,6 +15,100 @@ export interface SpatialListenerUpdate {
   timestamp: number;
 }
 
+export const MIN_POSITION = -100.0;
+export const MAX_POSITION = 100.0;
+export const MIN_ORIENTATION = -1.0;
+export const MAX_ORIENTATION = 1.0;
+
+function clamp(v: number, min: number, max: number): number {
+  if (Number.isNaN(v) || !Number.isFinite(v)) return 0;
+  return Math.max(min, Math.min(max, v));
+}
+
+function clampVector(v: Vector3D, min: number, max: number): Vector3D {
+  return {
+    x: clamp(v.x, min, max),
+    y: clamp(v.y, min, max),
+    z: clamp(v.z, min, max),
+  };
+}
+
+function normalizeVector(v: Vector3D): Vector3D {
+  const len = Math.sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
+  if (len === 0) {
+    return { x: 0, y: 0, z: -1 };
+  }
+  return {
+    x: v.x / len,
+    y: v.y / len,
+    z: v.z / len,
+  };
+}
+
+function getTangent(
+  list: SpatialListenerUpdate[],
+  index: number,
+  field: "position" | "forward",
+): Vector3D {
+  const N = list.length;
+  if (N < 2) {
+    return { x: 0, y: 0, z: 0 };
+  }
+
+  if (index === 0) {
+    const p0 = list[0][field];
+    const p1 = list[1][field];
+    const dt = list[1].timestamp - list[0].timestamp;
+    if (dt <= 0) return { x: 0, y: 0, z: 0 };
+    return {
+      x: (p1.x - p0.x) / dt,
+      y: (p1.y - p0.y) / dt,
+      z: (p1.z - p0.z) / dt,
+    };
+  }
+
+  if (index === N - 1) {
+    const pN_2 = list[N - 2][field];
+    const pN_1 = list[N - 1][field];
+    const dt = list[N - 1].timestamp - list[N - 2].timestamp;
+    if (dt <= 0) return { x: 0, y: 0, z: 0 };
+    return {
+      x: (pN_1.x - pN_2.x) / dt,
+      y: (pN_1.y - pN_2.y) / dt,
+      z: (pN_1.z - pN_2.z) / dt,
+    };
+  }
+
+  const pPrev = list[index - 1][field];
+  const pNext = list[index + 1][field];
+  const dt = list[index + 1].timestamp - list[index - 1].timestamp;
+  if (dt <= 0) return { x: 0, y: 0, z: 0 };
+  return {
+    x: (pNext.x - pPrev.x) / dt,
+    y: (pNext.y - pPrev.y) / dt,
+    z: (pNext.z - pPrev.z) / dt,
+  };
+}
+
+function interpolateHermite(
+  p0: number,
+  m0: number,
+  p1: number,
+  m1: number,
+  h: number,
+  t: number,
+): number {
+  const t2 = t * t;
+  const t3 = t2 * t;
+
+  const h00 = 2 * t3 - 3 * t2 + 1;
+  const h10 = t3 - 2 * t2 + t;
+  const h01 = -2 * t3 + 3 * t2;
+  const h11 = t3 - t2;
+
+  return h00 * p0 + h10 * h * m0 + h01 * p1 + h11 * h * m1;
+}
+
 export class RemoteListenerInterpolator {
   private history = new Map<string, SpatialListenerUpdate[]>();
   private readonly maxHistory: number;
@@ -33,7 +127,23 @@ export class RemoteListenerInterpolator {
    */
   applyUpdate(update: SpatialListenerUpdate, router: SpatialAudioRouter): void {
     const list = this.history.get(update.userId) ?? [];
-    list.push(update);
+
+    const clampedPos = clampVector(update.position, MIN_POSITION, MAX_POSITION);
+    const clampedForward = clampVector(
+      update.forward,
+      MIN_ORIENTATION,
+      MAX_ORIENTATION,
+    );
+    const clampedUp = clampVector(update.up, MIN_ORIENTATION, MAX_ORIENTATION);
+
+    const sanitizedUpdate: SpatialListenerUpdate = {
+      ...update,
+      position: clampedPos,
+      forward: clampedForward,
+      up: clampedUp,
+    };
+
+    list.push(sanitizedUpdate);
     if (list.length > this.maxHistory) {
       list.shift();
     }
@@ -41,16 +151,17 @@ export class RemoteListenerInterpolator {
 
     router.updatePeerPosition(
       update.userId,
-      update.position.x,
-      update.position.y,
-      update.position.z,
+      clampedPos.x,
+      clampedPos.y,
+      clampedPos.z,
     );
 
+    const normalizedForward = normalizeVector(clampedForward);
     router.updatePeerOrientation(
       update.userId,
-      update.forward.x,
-      update.forward.y,
-      update.forward.z,
+      normalizedForward.x,
+      normalizedForward.y,
+      normalizedForward.z,
     );
   }
 
@@ -65,37 +176,98 @@ export class RemoteListenerInterpolator {
     if (!list || list.length === 0) return null;
 
     if (list.length === 1) {
-      return { position: list[0].position, forward: list[0].forward };
+      return {
+        position: clampVector(list[0].position, MIN_POSITION, MAX_POSITION),
+        forward: normalizeVector(
+          clampVector(list[0].forward, MIN_ORIENTATION, MAX_ORIENTATION),
+        ),
+      };
     }
 
-    let before = list[0];
-    let after = list[list.length - 1];
+    let beforeIdx = 0;
+    let afterIdx = list.length - 1;
 
     for (let i = 0; i < list.length - 1; i++) {
       if (list[i].timestamp <= atTime && list[i + 1].timestamp >= atTime) {
-        before = list[i];
-        after = list[i + 1];
+        beforeIdx = i;
+        afterIdx = i + 1;
         break;
       }
     }
 
+    const before = list[beforeIdx];
+    const after = list[afterIdx];
     const duration = after.timestamp - before.timestamp;
     const t =
       duration > 0
         ? Math.max(0, Math.min(1, (atTime - before.timestamp) / duration))
         : 0;
 
+    const m0 = getTangent(list, beforeIdx, "position");
+    const m1 = getTangent(list, afterIdx, "position");
+
+    const fm0 = getTangent(list, beforeIdx, "forward");
+    const fm1 = getTangent(list, afterIdx, "forward");
+
+    const interpPos = {
+      x: interpolateHermite(
+        before.position.x,
+        m0.x,
+        after.position.x,
+        m1.x,
+        duration,
+        t,
+      ),
+      y: interpolateHermite(
+        before.position.y,
+        m0.y,
+        after.position.y,
+        m1.y,
+        duration,
+        t,
+      ),
+      z: interpolateHermite(
+        before.position.z,
+        m0.z,
+        after.position.z,
+        m1.z,
+        duration,
+        t,
+      ),
+    };
+
+    const interpForward = {
+      x: interpolateHermite(
+        before.forward.x,
+        fm0.x,
+        after.forward.x,
+        fm1.x,
+        duration,
+        t,
+      ),
+      y: interpolateHermite(
+        before.forward.y,
+        fm0.y,
+        after.forward.y,
+        fm1.y,
+        duration,
+        t,
+      ),
+      z: interpolateHermite(
+        before.forward.z,
+        fm0.z,
+        after.forward.z,
+        fm1.z,
+        duration,
+        t,
+      ),
+    };
+
     return {
-      position: {
-        x: before.position.x + t * (after.position.x - before.position.x),
-        y: before.position.y + t * (after.position.y - before.position.y),
-        z: before.position.z + t * (after.position.z - before.position.z),
-      },
-      forward: {
-        x: before.forward.x + t * (after.forward.x - before.forward.x),
-        y: before.forward.y + t * (after.forward.y - before.forward.y),
-        z: before.forward.z + t * (after.forward.z - before.forward.z),
-      },
+      position: clampVector(interpPos, MIN_POSITION, MAX_POSITION),
+      forward: normalizeVector(
+        clampVector(interpForward, MIN_ORIENTATION, MAX_ORIENTATION),
+      ),
     };
   }
 

--- a/src/lib/spatial/SpatialAudioRouter.ts
+++ b/src/lib/spatial/SpatialAudioRouter.ts
@@ -24,17 +24,25 @@ export class SpatialAudioRouter {
    * Update local AudioListener position in world space.
    */
   updateListenerPosition(x: number, y: number, z: number): void {
+    const clampPos = (v: number) =>
+      Math.max(
+        -100,
+        Math.min(100, Number.isNaN(v) || !Number.isFinite(v) ? 0 : v),
+      );
+    const cx = clampPos(x);
+    const cy = clampPos(y);
+    const cz = clampPos(z);
     const listener = this.ctx.listener;
     if ("positionX" in listener) {
-      listener.positionX.value = x;
-      listener.positionY.value = y;
-      listener.positionZ.value = z;
+      listener.positionX.value = cx;
+      listener.positionY.value = cy;
+      listener.positionZ.value = cz;
     } else if ("setPosition" in listener) {
       (
         listener as unknown as {
           setPosition: (x: number, y: number, z: number) => void;
         }
-      ).setPosition(x, y, z);
+      ).setPosition(cx, cy, cz);
     }
   }
 
@@ -49,14 +57,22 @@ export class SpatialAudioRouter {
     upY: number,
     upZ: number,
   ): void {
+    const clampOri = (v: number) =>
+      Math.max(-1, Math.min(1, Number.isNaN(v) || !Number.isFinite(v) ? 0 : v));
+    const cfx = clampOri(forwardX);
+    const cfy = clampOri(forwardY);
+    const cfz = clampOri(forwardZ);
+    const cux = clampOri(upX);
+    const cuy = clampOri(upY);
+    const cuz = clampOri(upZ);
     const listener = this.ctx.listener;
     if ("forwardX" in listener) {
-      listener.forwardX.value = forwardX;
-      listener.forwardY.value = forwardY;
-      listener.forwardZ.value = forwardZ;
-      listener.upX.value = upX;
-      listener.upY.value = upY;
-      listener.upZ.value = upZ;
+      listener.forwardX.value = cfx;
+      listener.forwardY.value = cfy;
+      listener.forwardZ.value = cfz;
+      listener.upX.value = cux;
+      listener.upY.value = cuy;
+      listener.upZ.value = cuz;
     } else if ("setOrientation" in listener) {
       (
         listener as unknown as {
@@ -69,7 +85,7 @@ export class SpatialAudioRouter {
             uz: number,
           ) => void;
         }
-      ).setOrientation(forwardX, forwardY, forwardZ, upX, upY, upZ);
+      ).setOrientation(cfx, cfy, cfz, cux, cuy, cuz);
     }
   }
 
@@ -117,20 +133,29 @@ export class SpatialAudioRouter {
     const chain = this.chains.get(peerId);
     if (!chain) return;
 
+    const clampPos = (v: number) =>
+      Math.max(
+        -100,
+        Math.min(100, Number.isNaN(v) || !Number.isFinite(v) ? 0 : v),
+      );
+    const cx = clampPos(x);
+    const cy = clampPos(y);
+    const cz = clampPos(z);
+
     if (
       typeof chain.panner.positionX === "object" &&
       chain.panner.positionX !== null &&
       "value" in chain.panner.positionX
     ) {
-      chain.panner.positionX.value = x;
-      chain.panner.positionY.value = y;
-      chain.panner.positionZ.value = z;
+      chain.panner.positionX.value = cx;
+      chain.panner.positionY.value = cy;
+      chain.panner.positionZ.value = cz;
     } else if ("setPosition" in chain.panner) {
       (
         chain.panner as unknown as {
           setPosition: (x: number, y: number, z: number) => void;
         }
-      ).setPosition(x, y, z);
+      ).setPosition(cx, cy, cz);
     }
   }
 
@@ -146,20 +171,26 @@ export class SpatialAudioRouter {
     const chain = this.chains.get(peerId);
     if (!chain) return;
 
+    const clampOri = (v: number) =>
+      Math.max(-1, Math.min(1, Number.isNaN(v) || !Number.isFinite(v) ? 0 : v));
+    const cox = clampOri(ox);
+    const coy = clampOri(oy);
+    const coz = clampOri(oz);
+
     if (
       typeof chain.panner.orientationX === "object" &&
       chain.panner.orientationX !== null &&
       "value" in chain.panner.orientationX
     ) {
-      chain.panner.orientationX.value = ox;
-      chain.panner.orientationY.value = oy;
-      chain.panner.orientationZ.value = oz;
+      chain.panner.orientationX.value = cox;
+      chain.panner.orientationY.value = coy;
+      chain.panner.orientationZ.value = coz;
     } else if ("setOrientation" in chain.panner) {
       (
         chain.panner as unknown as {
           setOrientation: (x: number, y: number, z: number) => void;
         }
-      ).setOrientation(ox, oy, oz);
+      ).setOrientation(cox, coy, coz);
     }
   }
 


### PR DESCRIPTION
closes #1716

# Description

This PR resolves the volume jumps and panning distortion that occurred when moving in the 3D room. It upgrades the linear step interpolation in `RemoteListenerInterpolator` to a cubic Hermite spline interpolation model and clamps coordinate values.

## Key Changes

- **Cubic Hermite Spline Interpolation**: Replaced the linear step math inside `interpolate()` in `src/lib/spatial/RemoteListenerInterpolator.ts` with cubic Hermite spline interpolation using computed velocity/tangent vectors from history samples.
- **Web Audio Clamping & Normalization**: Integrated boundary clamping to constrain positions to `[-100.0, 100.0]` and orientation components to `[-1.0, 1.0]` across both `RemoteListenerInterpolator.ts` and `SpatialAudioRouter.ts` to prevent PannerNode audio clipping or division-by-zero errors. Added orientation vector normalization.
- **Automated Tests**: Updated `src/__tests__/lib/spatialAudio.test.ts` to verify the smooth transition steps generated by the cubic Hermite spline math and test coordinate bounds clamping.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Spatial listener movement now uses smoother interpolation for more natural audio positioning.
  - Spatial position and orientation values are constrained to safe supported ranges.
  - Invalid or non-finite spatial values are safely handled before being applied.

- **Bug Fixes**
  - Prevented extreme spatial inputs from producing unreliable listener or peer audio placement.
  - Ensured interpolated orientation values remain valid and stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->