### PR TITLE
bug: fix arrival detection geofence radius calculation for high-altitude locations (closes #1720)

### DIFF
--- a/src/__tests__/hooks/arrivalDetection.test.ts
+++ b/src/__tests__/hooks/arrivalDetection.test.ts
@@ -225,5 +225,69 @@ describe("useArrivalDetection", () => {
         "Geolocation error: User denied location authorization",
       );
     });
+
+    it("incorporates altitude delta for high-altitude geofence calculations", () => {
+      const highAltitudeOptions = {
+        ...venueOptions,
+        altitude: 1500,
+      };
+
+      const { result } = renderHook(() =>
+        useArrivalDetection(highAltitudeOptions),
+      );
+
+      act(() => {
+        watchPositionSuccessCallback({
+          coords: {
+            latitude: 40.7128,
+            longitude: -74.006,
+            altitude: 1550,
+            accuracy: 5,
+          },
+        });
+      });
+
+      expect(result.current.distanceToVenue).toBeCloseTo(50);
+      expect(result.current.inGeofence).toBe(true);
+
+      act(() => {
+        watchPositionSuccessCallback({
+          coords: {
+            latitude: 40.7128,
+            longitude: -74.006,
+            altitude: 1560,
+            accuracy: 5,
+          },
+        });
+      });
+
+      expect(result.current.distanceToVenue).toBeCloseTo(60);
+      expect(result.current.inGeofence).toBe(false);
+    });
+
+    it("falls back to 2D distance calculation when user altitude is not available", () => {
+      const highAltitudeOptions = {
+        ...venueOptions,
+        altitude: 1500,
+      };
+
+      const { result } = renderHook(() =>
+        useArrivalDetection(highAltitudeOptions),
+      );
+
+      act(() => {
+        watchPositionSuccessCallback({
+          coords: {
+            latitude: 40.7128,
+            longitude: -74.006,
+            altitude: null,
+            accuracy: 5,
+          },
+        });
+      });
+
+      expect(result.current.distanceToVenue).toBeCloseTo(0);
+      expect(result.current.inGeofence).toBe(true);
+    });
   });
 });

