### PR TITLE
Add scroll-to-top button component

### DIFF
--- a/src/__tests__/components/ScrollToTopButton.test.tsx
+++ b/src/__tests__/components/ScrollToTopButton.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ScrollToTopButton } from "@/components/ui/ScrollToTopButton";
+
+describe("ScrollToTopButton", () => {
+  const originalScrollTo = window.scrollTo;
+  const originalScrollY = Object.getOwnPropertyDescriptor(window, "scrollY");
+
+  beforeEach(() => {
+    // Start each test at scroll position 0
+    Object.defineProperty(window, "scrollY", {
+      configurable: true,
+      value: 0,
+    });
+    window.scrollTo = jest.fn();
+  });
+
+  afterEach(() => {
+    window.scrollTo = originalScrollTo;
+    if (originalScrollY) {
+      Object.defineProperty(window, "scrollY", originalScrollY);
+    }
+  });
+
+  it("is not visible when scrollY is 0", () => {
+    render(<ScrollToTopButton />);
+
+    const btn = screen.getByRole("button", { name: "Scroll to top of page" });
+    // Hidden: opacity-0 scale-75 pointer-events-none
+    expect(btn).toHaveClass("opacity-0");
+    expect(btn).toHaveClass("pointer-events-none");
+  });
+
+  it("becomes visible when scrollY exceeds 300px", () => {
+    render(<ScrollToTopButton />);
+
+    act(() => {
+      Object.defineProperty(window, "scrollY", { configurable: true, value: 350 });
+      fireEvent.scroll(window);
+    });
+
+    const btn = screen.getByRole("button", { name: "Scroll to top of page" });
+    expect(btn).toHaveClass("opacity-100");
+    expect(btn).not.toHaveClass("pointer-events-none");
+  });
+
+  it("is not visible when scrollY is exactly 300px", () => {
+    render(<ScrollToTopButton />);
+
+    act(() => {
+      Object.defineProperty(window, "scrollY", { configurable: true, value: 300 });
+      fireEvent.scroll(window);
+    });
+
+    const btn = screen.getByRole("button", { name: "Scroll to top of page" });
+    expect(btn).toHaveClass("opacity-0");
+  });
+
+  it("hides again when user scrolls back above 300px", () => {
+    render(<ScrollToTopButton />);
+
+    // Scroll down
+    act(() => {
+      Object.defineProperty(window, "scrollY", { configurable: true, value: 400 });
+      fireEvent.scroll(window);
+    });
+
+    // Scroll back up
+    act(() => {
+      Object.defineProperty(window, "scrollY", { configurable: true, value: 100 });
+      fireEvent.scroll(window);
+    });
+
+    const btn = screen.getByRole("button", { name: "Scroll to top of page" });
+    expect(btn).toHaveClass("opacity-0");
+  });
+
+  it("calls window.scrollTo with smooth behavior on click", () => {
+    render(<ScrollToTopButton />);
+
+    act(() => {
+      Object.defineProperty(window, "scrollY", { configurable: true, value: 500 });
+      fireEvent.scroll(window);
+    });
+
+    const btn = screen.getByRole("button", { name: "Scroll to top of page" });
+    fireEvent.click(btn);
+
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: "smooth" });
+  });
+
+  it("has the correct aria-label for accessibility", () => {
+    render(<ScrollToTopButton />);
+
+    const btn = screen.getByRole("button", { name: "Scroll to top of page" });
+    expect(btn).toHaveAttribute("aria-label", "Scroll to top of page");
+  });
+
+  it("has the id scroll-to-top-btn for browser testing", () => {
+    render(<ScrollToTopButton />);
+    expect(document.getElementById("scroll-to-top-btn")).toBeInTheDocument();
+  });
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import I18nProvider from "../components/I18nProvider";
 import { ThemeProvider } from "../components/ThemeProvider";
 import { SoundProvider } from "../components/SoundProvider";
 import { ScrollProgress } from "../components/ui/ScrollProgress";
+import { ScrollToTopButton } from "../components/ui/ScrollToTopButton";
 import { CookieBanner } from "../components/CookieBanner";
 import { CurrencyProvider } from "@/context/CurrencyContext";
 import { SyncManager } from "../hooks/usePWA";
@@ -211,6 +212,7 @@ export default async function RootLayout({
         suppressHydrationWarning
       >
         <ScrollProgress />
+        <ScrollToTopButton />
         <SyncManager />
         {bodyContent}
         <CookieBanner />

--- a/src/components/ui/ScrollToTopButton.tsx
+++ b/src/components/ui/ScrollToTopButton.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+/**
+ * ScrollToTopButton
+ *
+ * A floating action button that appears once the user scrolls more than 300px
+ * down the page. Clicking it smoothly scrolls the window back to the top.
+ *
+ * Accessibility:
+ *  - aria-label="Scroll to top of page"
+ *  - Fully keyboard-navigable (focus-visible ring)
+ *  - Respects prefers-reduced-motion via CSS (globals.css already handles this)
+ */
+export function ScrollToTopButton() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  const handleScroll = useCallback(() => {
+    setIsVisible(window.scrollY > 300);
+  }, []);
+
+  useEffect(() => {
+    // Evaluate once on mount in case the page loads mid-scroll
+    handleScroll();
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [handleScroll]);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  return (
+    <button
+      id="scroll-to-top-btn"
+      onClick={scrollToTop}
+      aria-label="Scroll to top of page"
+      className={[
+        // Layout & shape
+        "fixed bottom-6 right-6 z-50",
+        "h-12 w-12 rounded-full",
+        // Flex centering
+        "flex items-center justify-center",
+        // Colours – uses the project-wide accent system
+        "accent-bg text-white",
+        // Shadow / glow
+        "shadow-lg accent-shadow-lg",
+        // Hover & active states
+        "hover:opacity-90 active:scale-95",
+        // Transitions – enter/exit + micro-interaction
+        "transition-all duration-300 ease-in-out",
+        // Show / hide via opacity + scale (GPU-composited, no layout shift)
+        isVisible
+          ? "opacity-100 scale-100 pointer-events-auto"
+          : "opacity-0 scale-75 pointer-events-none",
+        // Focus ring (project standard)
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+      ].join(" ")}
+    >
+      {/* Up-arrow SVG icon */}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="h-5 w-5"
+        aria-hidden="true"
+      >
+        <path d="M18 15l-6-6-6 6" />
+      </svg>
+    </button>
+  );
+}


### PR DESCRIPTION
## Description


- Added a reusable `ScrollToTopButton` component.
- Displayed the button only after scrolling more than 300px.
- Implemented smooth scrolling to the top.
- Added an accessible `aria-label`.
- Styled the button to match the existing UI.

## Related Issue

<!-- 
Please link to the issue here using the standard keywords. 
Example: Fixes #123 or Closes #123
-->
Fixes #1831 

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

<!-- Add visual evidence if this PR changes UI/UX. -->

## Breaking Changes

- [ ] Yes (please describe below)
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a floating “Scroll to top” button that appears after scrolling more than 300px.
  - Clicking the button smoothly returns the page to the top.
  - Included accessible labeling and keyboard focus support.

- **Tests**
  - Added coverage for button visibility, scrolling behavior, accessibility, and rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->