### PR TITLE
fix: resolve WebSockets reconnect loop when switching mobile networks

### DIFF
--- a/src/__tests__/lib/partySocketReconnectLoop.test.ts
+++ b/src/__tests__/lib/partySocketReconnectLoop.test.ts
@@ -1,0 +1,29 @@
+import {
+  attachJitteredBackoff,
+  PARTY_SOCKET_RECONNECT_OPTIONS,
+} from "@/lib/partySocketReconnect";
+
+describe("PartySocket Reconnect Loop & Mobile Network Switch (#1746)", () => {
+  it("limits maximum reconnection attempts to 5", () => {
+    expect(PARTY_SOCKET_RECONNECT_OPTIONS.maxRetries).toBe(5);
+  });
+
+  it("resets _retryCount when browser online event fires", () => {
+    const mockConnect = jest.fn();
+    const socket: any = {
+      _retryCount: 4,
+      _getNextDelay: () => 0,
+      _connect: mockConnect,
+      addEventListener: jest.fn(),
+    };
+
+    attachJitteredBackoff(socket);
+    expect(socket._retryCount).toBe(4);
+
+    // Simulate browser coming online after network flap (Wi-Fi -> cellular)
+    window.dispatchEvent(new Event("online"));
+
+    expect(socket._retryCount).toBe(0);
+    expect(mockConnect).toHaveBeenCalled();
+  });
+});

--- a/src/lib/partySocketReconnect.ts
+++ b/src/lib/partySocketReconnect.ts
@@ -36,7 +36,7 @@
  */
 
 export const PARTY_SOCKET_RECONNECT_OPTIONS = {
-  maxRetries: 10,
+  maxRetries: 5,
   minReconnectionDelay: 1_000,
   maxReconnectionDelay: 30_000,
   reconnectionDelayGrowFactor: 2,
@@ -242,6 +242,7 @@ export function attachJitteredBackoff<T extends object>(socket: T): T {
 
   if (typeof window !== "undefined") {
     window.addEventListener("online", () => {
+      s._retryCount = 0;
       if (s.__worksphereState !== ConnectionState.CONNECTED) {
         (s as any).__worksphereForceReconnect?.();
       }


### PR DESCRIPTION
Closes #1746

## 📌 Description
Resolves an infinite reconnection loop issue with `PartySocket` client connections when mobile devices switch network interfaces (e.g., from Wi-Fi to cellular data).

## 🛠️ Key Changes
- Updated `PARTY_SOCKET_RECONNECT_OPTIONS` in `src/lib/partySocketReconnect.ts` to cap `maxRetries` at 5.
- Updated browser `online` window event listener in `attachJitteredBackoff` to reset `_retryCount` to 0 and trigger connection backoff reset upon network interface recovery.
- Added unit test in `src/__tests__/lib/partySocketReconnectLoop.test.ts` simulating network interface flap and verifying retry count reset.

## 🧪 Verification & Testing
- Ran Jest unit tests: `npm test src/__tests__/lib/partySocketReconnectLoop.test.ts` (PASS).
- Verified exponential backoff and maximum retry cap limits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved socket recovery after network connectivity returns by resetting retry attempts and reconnecting promptly.
  * Reduced the maximum number of automatic reconnection attempts from 10 to 5.

* **Tests**
  * Added coverage for retry limits and reconnection behavior after a network interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->