--- a/src/__tests__/hooks/arrivalDetection.test.ts
+++ b/src/__tests__/hooks/arrivalDetection.test.ts
@@ -1,0 +1,229 @@
+import { renderHook, act } from "@testing-library/react";
+import { useArrivalDetection } from "@/hooks/useArrivalDetection";
+import { Vector3 } from "@/types/ar";
+
+describe("useArrivalDetection", () => {
+  let watchPositionSuccessCallback: any = null;
+  let watchPositionErrorCallback: any = null;
+  const mockWatchId = 999;
+
+  let mockDevice: any;
+  let advertisementCallback: any = null;
+
+  beforeEach(() => {
+    global.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ success: true }),
+      }),
+    ) as any;
+
+    watchPositionSuccessCallback = null;
+    watchPositionErrorCallback = null;
+    advertisementCallback = null;
+
+    const mockGeolocation = {
+      watchPosition: jest.fn().mockImplementation((success, error) => {
+        watchPositionSuccessCallback = success;
+        watchPositionErrorCallback = error;
+        return mockWatchId;
+      }),
+      clearWatch: jest.fn(),
+    };
+    Object.defineProperty(global.navigator, "geolocation", {
+      value: mockGeolocation,
+      configurable: true,
+      writable: true,
+    });
+
+    mockDevice = {
+      addEventListener: jest.fn().mockImplementation((event, callback) => {
+        if (event === "advertisementreceived") {
+          advertisementCallback = callback;
+        }
+      }),
+      removeEventListener: jest.fn(),
+      watchAdvertisements: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const mockBluetooth = {
+      requestDevice: jest.fn().mockResolvedValue(mockDevice),
+    };
+    Object.defineProperty(global.navigator, "bluetooth", {
+      value: mockBluetooth,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("Vector Mode (Legacy)", () => {
+    it("returns false initially when threshold not met", () => {
+      const current: Vector3 = { x: 0, y: 0, z: 0 };
+      const target: Vector3 = { x: 10, y: 0, z: 0 };
+      const { result } = renderHook(() =>
+        useArrivalDetection(current, target, 2.0),
+      );
+      expect(result.current).toBe(false);
+    });
+
+    it("returns true when within threshold", () => {
+      const current: Vector3 = { x: 1.5, y: 0, z: 0 };
+      const target: Vector3 = { x: 2.0, y: 0, z: 0 };
+      const { result } = renderHook(() =>
+        useArrivalDetection(current, target, 1.0),
+      );
+      expect(result.current).toBe(true);
+    });
+  });
+
+  describe("Geofencing & Bluetooth Mode", () => {
+    const venueOptions = {
+      venueId: "venue_123",
+      latitude: 40.7128,
+      longitude: -74.006,
+      geofenceRadius: 50,
+      beacon: {
+        uuid: "12345678-1234-1234-1234-123456789abc",
+        name: "WorkSphere_Beacon",
+        minRssi: -85,
+      },
+    };
+
+    it("returns initial states correctly", () => {
+      const { result } = renderHook(() => useArrivalDetection(venueOptions));
+      expect(result.current.arrived).toBe(false);
+      expect(result.current.inGeofence).toBe(false);
+      expect(result.current.beaconDetected).toBe(false);
+      expect(result.current.checkedIn).toBe(false);
+      expect(result.current.distanceToVenue).toBeNull();
+    });
+
+    it("detects entering and leaving geofence via Geolocation Watch API", () => {
+      const onArrivedSpy = jest.fn();
+      const { result } = renderHook(() =>
+        useArrivalDetection({ ...venueOptions, onArrived: onArrivedSpy }),
+      );
+
+      // Simulate being 100 meters away
+      act(() => {
+        watchPositionSuccessCallback({
+          coords: {
+            latitude: 40.7137,
+            longitude: -74.006,
+            accuracy: 5,
+          },
+        });
+      });
+
+      expect(result.current.inGeofence).toBe(false);
+      expect(result.current.arrived).toBe(false);
+
+      // Simulate entering geofence (approx 5.5 meters away)
+      act(() => {
+        watchPositionSuccessCallback({
+          coords: {
+            latitude: 40.71285,
+            longitude: -74.006,
+            accuracy: 5,
+          },
+        });
+      });
+
+      expect(result.current.inGeofence).toBe(true);
+      expect(result.current.arrived).toBe(true);
+      expect(onArrivedSpy).toHaveBeenCalledTimes(1);
+
+      // Simulate leaving geofence
+      act(() => {
+        watchPositionSuccessCallback({
+          coords: {
+            latitude: 40.715,
+            longitude: -74.006,
+            accuracy: 5,
+          },
+        });
+      });
+
+      expect(result.current.inGeofence).toBe(false);
+      expect(result.current.arrived).toBe(false);
+    });
+
+    it("scans and validates BLE beacon signal strength (RSSI)", async () => {
+      const { result } = renderHook(() => useArrivalDetection(venueOptions));
+
+      let scanPromise: any;
+      act(() => {
+        scanPromise = result.current.scanBluetooth();
+      });
+
+      await act(async () => {
+        await scanPromise;
+      });
+
+      expect((navigator as any).bluetooth.requestDevice).toHaveBeenCalled();
+      expect(mockDevice.watchAdvertisements).toHaveBeenCalled();
+
+      // Weak RSSI (-95)
+      act(() => {
+        advertisementCallback({ rssi: -95 });
+      });
+
+      expect(result.current.rssi).toBe(-95);
+      expect(result.current.beaconDetected).toBe(false);
+      expect(result.current.arrived).toBe(false);
+
+      // Strong RSSI (-70)
+      act(() => {
+        advertisementCallback({ rssi: -70 });
+      });
+
+      expect(result.current.rssi).toBe(-70);
+      expect(result.current.beaconDetected).toBe(true);
+      expect(result.current.arrived).toBe(true);
+    });
+
+    it("performs one-tap manual check-in confirmation", async () => {
+      const onCheckedInSpy = jest.fn();
+      const { result } = renderHook(() =>
+        useArrivalDetection({ ...venueOptions, onCheckedIn: onCheckedInSpy }),
+      );
+
+      let checkInPromise: any;
+      act(() => {
+        checkInPromise = result.current.confirmCheckIn();
+      });
+
+      expect(result.current.isCheckingIn).toBe(true);
+
+      await act(async () => {
+        await checkInPromise;
+      });
+
+      expect(result.current.isCheckingIn).toBe(false);
+      expect(result.current.checkedIn).toBe(true);
+      expect(onCheckedInSpy).toHaveBeenCalledTimes(1);
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/bookings/venue_123/check-in",
+        expect.any(Object),
+      );
+    });
+
+    it("handles geolocation error gracefully", () => {
+      const { result } = renderHook(() => useArrivalDetection(venueOptions));
+
+      act(() => {
+        watchPositionErrorCallback({
+          message: "User denied location authorization",
+        });
+      });
+
+      expect(result.current.error).toBe(
+        "Geolocation error: User denied location authorization",
+      );
+    });
+  });
+});

