### PR TITLE
fix: prevent duplicate toast notifications during rapid offline sync retries

### DIFF
--- a/src/__tests__/components/ToastDuplicateFilter.test.tsx
+++ b/src/__tests__/components/ToastDuplicateFilter.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ToastProvider, useToast } from "@/components/ui/Toast";
+
+function TestConsumer() {
+  const { toast } = useToast();
+  return (
+    <button
+      onClick={() => toast("Sync failed", "error")}
+      data-testid="trigger-toast"
+    >
+      Trigger Toast
+    </button>
+  );
+}
+
+describe("Toast Duplicate Message Debounce (#1748)", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("suppresses duplicate toast messages triggered within 3 seconds", () => {
+    render(
+      <ToastProvider>
+        <TestConsumer />
+      </ToastProvider>,
+    );
+
+    const button = screen.getByTestId("trigger-toast");
+
+    // Click 3 times rapidly
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    // Only 1 toast item should be rendered
+    const toasts = screen.getAllByRole("status");
+    expect(toasts).toHaveLength(1);
+    expect(screen.getByText("Sync failed")).toBeInTheDocument();
+  });
+
+  it("allows identical toast message after 3 seconds have passed", () => {
+    render(
+      <ToastProvider>
+        <TestConsumer />
+      </ToastProvider>,
+    );
+
+    const button = screen.getByTestId("trigger-toast");
+
+    fireEvent.click(button);
+    expect(screen.getAllByRole("status")).toHaveLength(1);
+
+    // Advance time by 3001ms
+    act(() => {
+      jest.advanceTimersByTime(3001);
+    });
+
+    fireEvent.click(button);
+    expect(screen.getAllByRole("status")).toHaveLength(2);
+  });
+});

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -3,6 +3,7 @@
 import {
   useState,
   useEffect,
+  useRef,
   useCallback,
   createContext,
   useContext,
@@ -46,6 +47,7 @@ export function useToast(): ToastContextValue {
 
 export function ToastProvider({ children }: { children: React.ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([]);
+  const recentMessagesRef = useRef<Map<string, number>>(new Map());
 
   const addToast = useCallback(
     (
@@ -54,7 +56,14 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
       action?: { label: string; onClick: () => void },
       countdown?: number,
     ) => {
-      const id = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+      const now = Date.now();
+      const lastSeen = recentMessagesRef.current.get(message);
+      if (countdown === undefined && lastSeen && now - lastSeen < 3000) {
+        return; // Suppress duplicate toast dispatch within 3-second window (#1748)
+      }
+      recentMessagesRef.current.set(message, now);
+
+      const id = `${now}-${Math.random().toString(36).slice(2, 9)}-${recentMessagesRef.current.size}`;
       setToasts((prev) => {
         if (countdown !== undefined && message.includes("Rate limit")) {
           const existingIndex = prev.findIndex(


### PR DESCRIPTION
Closes #1748

## 📌 Description
Prevents duplicate toast notification dispatches in `Toast.tsx` during rapid offline sync retries when network connectivity fluctuates.

## 🛠️ Key Changes
- Implemented a 3-second (3000ms) message debounce filter using `useRef` tracking message timestamps in `src/components/ui/Toast.tsx`.
- Ensured rate limit countdown toasts can continue updating existing toasts while standard duplicate toast messages (such as "Sync failed") within 3 seconds are suppressed.
- Generated unique React keys for queued toast items incorporating timestamp, random seed, and queue length.
- Added unit test suite in `src/__tests__/components/ToastDuplicateFilter.test.tsx`.

## 🧪 Verification & Testing
- Ran Jest unit tests: `npm test src/__tests__/components/ToastDuplicateFilter.test.tsx src/__tests__/components/Toast.test.tsx` (PASS).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented identical error notifications from appearing repeatedly when triggered within a 3-second window.
  * Identical notifications can be displayed again after the debounce period expires.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->