### PR TITLE
fix: prevent Read Aloud tooltip from rendering on touch devices

### DIFF
--- a/src/__tests__/components/ReadAloudButton.test.tsx
+++ b/src/__tests__/components/ReadAloudButton.test.tsx
@@ -87,9 +87,23 @@ describe("ReadAloudButton UI component", () => {
     expect(
       screen.getByRole("button", { name: /Read message aloud/i }),
     ).toBeInTheDocument();
+
     expect(
       screen.getByRole("combobox", { name: /Playback speed/i }),
     ).toBeInTheDocument();
+  });
+
+  it("does not render tooltip on touch devices", () => {
+    Object.defineProperty(window, "ontouchstart", {
+      value: jest.fn(),
+      configurable: true,
+    });
+
+    render(<ReadAloudButton text="Sample text to read" />);
+
+    expect(screen.queryByText("Read aloud")).not.toBeInTheDocument();
+
+    delete (window as Partial<Window>).ontouchstart;
   });
 
   it("includes 1x, 1.25x, and 1.5x speed options in the dropdown", () => {

--- a/src/components/chat/ReadAloudButton.tsx
+++ b/src/components/chat/ReadAloudButton.tsx
@@ -11,6 +11,16 @@ function Tooltip({
   children: React.ReactNode;
   text: string;
 }) {
+  const [isTouchDevice, setIsTouchDevice] = React.useState(false);
+
+  React.useEffect(() => {
+    setIsTouchDevice("ontouchstart" in window);
+  }, []);
+
+  if (isTouchDevice) {
+    return <>{children}</>;
+  }
+
   return (
     <div className="relative inline-flex items-center group">
       {children}


### PR DESCRIPTION
## Summary

- Prevent the Read Aloud tooltip from rendering on touch devices.
- Preserve existing tooltip behaviour on non-touch devices.
- Add a regression test to ensure tooltips remain hidden on touch devices.

Fixes #1810

## Testing

- [x] `npm test -- ReadAloudButton.test.tsx`

Test Results:
- ✅ 1 test suite passed
- ✅ 8 tests passed
- 
## Checklist

- [x] Implemented the tooltip fix for touch devices
- [x] Added a regression test for touch-device behaviour
- [x] Existing functionality remains unchanged on non-touch devices
- [x] Tests pass successfully
- [x] Code formatted with Prettier
- [x] ESLint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Read Aloud control on touch devices by hiding hover and focus tooltips that are not applicable to touch interactions.
  * Preserved the existing button and playback speed selection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->