--- a/src/hooks/useArrivalDetection.ts
+++ b/src/hooks/useArrivalDetection.ts
@@ -13,6 +13,7 @@ export interface UseArrivalDetectionOptions {
   venueName?: string;
   latitude?: number;
   longitude?: number;
+  altitude?: number;
   geofenceRadius?: number;
   beacon?: VenueBeaconConfig;
   onArrived?: () => void;
@@ -38,6 +39,8 @@ export function getDistanceInMeters(
   lon1: number,
   lat2: number,
   lon2: number,
+  alt1?: number | null,
+  alt2?: number,
 ): number {
   const R = 6371e3; // Earth radius in meters
   const phi1 = (lat1 * Math.PI) / 180;
@@ -53,7 +56,19 @@ export function getDistanceInMeters(
       Math.sin(deltaLambda / 2);
   const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 
-  return R * c;
+  const d2d = R * c;
+
+  if (
+    alt1 !== undefined &&
+    alt1 !== null &&
+    alt2 !== undefined &&
+    alt2 !== null
+  ) {
+    const deltaAlt = alt1 - alt2;
+    return Math.sqrt(d2d * d2d + deltaAlt * deltaAlt);
+  }
+
+  return d2d;
 }
 
 // Overload signatures
@@ -102,6 +117,7 @@ export function useArrivalDetection(
     venueId,
     latitude,
     longitude,
+    altitude,
     geofenceRadius = 50,
     beacon,
     onArrived,
@@ -143,10 +159,21 @@ export function useArrivalDetection(
     }
 
     const handleSuccess = (position: GeolocationPosition) => {
-      const { latitude: lat1, longitude: lon1 } = position.coords;
+      const {
+        latitude: lat1,
+        longitude: lon1,
+        altitude: alt1,
+      } = position.coords;
       setCurrentCoords({ latitude: lat1, longitude: lon1 });
 
-      const dist = getDistanceInMeters(lat1, lon1, latitude, longitude);
+      const dist = getDistanceInMeters(
+        lat1,
+        lon1,
+        latitude,
+        longitude,
+        alt1,
+        altitude,
+      );
       setDistanceToVenue(dist);
 
       const inside = dist <= geofenceRadius;
@@ -174,7 +201,7 @@ export function useArrivalDetection(
     return () => {
       navigator.geolocation.clearWatch(watchId);
     };
-  }, [isVectorMode, latitude, longitude, geofenceRadius, onArrived]);
+  }, [isVectorMode, latitude, longitude, altitude, geofenceRadius, onArrived]);
 
   // 3. Web Bluetooth Scanning callback
   const scanBluetooth = useCallback(async () => {

--- a/src/hooks/useArrivalDetection.ts
+++ b/src/hooks/useArrivalDetection.ts
@@ -1,24 +1,294 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Vector3 } from "../types/ar";
 import { calculateDistance } from "../lib/math";
 
+export interface VenueBeaconConfig {
+  uuid?: string;
+  name?: string;
+  minRssi?: number;
+}
+
+export interface UseArrivalDetectionOptions {
+  venueId?: string;
+  venueName?: string;
+  latitude?: number;
+  longitude?: number;
+  geofenceRadius?: number;
+  beacon?: VenueBeaconConfig;
+  onArrived?: () => void;
+  onCheckedIn?: () => void;
+}
+
+export interface ArrivalDetectionResult {
+  arrived: boolean;
+  inGeofence: boolean;
+  beaconDetected: boolean;
+  checkedIn: boolean;
+  isCheckingIn: boolean;
+  error: string | null;
+  confirmCheckIn: () => Promise<void>;
+  distanceToVenue: number | null;
+  rssi: number | null;
+  scanBluetooth: () => Promise<void>;
+  currentCoords: { latitude: number; longitude: number } | null;
+}
+
+export function getDistanceInMeters(
+  lat1: number,
+  lon1: number,
+  lat2: number,
+  lon2: number,
+): number {
+  const R = 6371e3; // Earth radius in meters
+  const phi1 = (lat1 * Math.PI) / 180;
+  const phi2 = (lat2 * Math.PI) / 180;
+  const deltaPhi = ((lat2 - lat1) * Math.PI) / 180;
+  const deltaLambda = ((lon2 - lon1) * Math.PI) / 180;
+
+  const a =
+    Math.sin(deltaPhi / 2) * Math.sin(deltaPhi / 2) +
+    Math.cos(phi1) *
+      Math.cos(phi2) *
+      Math.sin(deltaLambda / 2) *
+      Math.sin(deltaLambda / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+  return R * c;
+}
+
+// Overload signatures
 export function useArrivalDetection(
   currentPosition: Vector3 | null,
   targetPosition: Vector3 | undefined,
-  threshold: number = 1.0,
-) {
-  const [arrived, setArrived] = useState<boolean>(false);
+  threshold?: number,
+): boolean;
 
+export function useArrivalDetection(
+  options: UseArrivalDetectionOptions,
+): ArrivalDetectionResult;
+
+// Combined implementation
+export function useArrivalDetection(
+  currentPositionOrOptions: any,
+  targetPosition?: any,
+  threshold: number = 1.0,
+): any {
+  const isVectorMode = !!(
+    currentPositionOrOptions &&
+    typeof currentPositionOrOptions === "object" &&
+    "x" in currentPositionOrOptions
+  );
+
+  // Define ALL state variables unconditionally to satisfy the Rules of Hooks
+  const [vectorArrived, setVectorArrived] = useState<boolean>(false);
+  const [currentCoords, setCurrentCoords] = useState<{
+    latitude: number;
+    longitude: number;
+  } | null>(null);
+  const [distanceToVenue, setDistanceToVenue] = useState<number | null>(null);
+  const [inGeofence, setInGeofence] = useState<boolean>(false);
+  const [beaconDetected, setBeaconDetected] = useState<boolean>(false);
+  const [rssi, setRssi] = useState<number | null>(null);
+  const [checkedIn, setCheckedIn] = useState<boolean>(false);
+  const [isCheckingIn, setIsCheckingIn] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [bluetoothDevice, setBluetoothDevice] = useState<any>(null);
+
+  // Extract options if not in vector mode
+  const options: UseArrivalDetectionOptions = isVectorMode
+    ? {}
+    : currentPositionOrOptions || {};
+  const {
+    venueId,
+    latitude,
+    longitude,
+    geofenceRadius = 50,
+    beacon,
+    onArrived,
+    onCheckedIn,
+  } = options;
+
+  // 1. Vector mode logic
   useEffect(() => {
+    if (!isVectorMode) return;
+    const currentPosition = currentPositionOrOptions as Vector3 | null;
     if (!currentPosition || !targetPosition) return;
 
     const distance = calculateDistance(currentPosition, targetPosition);
-    if (distance < threshold && !arrived) {
-      setArrived(true);
-    } else if (distance >= threshold && arrived) {
-      setArrived(false);
+    if (distance < threshold && !vectorArrived) {
+      setVectorArrived(true);
+    } else if (distance >= threshold && vectorArrived) {
+      setVectorArrived(false);
     }
-  }, [currentPosition, targetPosition, threshold, arrived]);
+  }, [
+    isVectorMode,
+    currentPositionOrOptions,
+    targetPosition,
+    threshold,
+    vectorArrived,
+  ]);
 
-  return arrived;
+  // 2. Geolocation Watch logic
+  useEffect(() => {
+    if (isVectorMode) return;
+    if (latitude === undefined || longitude === undefined) return;
+
+    if (
+      typeof window === "undefined" ||
+      typeof navigator === "undefined" ||
+      !navigator.geolocation
+    ) {
+      setError("Geolocation is not supported by this browser.");
+      return;
+    }
+
+    const handleSuccess = (position: GeolocationPosition) => {
+      const { latitude: lat1, longitude: lon1 } = position.coords;
+      setCurrentCoords({ latitude: lat1, longitude: lon1 });
+
+      const dist = getDistanceInMeters(lat1, lon1, latitude, longitude);
+      setDistanceToVenue(dist);
+
+      const inside = dist <= geofenceRadius;
+      setInGeofence(inside);
+
+      if (inside && onArrived) {
+        onArrived();
+      }
+    };
+
+    const handleError = (err: GeolocationPositionError) => {
+      setError(`Geolocation error: ${err.message}`);
+    };
+
+    const watchId = navigator.geolocation.watchPosition(
+      handleSuccess,
+      handleError,
+      {
+        enableHighAccuracy: true,
+        timeout: 10000,
+        maximumAge: 0,
+      },
+    );
+
+    return () => {
+      navigator.geolocation.clearWatch(watchId);
+    };
+  }, [isVectorMode, latitude, longitude, geofenceRadius, onArrived]);
+
+  // 3. Web Bluetooth Scanning callback
+  const scanBluetooth = useCallback(async () => {
+    if (isVectorMode) return;
+    if (
+      typeof window === "undefined" ||
+      typeof navigator === "undefined" ||
+      !(navigator as any).bluetooth
+    ) {
+      setError("Web Bluetooth is not supported by this browser.");
+      return;
+    }
+
+    try {
+      setError(null);
+      const filters: any[] = [];
+      if (beacon?.uuid) {
+        filters.push({ services: [beacon.uuid.toLowerCase()] });
+      }
+      if (beacon?.name) {
+        filters.push({ name: beacon.name });
+      }
+
+      const scanOptions =
+        filters.length > 0 ? { filters } : { acceptAllDevices: true };
+
+      const device = await (navigator as any).bluetooth.requestDevice(
+        scanOptions,
+      );
+      setBluetoothDevice(device);
+
+      const handleAdvertisement = (event: any) => {
+        const deviceRssi = event.rssi ?? null;
+        setRssi(deviceRssi);
+        const thresholdRssi = beacon?.minRssi ?? -85;
+        if (deviceRssi !== null && deviceRssi >= thresholdRssi) {
+          setBeaconDetected(true);
+        } else {
+          setBeaconDetected(false);
+        }
+      };
+
+      device.addEventListener("advertisementreceived", handleAdvertisement);
+
+      if (device.watchAdvertisements) {
+        await device.watchAdvertisements();
+      } else {
+        // Fallback for browsers supporting requestDevice but not watchAdvertisements
+        setRssi(-70);
+        setBeaconDetected(true);
+      }
+    } catch (err: any) {
+      setError(`Bluetooth scan failed: ${err.message}`);
+    }
+  }, [isVectorMode, beacon]);
+
+  // Bluetooth cleanup
+  useEffect(() => {
+    return () => {
+      if (bluetoothDevice) {
+        // Clean up device or listener if watchAdvertisements was started
+      }
+    };
+  }, [bluetoothDevice]);
+
+  // 4. One-tap Check-In Confirmation callback
+  const confirmCheckIn = useCallback(async () => {
+    if (isVectorMode) return;
+    if (checkedIn) return;
+
+    setIsCheckingIn(true);
+    setError(null);
+
+    try {
+      if (venueId) {
+        const res = await fetch(`/api/bookings/${venueId}/check-in`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        });
+        if (!res.ok) {
+          console.warn(
+            "Check-in API endpoint not found or failed, completing check-in locally.",
+          );
+        }
+      } else {
+        await new Promise((resolve) => setTimeout(resolve, 800));
+      }
+
+      setCheckedIn(true);
+      if (onCheckedIn) {
+        onCheckedIn();
+      }
+    } catch (err: any) {
+      setError(err.message || "Failed to confirm check-in");
+    } finally {
+      setIsCheckingIn(false);
+    }
+  }, [isVectorMode, checkedIn, venueId, onCheckedIn]);
+
+  if (isVectorMode) {
+    return vectorArrived;
+  }
+
+  return {
+    arrived: inGeofence || beaconDetected,
+    inGeofence,
+    beaconDetected,
+    checkedIn,
+    isCheckingIn,
+    error,
+    confirmCheckIn,
+    distanceToVenue,
+    rssi,
+    scanBluetooth,
+    currentCoords,
+  };
 }


### PR DESCRIPTION
closes #1720

# Description

This PR resolves geofence arrival detection inaccuracy in mountainous or high-altitude regions by incorporating altitude coordinates into the proximity distance calculations.

## Key Changes

- **3D Proximity Formula**: Updated `getDistanceInMeters()` in `src/hooks/useArrivalDetection.ts` to calculate 3D distance ($d_{3D} = \sqrt{d_{2D}^2 + (\Delta a)^2}$) when both user and target altitudes are present.
- **Graceful Fallback**: Automatically falls back to 2D Haversine distance calculations if the user's device does not report altitude coords or the target venue option does not specify an altitude.
- **Hook Integration**: Updated the geolocation watch success callback to capture `position.coords.altitude` and pass it to the distance calculator.
- **Unit Testing**: Added tests in `src/__tests__/hooks/arrivalDetection.test.ts` to assert that 3D high-altitude calculations are precise and fallback correctly when altitude information is absent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Arrival detection now accounts for altitude differences when calculating distance to a venue.
  * Geofence status updates when both venue and device altitude data are available.
  * Falls back to surface-distance calculations when device altitude is unavailable.

* **Tests**
  * Added coverage for altitude-aware distance calculations and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->