### PR TITLE
fix: fix venue card star rating display alignment in dark mode

### DIFF
--- a/src/__tests__/components/VenueCardRatingLayout.test.tsx
+++ b/src/__tests__/components/VenueCardRatingLayout.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { VenueCard } from "@/components/VenueCard";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ prefetch: jest.fn() }),
+}));
+
+const mockVenue = {
+  id: "test-venue-rating",
+  name: "Star Lounge",
+  category: "cafe",
+  address: "456 Market St",
+  rating: 4.8,
+  position: { lat: 37.7749, lng: -122.4194 },
+};
+
+describe("VenueCard Rating Layout (#1745)", () => {
+  it("renders star rating container with inline-flex alignment and high-contrast dark mode classes", async () => {
+    render(<VenueCard venue={mockVenue} />);
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    const ratingContainer = screen.getByTestId("star-rating-container");
+    expect(ratingContainer).toBeInTheDocument();
+    expect(ratingContainer).toHaveClass("inline-flex");
+    expect(ratingContainer).toHaveClass("items-center");
+    expect(ratingContainer).toHaveClass("gap-1");
+
+    const starIcon = ratingContainer.querySelector("svg");
+    expect(starIcon).toBeInTheDocument();
+    expect(starIcon).toHaveClass("text-amber-500");
+    expect(starIcon).toHaveClass("dark:text-amber-400");
+  });
+});

--- a/src/components/VenueCard.tsx
+++ b/src/components/VenueCard.tsx
@@ -358,8 +358,7 @@ export function VenueCard({
     }
   };
 
-  const displayRating =
-    enrichData?.rating ?? venue.rating ?? 0;
+  const displayRating = enrichData?.rating ?? venue.rating ?? 0;
   const photos = enrichData?.photos || [];
   const amenities = enrichData?.amenities;
 
@@ -538,12 +537,15 @@ export function VenueCard({
 
         {/* Rating & Category */}
         <div className="flex items-center gap-3 mb-3">
-          <div className="flex items-center gap-1">
+          <div
+            className="inline-flex items-center gap-1 font-medium text-amber-500 dark:text-amber-400"
+            data-testid="star-rating-container"
+          >
             <Star
               className={`w-4 h-4 shrink-0 ${
                 displayRating > 0
-                  ? "text-yellow-500 fill-current"
-                  : "text-zinc-300 dark:text-zinc-600"
+                  ? "text-amber-500 fill-amber-500 dark:text-amber-400 dark:fill-amber-400"
+                  : "text-zinc-400 dark:text-zinc-500"
               }`}
             />
             <span className="text-sm font-medium text-zinc-900 dark:text-zinc-50">


### PR DESCRIPTION
## 📌 Description
Fixes an alignment defect in `VenueCard.tsx` where star rating icons misaligned vertically with adjacent text category badges when toggling between light and dark mode themes.

## 🛠️ Key Changes
- Updated star rating container styling in `src/components/VenueCard.tsx` to `inline-flex items-center gap-1`.
- Added high-contrast dark mode classes (`text-amber-500 fill-amber-500 dark:text-amber-400 dark:fill-amber-400` for filled stars and `text-zinc-400 dark:text-zinc-500` for outline stars).
- Added `data-testid="star-rating-container"` for layout testing.
- Added comprehensive unit test in `src/__tests__/components/VenueCardRatingLayout.test.tsx`.

## 🧪 Verification & Testing
- Ran Jest unit test suite: `npm test src/__tests__/components/VenueCardRatingLayout.test.tsx` (PASS).
- Verified consistent flex alignment across light and dark theme modes.

Closes #1745 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated venue rating displays with clearer star-rating styling and improved visual distinction for venues with ratings.

* **Bug Fixes**
  * Improved handling of missing or unavailable rating values to ensure consistent display behavior.

* **Tests**
  * Added coverage verifying the rating layout, star visibility, and rating color styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->