### PR TITLE
Feature: Add venue category filter chip count indicators

### DIFF
--- a/src/components/EnhancedChatbot.tsx
+++ b/src/components/EnhancedChatbot.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useUser, useAuth } from "@clerk/nextjs";
 import { motion, AnimatePresence } from "framer-motion";
 import { useMultiplayerSession } from "@/hooks/useRealTime";
@@ -158,6 +158,21 @@ export function EnhancedChatbot({
     {},
   );
   const [filters, setFilters] = useState<Filters>({});
+  const categoryCounts = useMemo(() => {
+    const counts = { cafe: 0, coworking: 0, library: 0 };
+    const latestWithVenues = [...messages]
+      .reverse()
+      .find((m) => m.venues && m.venues.length > 0);
+    const venues = latestWithVenues?.venues ?? [];
+    venues.forEach((v) => {
+      const cat = (v.category || "").toLowerCase();
+      if (cat === "cafe") counts.cafe += 1;
+      else if (cat === "library") counts.library += 1;
+      else if (cat === "coworking_space" || cat === "coworking")
+        counts.coworking += 1;
+    });
+    return counts;
+  }, [messages]);
   const [showFilters, setShowFilters] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
   const [ratingVenue, setRatingVenue] = useState<Venue | null>(null);
@@ -1103,6 +1118,7 @@ export function EnhancedChatbot({
       </AnimatePresence>
 
       <ChatHeader
+        categoryCounts={categoryCounts}
         onOpenVenueSubmission={() => setShowVenueSubmission(true)}
         userLocation={location}
         onLocationChange={handleLocationChange}

--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -62,6 +62,7 @@ interface ChatHeaderProps {
     pourOverAvailable?: boolean;
     musicStyle?: "all" | "lofi" | "classical_jazz" | "no_music";
   };
+  categoryCounts?: { cafe: number; coworking: number; library: number };
   showFilters: boolean;
   setShowFilters: (show: boolean) => void;
   onToggleFilter: (filter: string) => void;
@@ -91,6 +92,7 @@ export function ChatHeader({
   userLocation,
   onLocationChange,
   filters,
+  categoryCounts = { cafe: 0, coworking: 0, library: 0 },
   showFilters,
   setShowFilters,
   onToggleFilter,
@@ -403,6 +405,41 @@ export function ChatHeader({
             className="mt-4 p-3.5 sm:p-5 bg-zinc-50 dark:bg-zinc-900 border-2 border-orange-500/30 rounded-[2rem] flex flex-col gap-4 sm:gap-5 animate-in slide-in-from-top-2 duration-200 shadow-2xl"
             onMouseDown={(e) => e.stopPropagation()}
           >
+            {/* Section 0: Venue Category Filters */}
+            <div>
+              <div className="text-[9px] font-black text-zinc-400 dark:text-zinc-500 uppercase tracking-widest mb-2.5 ml-1">
+                Venue Categories
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  className="flex items-center gap-1.5 sm:gap-2 px-2.5 py-1.5 sm:px-3.5 sm:py-2 rounded-xl text-[9px] font-black uppercase tracking-wide sm:tracking-widest transition-all bg-white dark:bg-zinc-800 text-zinc-500 border border-zinc-200 dark:border-zinc-700"
+                >
+                  Cafes
+                  <span className="inline-flex items-center justify-center min-w-[1.1rem] h-[1.1rem] px-1 rounded-full bg-orange-600 text-white text-[8px] font-black">
+                    {categoryCounts.cafe}
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  className="flex items-center gap-1.5 sm:gap-2 px-2.5 py-1.5 sm:px-3.5 sm:py-2 rounded-xl text-[9px] font-black uppercase tracking-wide sm:tracking-widest transition-all bg-white dark:bg-zinc-800 text-zinc-500 border border-zinc-200 dark:border-zinc-700"
+                >
+                  Coworking
+                  <span className="inline-flex items-center justify-center min-w-[1.1rem] h-[1.1rem] px-1 rounded-full bg-orange-600 text-white text-[8px] font-black">
+                    {categoryCounts.coworking}
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  className="flex items-center gap-1.5 sm:gap-2 px-2.5 py-1.5 sm:px-3.5 sm:py-2 rounded-xl text-[9px] font-black uppercase tracking-wide sm:tracking-widest transition-all bg-white dark:bg-zinc-800 text-zinc-500 border border-zinc-200 dark:border-zinc-700"
+                >
+                  Libraries
+                  <span className="inline-flex items-center justify-center min-w-[1.1rem] h-[1.1rem] px-1 rounded-full bg-orange-600 text-white text-[8px] font-black">
+                    {categoryCounts.library}
+                  </span>
+                </button>
+              </div>
+            </div>
             {/* Section 1: Standard Toggles */}
             <div>
               <div className="text-[9px] font-black text-zinc-400 dark:text-zinc-500 uppercase tracking-widest mb-2.5 ml-1">


### PR DESCRIPTION
Fixes #1425

## Changes
- Computed matching venue count per category (Cafes, Coworking, Libraries) from active dataset
- Added numeric pill badge inside filter chip buttons in ChatHeader.tsx
- Counts update dynamically when search filters are applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added venue category filters for Cafes, Coworking spaces, and Libraries.
  * Filter options now display the number of available venues in each category.
  * Category counts update based on the latest venue results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->