### PR TITLE
feat(social): add user workspace streak badge to profile header (closes issue #1931)

### DIFF
--- a/src/components/Header/StreakBadge.tsx
+++ b/src/components/Header/StreakBadge.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Flame } from "lucide-react";
+
+interface StreakData {
+  currentStreak: number;
+  longestStreak: number;
+  unlockedMilestones: number[];
+}
+
+export function StreakBadge() {
+  const [streakData, setStreakData] = useState<StreakData | null>(null);
+
+  useEffect(() => {
+    fetch("/api/user/streak")
+      .then((res) => {
+        if (!res.ok) throw new Error("Failed to fetch streak");
+        return res.json();
+      })
+      .then((data) => setStreakData(data))
+      .catch((err) => console.error("Error fetching streak:", err));
+  }, []);
+
+  if (!streakData || streakData.currentStreak === 0) return null;
+
+  return (
+    <div className="group relative flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-orange-500/10 text-orange-600 dark:bg-orange-500/20 dark:text-orange-400 font-semibold cursor-default transition-all hover:bg-orange-500/20 dark:hover:bg-orange-500/30">
+      <Flame className="w-4 h-4 fill-orange-500 text-orange-500" />
+      <span className="text-sm">{streakData.currentStreak}</span>
+
+      {/* Tooltip */}
+      <div className="absolute top-full right-0 mt-2 w-48 p-3 rounded-lg bg-white dark:bg-zinc-800 shadow-xl border border-zinc-200 dark:border-zinc-700 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity z-50">
+        <div className="text-sm font-bold text-zinc-900 dark:text-zinc-100 mb-1">
+          {streakData.currentStreak}-Day Work Streak 🔥
+        </div>
+        <div className="text-xs text-zinc-500 dark:text-zinc-400">
+          Keep it up! Your longest streak is {streakData.longestStreak} days.
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -10,6 +10,7 @@ import { ThemeToggle } from "@/components/ThemeToggle";
 import { OfflineSyncBadge } from "@/components/Header/OfflineSyncBadge";
 
 import { NotificationBell } from "@/components/NotificationBell";
+import { StreakBadge } from "@/components/Header/StreakBadge";
 
 interface TopNavProps {
   hideAuth?: boolean;
@@ -118,6 +119,7 @@ export function TopNav({ hideAuth = false }: TopNavProps) {
                     <Shield className="w-4 h-4" />
                     Admin
                   </Link>
+                  <StreakBadge />
                   <NotificationBell />
                   <div className="flex items-center justify-center w-8 h-8 rounded-full overflow-hidden shrink-0 ml-1">
                     <ReactiveUserButton


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does and why it is needed. -->

## Related Issue

<!-- 
Please link to the issue here using the standard keywords. 
Example: Fixes #123 or Closes #123
-->
Fixes #

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

<!-- Add visual evidence if this PR changes UI/UX. -->

## Breaking Changes

- [ ] Yes (please describe below)
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a streak badge to the signed-in navigation.
  * Displays the current streak and, on hover, the longest streak achieved.
  * The badge appears only when an active streak is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->