### PR TITLE
fix: standardize favorites on OSM placeId to fix broken heart state on page reload (#1900)

### DIFF
--- a/src/app/api/favorites/route.ts
+++ b/src/app/api/favorites/route.ts
@@ -19,7 +19,18 @@ export async function GET() {
     const favorites = await prisma.favorite.findMany({
       where: { userId },
       include: {
-        venue: true,
+        venue: {
+          select: {
+            id: true,
+            placeId: true,
+            name: true,
+            latitude: true,
+            longitude: true,
+            category: true,
+            address: true,
+            image: true,
+          },
+        },
         tags: {
           orderBy: { createdAt: "asc" },
         },
@@ -29,7 +40,12 @@ export async function GET() {
       },
     });
 
-    return NextResponse.json({ favorites });
+    return NextResponse.json({
+      favorites: favorites.map((f) => ({
+        ...f,
+        venuePlaceId: f.venue.placeId,
+      })),
+    });
   } catch (error) {
     console.error("GET /api/favorites error:", error);
     return NextResponse.json(

--- a/src/components/EnhancedChatbot.tsx
+++ b/src/components/EnhancedChatbot.tsx
@@ -495,7 +495,10 @@ export function EnhancedChatbot({
         const data = await res.json();
         setFavorites(
           new Set<string>(
-            data.favorites?.map((f: { venueId: string }) => f.venueId) || [],
+            data.favorites?.map(
+              (f: { venuePlaceId?: string; venueId: string }) =>
+                f.venuePlaceId || f.venueId,
+            ) || [],
           ),
         );
       }


### PR DESCRIPTION
﻿## Description

This PR fixes the favorites system where the heart icon never shows the correct "favorited" state after page reload due to an ID mismatch between the backend (Prisma internal UUIDs) and frontend (OSM IDs).

When adding a favorite, the venue is upserted by placeId (OSM ID like "12345"), but the favorite record stores enueId as the Prisma internal UUID. The frontend loads favorites and checks avorites.has(venue.id) where enue.id is the OSM ID — which never matches the stored Prisma UUID. During a session, optimistic updates work because the OSM ID is added to the local Set, but on refresh, all venues appear unfavorited.

This PR:
1. Adds enue.placeId (OSM ID) to the favorites GET response as enuePlaceId
2. Keys the favorites Set by enuePlaceId instead of enueId in the frontend
3. Falls back to enueId if enuePlaceId is unavailable

---

## Related Issue

* Closes #1900

---

## Component(s) Affected

* [x] Backend (src/app/api/favorites/route.ts)
* [x] Frontend (src/components/EnhancedChatbot.tsx, plus ChatMessages.tsx and VenueDetailDialog.tsx via propagation)
* [ ] Mobile app
* [ ] Docs only
* [ ] CI / tooling

---

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor
* [ ] Tests
* [ ] Other:

---

## Testing Performed

### Commands executed

* [x] npm run lint
* [x] npm run build

### Manually verified

* Verified favorites heart shows correct state on page load
* Verified toggle favorite (add/remove) works correctly
* Verified state persists across page navigation and reload
* Verified VenueDetailDialog Save button reflects correct state

### Edge cases considered

* Venues without placeId (fallback to venueId)
* Empty favorites list
* New venues not yet saved as favorites
* Cross-session persistence

---

## API Documentation

GET /api/favorites response now includes enuePlaceId (OSM ID) on each favorite object.

---

## Checklist

* [x] I have read CONTRIBUTING.md
* [ ] I rebased/merged the latest main into this branch
* [x] I tested my changes locally
* [x] I removed debug prints and unused imports
* [x] This PR is scoped to one logical change
