### PR TITLE
fix: handle expired Clerk JWT token gracefully in WebSocket authentication

### DIFF
--- a/party/server.ts
+++ b/party/server.ts
@@ -105,7 +105,8 @@ export default class WorkspaceServer implements Party.Server {
         }
       } catch (err) {
         console.error("Token verification or DB fetch failed:", err);
-        isViewer = true;
+        conn.close(4001, "Unauthorized: Token expired");
+        return;
       }
     } else {
       isViewer = true;

--- a/src/__tests__/hooks/PartySocketAuthRefresh.test.ts
+++ b/src/__tests__/hooks/PartySocketAuthRefresh.test.ts
@@ -1,0 +1,55 @@
+import { renderHook, act } from "@testing-library/react";
+import usePartySocketReconnect from "@/hooks/usePartySocketReconnect";
+
+const mockGetToken = jest.fn();
+jest.mock("@clerk/nextjs", () => ({
+  useAuth: () => ({
+    getToken: mockGetToken,
+  }),
+}));
+
+const mockCloseListeners: Array<(event: any) => void> = [];
+const mockConnect = jest.fn();
+
+jest.mock("partysocket/react", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    query: { token: "expired-token" },
+    _connect: mockConnect,
+    addEventListener: jest.fn((event: string, cb: (e: any) => void) => {
+      if (event === "close") {
+        mockCloseListeners.push(cb);
+      }
+    }),
+    removeEventListener: jest.fn(),
+  })),
+}));
+
+describe("PartySocket Expired Clerk Token Re-authentication (#1750)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCloseListeners.length = 0;
+  });
+
+  it("intercepts 4001 auth closure code, fetches fresh Clerk JWT token, and forces reconnection", async () => {
+    mockGetToken.mockResolvedValueOnce("fresh-clerk-jwt-token");
+
+    const { result } = renderHook(() =>
+      usePartySocketReconnect({ host: "localhost:1999", room: "test-room" }),
+    );
+
+    expect(result.current).toBeDefined();
+    expect(mockCloseListeners.length).toBeGreaterThan(0);
+
+    // Simulate WebSocket close event with code 4001 (Unauthorized: Token expired)
+    await act(async () => {
+      for (const listener of mockCloseListeners) {
+        await listener({ code: 4001, reason: "Unauthorized: Token expired" });
+      }
+    });
+
+    expect(mockGetToken).toHaveBeenCalledWith({ skipCache: true });
+    expect(result.current.query.token).toBe("fresh-clerk-jwt-token");
+    expect(mockConnect).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/usePartySocketReconnect.ts
+++ b/src/hooks/usePartySocketReconnect.ts
@@ -1,6 +1,8 @@
 "use client";
 
+import { useEffect } from "react";
 import usePartySocket from "partysocket/react";
+import { useAuth } from "@clerk/nextjs";
 import {
   attachJitteredBackoff,
   PARTY_SOCKET_RECONNECT_OPTIONS,
@@ -11,12 +13,50 @@ type PartySocketOptions = Parameters<typeof usePartySocket>[0];
 /**
  * PartySocket with capped retries + jittered exponential backoff.
  * Drop-in for `partysocket/react`'s usePartySocket.
+ * Automatically intercepts 4001 token expiration codes, fetches a fresh Clerk JWT, and reconnects seamlessly.
  */
 export default function usePartySocketReconnect(options: PartySocketOptions) {
+  const { getToken } = useAuth();
   const socket = usePartySocket({
     ...PARTY_SOCKET_RECONNECT_OPTIONS,
     ...options,
   });
 
-  return attachJitteredBackoff(socket);
+  const attachedSocket = attachJitteredBackoff(socket);
+
+  useEffect(() => {
+    if (
+      !attachedSocket ||
+      typeof (attachedSocket as any).addEventListener !== "function"
+    )
+      return;
+
+    const handleClose = async (event: any) => {
+      if (event?.code === 4001) {
+        try {
+          const freshToken = await getToken({ skipCache: true });
+          if (freshToken) {
+            if ((attachedSocket as any).query) {
+              (attachedSocket as any).query.token = freshToken;
+            }
+            (attachedSocket as any).__worksphereForceReconnect?.();
+          }
+        } catch (err) {
+          console.error(
+            "[PartySocket] Failed to refresh expired Clerk token:",
+            err,
+          );
+        }
+      }
+    };
+
+    (attachedSocket as any).addEventListener("close", handleClose);
+    return () => {
+      if (typeof (attachedSocket as any).removeEventListener === "function") {
+        (attachedSocket as any).removeEventListener("close", handleClose);
+      }
+    };
+  }, [attachedSocket, getToken]);
+
+  return attachedSocket;
 }


### PR DESCRIPTION
Closes #1750

## 📌 Description
Handles expired Clerk JWT session tokens during active PartyKit WebSocket connections by intercepting WebSocket close code 4001, refreshing the authentication token via Clerk SDK, and reconnecting seamlessly.

## 🛠️ Key Changes
- Configured authentication failure handling in `party/server.ts` to close connections with status code `4001` (`Unauthorized: Token expired`) when token verification fails.
- Updated `usePartySocketReconnect` in `src/hooks/usePartySocketReconnect.ts` with a `close` event listener that intercepts code `4001`, calls `getToken({ skipCache: true })`, updates query token parameter, and forces socket reconnection.
- Added unit test suite in `src/__tests__/hooks/PartySocketAuthRefresh.test.ts`.

## 🧪 Verification & Testing
- Ran Jest unit tests: `npm test src/__tests__/hooks/PartySocketAuthRefresh.test.ts` (PASS).
