### PR TITLE
 fix(webrtc): dynamically adjust peer video and audio bitrates in useWebRTCMesh

### DIFF
--- a/src/__tests__/hooks/useWebRTCMesh.test.ts
+++ b/src/__tests__/hooks/useWebRTCMesh.test.ts
@@ -1,5 +1,6 @@
 import { renderHook, act } from "@testing-library/react";
 import { useWebRTCMesh } from "@/hooks/useWebRTCMesh";
+import { adaptVideoBitrate } from "@/lib/screenShareBitrate";
 
 // Mock Clerk
 jest.mock("@clerk/nextjs", () => ({
@@ -73,6 +74,26 @@ class MockAudioContext {
 (global as any).AudioContext = MockAudioContext;
 (global as any).webkitAudioContext = MockAudioContext;
 
+class MockRTCPeerConnection {
+  onicecandidate: any = null;
+  ontrack: any = null;
+  oniceconnectionstatechange: any = null;
+  onnegotiationneeded: any = null;
+  iceConnectionState = "connected";
+  signalingState = "stable";
+
+  getSenders = jest.fn().mockReturnValue([]);
+  getStats = jest.fn().mockResolvedValue(new Map());
+  addTrack = jest.fn();
+  close = jest.fn();
+  setLocalDescription = jest.fn().mockResolvedValue(undefined);
+  setRemoteDescription = jest.fn().mockResolvedValue(undefined);
+  createOffer = jest.fn().mockResolvedValue({ type: "offer", sdp: "sdp" });
+  createAnswer = jest.fn().mockResolvedValue({ type: "answer", sdp: "sdp" });
+  addIceCandidate = jest.fn().mockResolvedValue(undefined);
+}
+(global as any).RTCPeerConnection = MockRTCPeerConnection;
+
 describe("useWebRTCMesh Bandwidth Probing", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -144,6 +165,42 @@ describe("useWebRTCMesh Bandwidth Probing", () => {
     // Now it should be good
     expect(result.current.networkQuality).toBe("good");
     expect(mockApplyConstraints).toHaveBeenCalledWith({ sampleRate: 48000 });
+  });
+
+  it("periodically triggers adaptVideoBitrate and handles low quality transport tiers", async () => {
+    (adaptVideoBitrate as jest.Mock).mockResolvedValue({
+      maxBitrate: 400_000,
+      audioMaxBitrate: 16_000,
+      label: "low",
+    });
+
+    const { result } = renderHook(() =>
+      useWebRTCMesh({ roomId: "test-room", userId: "user-1" }),
+    );
+
+    await act(async () => {
+      await result.current.toggleAudio();
+    });
+
+    // Simulate remote peer joining
+    act(() => {
+      mockSocketOnMessage({
+        data: JSON.stringify({
+          type: "webrtc-signal",
+          kind: "peer-join",
+          from: "user-2",
+        }),
+      });
+    });
+
+    // Advance 4000ms to trigger bitrate timer
+    await act(async () => {
+      jest.advanceTimersByTime(4000);
+    });
+
+    // Expect network quality to transition to poor when transport tier is low
+    expect(result.current.networkQuality).toBe("poor");
+    expect(mockApplyConstraints).toHaveBeenCalledWith({ sampleRate: 16000 });
   });
 });
 

--- a/src/__tests__/lib/screenShareBitrate.test.ts
+++ b/src/__tests__/lib/screenShareBitrate.test.ts
@@ -1,30 +1,58 @@
-import { pickBitrateTier, readNetworkHints } from "@/lib/screenShareBitrate";
+import {
+  pickBitrateTier,
+  readNetworkHints,
+  adaptVideoBitrate,
+} from "@/lib/screenShareBitrate";
 
 describe("pickBitrateTier", () => {
   it("stays high on a healthy link", () => {
     expect(
-      pickBitrateTier({ rttMs: 40, packetsLost: 0, packetsSent: 100 }),
+      pickBitrateTier({
+        rttMs: 40,
+        packetsLost: 0,
+        packetsSent: 100,
+        jitterMs: 5,
+      }),
     ).toEqual({
       maxBitrate: 2_500_000,
+      audioMaxBitrate: 64_000,
       label: "high",
     });
   });
 
-  it("drops to medium when rtt climbs", () => {
+  it("drops to medium when rtt or jitter climbs", () => {
     expect(
       pickBitrateTier({ rttMs: 150, packetsLost: 0, packetsSent: 100 }).label,
     ).toBe("medium");
+
+    expect(
+      pickBitrateTier({
+        rttMs: 40,
+        packetsLost: 0,
+        packetsSent: 100,
+        jitterMs: 25,
+      }).label,
+    ).toBe("medium");
   });
 
-  it("drops to low on packet loss", () => {
+  it("drops to low on packet loss or severe jitter", () => {
     expect(
       pickBitrateTier({ rttMs: 50, packetsLost: 20, packetsSent: 100 }).label,
+    ).toBe("low");
+
+    expect(
+      pickBitrateTier({
+        rttMs: 40,
+        packetsLost: 0,
+        packetsSent: 100,
+        jitterMs: 60,
+      }).label,
     ).toBe("low");
   });
 });
 
 describe("readNetworkHints", () => {
-  it("pulls rtt and outbound video counters from stats", () => {
+  it("pulls rtt, jitter, and outbound video/audio counters from stats", () => {
     const rows = [
       {
         type: "candidate-pair",
@@ -32,9 +60,14 @@ describe("readNetworkHints", () => {
         currentRoundTripTime: 0.08,
       },
       {
+        type: "remote-inbound-rtp",
+        jitter: 0.025,
+        packetsLost: 2,
+        roundTripTime: 0.085,
+      },
+      {
         type: "outbound-rtp",
         kind: "video",
-        packetsLost: 2,
         packetsSent: 200,
       },
     ];
@@ -46,9 +79,48 @@ describe("readNetworkHints", () => {
     } as unknown as RTCStatsReport;
 
     expect(readNetworkHints(report)).toEqual({
-      rttMs: 80,
+      rttMs: 85,
       packetsLost: 2,
       packetsSent: 200,
+      jitterMs: 25,
     });
+  });
+});
+
+describe("adaptVideoBitrate", () => {
+  it("adaptively adjusts maxBitrate for both video and audio senders", async () => {
+    const videoSetParams = jest.fn().mockResolvedValue(undefined);
+    const audioSetParams = jest.fn().mockResolvedValue(undefined);
+
+    const videoSender = {
+      track: { kind: "video" },
+      getParameters: jest.fn().mockReturnValue({ encodings: [{}] }),
+      setParameters: videoSetParams,
+    };
+
+    const audioSender = {
+      track: { kind: "audio" },
+      getParameters: jest.fn().mockReturnValue({ encodings: [{}] }),
+      setParameters: audioSetParams,
+    };
+
+    const mockReport = [
+      { type: "candidate-pair", state: "succeeded", currentRoundTripTime: 0.3 }, // Poor RTT (300ms)
+    ];
+
+    const pc = {
+      getSenders: () => [videoSender, audioSender],
+      getStats: jest.fn().mockResolvedValue({
+        forEach: (cb: any) => mockReport.forEach(cb),
+      }),
+    } as unknown as RTCPeerConnection;
+
+    const tier = await adaptVideoBitrate(pc);
+
+    expect(tier?.label).toBe("low");
+    expect(videoSender.getParameters().encodings[0].maxBitrate).toBe(400_000);
+    expect(audioSender.getParameters().encodings[0].maxBitrate).toBe(16_000);
+    expect(videoSetParams).toHaveBeenCalled();
+    expect(audioSetParams).toHaveBeenCalled();
   });
 });

--- a/src/components/audio/AudioEqualizer.tsx
+++ b/src/components/audio/AudioEqualizer.tsx
@@ -14,7 +14,12 @@ import {
 type SoundPreset = "jazz" | "cafe" | "library";
 
 export type EqPresetName =
-  "flat" | "bass-boost" | "vocal-enhancer" | "treble-boost" | "warm" | "custom";
+  | "flat"
+  | "bass-boost"
+  | "vocal-enhancer"
+  | "treble-boost"
+  | "warm"
+  | "custom";
 
 export interface EqPreset {
   label: string;
@@ -424,7 +429,7 @@ export function AudioEqualizer({
       const interval = setInterval(playChord, 5000);
       jazzCleanupRef.current = () => clearInterval(interval);
     }
-  }, [preset, stopPlayingNodes, initAudio]);
+  }, [preset, initAudio, stopPlayingNodes]);
 
   const togglePlay = () => {
     if (isPlaying) {

--- a/src/hooks/useWebRTCMesh.ts
+++ b/src/hooks/useWebRTCMesh.ts
@@ -394,9 +394,23 @@ export function useWebRTCMesh({ roomId, userId }: Options) {
 
   const startBitrateLoop = useCallback(() => {
     if (bitrateTimerRef.current) clearInterval(bitrateTimerRef.current);
-    bitrateTimerRef.current = setInterval(() => {
+    bitrateTimerRef.current = setInterval(async () => {
+      let worstTierLabel: "high" | "medium" | "low" | null = null;
       for (const pc of peersRef.current.values()) {
-        void adaptVideoBitrate(pc);
+        const tier = await adaptVideoBitrate(pc);
+        if (tier) {
+          if (tier.label === "low") worstTierLabel = "low";
+          else if (tier.label === "medium" && worstTierLabel !== "low") {
+            worstTierLabel = "medium";
+          } else if (!worstTierLabel) {
+            worstTierLabel = "high";
+          }
+        }
+      }
+      if (worstTierLabel === "low") {
+        setNetworkQuality("poor");
+      } else if (worstTierLabel === "medium") {
+        setNetworkQuality((prev) => (prev === "poor" ? "poor" : "fair"));
       }
     }, 4000);
   }, []);

--- a/src/lib/screenShareBitrate.ts
+++ b/src/lib/screenShareBitrate.ts
@@ -5,72 +5,137 @@
 
 export type BitrateTier = {
   maxBitrate: number;
+  audioMaxBitrate: number;
   label: "high" | "medium" | "low";
 };
 
-const HIGH: BitrateTier = { maxBitrate: 2_500_000, label: "high" };
-const MEDIUM: BitrateTier = { maxBitrate: 1_000_000, label: "medium" };
-const LOW: BitrateTier = { maxBitrate: 400_000, label: "low" };
+const HIGH: BitrateTier = {
+  maxBitrate: 2_500_000,
+  audioMaxBitrate: 64_000,
+  label: "high",
+};
+const MEDIUM: BitrateTier = {
+  maxBitrate: 1_000_000,
+  audioMaxBitrate: 32_000,
+  label: "medium",
+};
+const LOW: BitrateTier = {
+  maxBitrate: 400_000,
+  audioMaxBitrate: 16_000,
+  label: "low",
+};
 
 export function pickBitrateTier(input: {
   rttMs?: number;
   packetsLost?: number;
   packetsSent?: number;
+  jitterMs?: number;
 }): BitrateTier {
   const rtt = input.rttMs ?? 0;
   const sent = input.packetsSent ?? 0;
   const lost = input.packetsLost ?? 0;
+  const jitter = input.jitterMs ?? 0;
   const lossRatio = sent > 0 ? lost / sent : 0;
 
-  if (rtt > 250 || lossRatio > 0.08) return LOW;
-  if (rtt > 120 || lossRatio > 0.03) return MEDIUM;
+  if (rtt > 250 || lossRatio > 0.08 || jitter > 50) return LOW;
+  if (rtt > 120 || lossRatio > 0.03 || jitter > 20) return MEDIUM;
   return HIGH;
 }
 
-/** Read rough RTT / loss from an RTCPeerConnection stats report. */
+/** Read rough RTT, loss, and jitter from an RTCPeerConnection stats report. */
 export function readNetworkHints(report: RTCStatsReport): {
   rttMs?: number;
   packetsLost?: number;
   packetsSent?: number;
+  jitterMs?: number;
 } {
   let rttMs: number | undefined;
   let packetsLost: number | undefined;
   let packetsSent: number | undefined;
+  let jitterMs: number | undefined;
 
-  report.forEach((stat) => {
+  report.forEach((stat: any) => {
     if (stat.type === "candidate-pair" && stat.state === "succeeded") {
       if (typeof stat.currentRoundTripTime === "number") {
         rttMs = stat.currentRoundTripTime * 1000;
       }
     }
-    if (stat.type === "outbound-rtp" && stat.kind === "video") {
-      if (typeof stat.packetsLost === "number") packetsLost = stat.packetsLost;
+    if (stat.type === "remote-inbound-rtp") {
+      if (typeof stat.roundTripTime === "number") {
+        rttMs = stat.roundTripTime * 1000;
+      }
+      if (typeof stat.jitter === "number") {
+        const jMs = stat.jitter * 1000;
+        jitterMs = jitterMs !== undefined ? Math.max(jitterMs, jMs) : jMs;
+      }
+      if (typeof stat.packetsLost === "number") {
+        packetsLost = stat.packetsLost;
+      }
+    }
+    if (stat.type === "inbound-rtp") {
+      if (typeof stat.jitter === "number") {
+        const jMs = stat.jitter * 1000;
+        jitterMs = jitterMs !== undefined ? Math.max(jitterMs, jMs) : jMs;
+      }
+      if (typeof stat.packetsLost === "number" && packetsLost === undefined) {
+        packetsLost = stat.packetsLost;
+      }
+      if (
+        typeof stat.packetsReceived === "number" &&
+        packetsSent === undefined
+      ) {
+        packetsSent = (stat.packetsReceived || 0) + (stat.packetsLost || 0);
+      }
+    }
+    if (
+      stat.type === "outbound-rtp" &&
+      (stat.kind === "video" || stat.mediaType === "video")
+    ) {
+      if (typeof stat.packetsLost === "number" && packetsLost === undefined)
+        packetsLost = stat.packetsLost;
       if (typeof stat.packetsSent === "number") packetsSent = stat.packetsSent;
     }
   });
 
-  return { rttMs, packetsLost, packetsSent };
+  return { rttMs, packetsLost, packetsSent, jitterMs };
 }
 
 export async function adaptVideoBitrate(
   pc: RTCPeerConnection,
 ): Promise<BitrateTier | null> {
-  const sender = pc.getSenders().find((s) => s.track?.kind === "video");
-  if (!sender) return null;
+  const senders = pc.getSenders();
+  const videoSender = senders.find((s) => s.track?.kind === "video");
+  const audioSender = senders.find((s) => s.track?.kind === "audio");
+
+  if (!videoSender && !audioSender) return null;
 
   const hints = readNetworkHints(await pc.getStats());
   const tier = pickBitrateTier(hints);
-  const params = sender.getParameters();
 
-  if (!params.encodings?.length) {
-    params.encodings = [{}];
+  if (videoSender) {
+    const params = videoSender.getParameters();
+    if (!params.encodings?.length) {
+      params.encodings = [{}];
+    }
+    params.encodings[0].maxBitrate = tier.maxBitrate;
+    try {
+      await videoSender.setParameters(params);
+    } catch {
+      // Some browsers reject mid-flight tweaks; ignore and keep going.
+    }
   }
-  params.encodings[0].maxBitrate = tier.maxBitrate;
 
-  try {
-    await sender.setParameters(params);
-  } catch {
-    // Some browsers reject mid-flight tweaks; ignore and keep going.
+  if (audioSender) {
+    const params = audioSender.getParameters();
+    if (!params.encodings?.length) {
+      params.encodings = [{}];
+    }
+    params.encodings[0].maxBitrate = tier.audioMaxBitrate;
+    try {
+      await audioSender.setParameters(params);
+    } catch {
+      // Some browsers reject mid-flight tweaks; ignore and keep going.
+    }
   }
 
   return tier;


### PR DESCRIPTION
Fixes #1421

Summary & Implementation Details
Real-Time Network Transport Telemetry Monitoring: Extended readNetworkHints in src/lib/screenShareBitrate.ts to extract rttMs, packetsLost, packetsSent, and jitterMs from RTCPeerConnection.getStats() reports across candidate-pair, remote-inbound-rtp, and inbound-rtp stat entries.
Adaptive Video & Audio Bitrate Adjustment: Updated pickBitrateTier and adaptVideoBitrate to dynamically adjust maxBitrate on RTCRtpEncodingParameters for both video and audio senders based on real-time network conditions:
High Tier: Video 2,500,000 bps, Audio 64,000 bps
Medium Tier: Video 1,000,000 bps, Audio 32,000 bps
Low Tier: Video 400,000 bps, Audio 16,000 bps (triggered when RTT > 250ms, packet loss ratio > 8%, or RTT jitter > 50ms).
Voice Call Continuity Preservation: Connected peer transport quality evaluation to the startBitrateLoop in useWebRTCMesh.ts to trigger audio downsampling (sampleRate: 16000) and audio encoding bitrate reduction during network degradation, maintaining clear voice communication.
Comprehensive Unit Tests: Updated src/__tests__/lib/screenShareBitrate.test.ts and src/__tests__/hooks/useWebRTCMesh.test.ts to cover RTT jitter parsing, multi-sender bitrate adaptation, tier thresholds, and state transitions during transport degradation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved screen-sharing quality adaptation using network latency, packet loss, and jitter.
  * Video and audio bitrates now adjust independently to better match network conditions.
  * Network quality indicators now reflect the combined conditions across active connections.

* **Bug Fixes**
  * Improved resilience when applying bitrate updates during active calls.
  * Added more reliable handling of changing network conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->