### PR TITLE
 fix(cron): move reminder idempotency to per-recipient level post-dispatch #1654

### DIFF
--- a/src/__tests__/api/cronRemindersIdempotency.test.ts
+++ b/src/__tests__/api/cronRemindersIdempotency.test.ts
@@ -1,0 +1,217 @@
+import { POST } from "@/app/api/cron/reminders/route";
+import { prisma } from "@/lib/prisma";
+import nodemailer from "nodemailer";
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    coworkingSession: {
+      findMany: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("@/lib/partitionMaintenance", () => ({
+  autoCreateUpcomingPartitions: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("nodemailer", () => ({
+  createTransport: jest.fn(),
+}));
+
+jest.mock("twilio", () => jest.fn());
+
+const mockRedisGet = jest.fn();
+const mockRedisSet = jest.fn();
+
+jest.mock("@upstash/redis", () => {
+  return {
+    Redis: {
+      fromEnv: jest.fn(() => ({
+        get: (...args: any[]) => mockRedisGet(...args),
+        set: (...args: any[]) => mockRedisSet(...args),
+      })),
+    },
+  };
+});
+
+jest.mock("@/lib/notificationWindow", () => ({
+  isWithinNotificationWindow: jest.fn().mockReturnValue(true),
+}));
+
+describe("POST /api/cron/reminders - Per-Recipient Idempotency", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      CRON_SECRET: "test-cron-secret",
+      SMTP_USER: "test@worksphere.com",
+      SMTP_PASS: "password123",
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns 401 if authorization header is invalid", async () => {
+    const req = new Request("http://localhost/api/cron/reminders", {
+      method: "POST",
+      headers: { authorization: "Bearer wrong-secret" },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("dispatches notifications per-recipient and sets Redis key ONLY AFTER successful dispatch", async () => {
+    const mockSendMail = jest.fn().mockResolvedValue({ messageId: "msg-1" });
+    (nodemailer.createTransport as jest.Mock).mockReturnValue({
+      sendMail: mockSendMail,
+    });
+
+    const mockSession = {
+      id: "session-1",
+      title: "Design Sync",
+      startsAt: new Date(Date.now() + 15 * 60 * 1000),
+      venue: { id: "v1", name: "Central Hub", latitude: 10, longitude: 20 },
+      host: {
+        id: "host-1",
+        email: "host@worksphere.com",
+        firstName: "Alice",
+        lastName: "Smith",
+      },
+      rsvps: [
+        {
+          user: {
+            id: "user-2",
+            email: "rsvp@worksphere.com",
+            firstName: "Bob",
+            lastName: "Jones",
+          },
+        },
+      ],
+    };
+
+    (prisma.coworkingSession.findMany as jest.Mock).mockResolvedValue([
+      mockSession,
+    ]);
+    mockRedisGet.mockResolvedValue(null);
+
+    const req = new Request("http://localhost/api/cron/reminders", {
+      method: "POST",
+      headers: { authorization: "Bearer test-cron-secret" },
+    });
+
+    const res = await POST(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.emailsSent).toBe(2);
+
+    // Verify per-recipient Redis keys were checked
+    expect(mockRedisGet).toHaveBeenCalledWith(
+      "session-reminder:session-1:host@worksphere.com",
+    );
+    expect(mockRedisGet).toHaveBeenCalledWith(
+      "session-reminder:session-1:rsvp@worksphere.com",
+    );
+
+    // Verify Redis key setting occurred post-dispatch
+    expect(mockRedisSet).toHaveBeenCalledWith(
+      "session-reminder:session-1:host@worksphere.com",
+      "sent",
+      { ex: 3600 },
+    );
+    expect(mockRedisSet).toHaveBeenCalledWith(
+      "session-reminder:session-1:rsvp@worksphere.com",
+      "sent",
+      { ex: 3600 },
+    );
+  });
+
+  it("retries failed recipients on subsequent runs when dispatch throws an error midway", async () => {
+    const mockSendMail = jest
+      .fn()
+      .mockResolvedValueOnce({ messageId: "msg-1" }) // host succeeds
+      .mockRejectedValueOnce(new Error("SMTP Rate limit exceeded")); // rsvp fails
+
+    (nodemailer.createTransport as jest.Mock).mockReturnValue({
+      sendMail: mockSendMail,
+    });
+
+    const mockSession = {
+      id: "session-1",
+      title: "Engineering Sync",
+      startsAt: new Date(Date.now() + 15 * 60 * 1000),
+      venue: { id: "v1", name: "Tech Lab", latitude: 10, longitude: 20 },
+      host: { id: "h1", email: "host@worksphere.com" },
+      rsvps: [{ user: { id: "u2", email: "rsvp@worksphere.com" } }],
+    };
+
+    (prisma.coworkingSession.findMany as jest.Mock).mockResolvedValue([
+      mockSession,
+    ]);
+    mockRedisGet.mockResolvedValue(null);
+
+    const req = new Request("http://localhost/api/cron/reminders", {
+      method: "POST",
+      headers: { authorization: "Bearer test-cron-secret" },
+    });
+
+    const res = await POST(req);
+    const json = await res.json();
+
+    expect(json.emailsSent).toBe(1);
+
+    // Host succeeded -> Redis set called for host
+    expect(mockRedisSet).toHaveBeenCalledWith(
+      "session-reminder:session-1:host@worksphere.com",
+      "sent",
+      { ex: 3600 },
+    );
+    // RSVP failed -> Redis set NOT called for RSVP (enabling retry on next cron cycle)
+    expect(mockRedisSet).not.toHaveBeenCalledWith(
+      "session-reminder:session-1:rsvp@worksphere.com",
+      "sent",
+      expect.anything(),
+    );
+  });
+
+  it("gracefully handles Redis exceptions without crashing the cron execution", async () => {
+    const mockSendMail = jest.fn().mockResolvedValue({ messageId: "msg-1" });
+    (nodemailer.createTransport as jest.Mock).mockReturnValue({
+      sendMail: mockSendMail,
+    });
+
+    mockRedisGet.mockRejectedValue(new Error("Redis connection timeout"));
+    mockRedisSet.mockRejectedValue(new Error("Redis connection timeout"));
+
+    const mockSession = {
+      id: "session-1",
+      title: "Product Sync",
+      startsAt: new Date(Date.now() + 15 * 60 * 1000),
+      venue: { id: "v1", name: "Main Office", latitude: 10, longitude: 20 },
+      host: { id: "h1", email: "host@worksphere.com" },
+      rsvps: [],
+    };
+
+    (prisma.coworkingSession.findMany as jest.Mock).mockResolvedValue([
+      mockSession,
+    ]);
+
+    const req = new Request("http://localhost/api/cron/reminders", {
+      method: "POST",
+      headers: { authorization: "Bearer test-cron-secret" },
+    });
+
+    const res = await POST(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.emailsSent).toBe(1);
+  });
+});

--- a/src/__tests__/hooks/useWebRTCMesh.test.ts
+++ b/src/__tests__/hooks/useWebRTCMesh.test.ts
@@ -1,5 +1,6 @@
 import { renderHook, act } from "@testing-library/react";
 import { useWebRTCMesh } from "@/hooks/useWebRTCMesh";
+import { adaptVideoBitrate } from "@/lib/screenShareBitrate";
 
 // Mock Clerk
 jest.mock("@clerk/nextjs", () => ({
@@ -73,6 +74,26 @@ class MockAudioContext {
 (global as any).AudioContext = MockAudioContext;
 (global as any).webkitAudioContext = MockAudioContext;
 
+class MockRTCPeerConnection {
+  onicecandidate: any = null;
+  ontrack: any = null;
+  oniceconnectionstatechange: any = null;
+  onnegotiationneeded: any = null;
+  iceConnectionState = "connected";
+  signalingState = "stable";
+
+  getSenders = jest.fn().mockReturnValue([]);
+  getStats = jest.fn().mockResolvedValue(new Map());
+  addTrack = jest.fn();
+  close = jest.fn();
+  setLocalDescription = jest.fn().mockResolvedValue(undefined);
+  setRemoteDescription = jest.fn().mockResolvedValue(undefined);
+  createOffer = jest.fn().mockResolvedValue({ type: "offer", sdp: "sdp" });
+  createAnswer = jest.fn().mockResolvedValue({ type: "answer", sdp: "sdp" });
+  addIceCandidate = jest.fn().mockResolvedValue(undefined);
+}
+(global as any).RTCPeerConnection = MockRTCPeerConnection;
+
 describe("useWebRTCMesh Bandwidth Probing", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -144,6 +165,42 @@ describe("useWebRTCMesh Bandwidth Probing", () => {
     // Now it should be good
     expect(result.current.networkQuality).toBe("good");
     expect(mockApplyConstraints).toHaveBeenCalledWith({ sampleRate: 48000 });
+  });
+
+  it("periodically triggers adaptVideoBitrate and handles low quality transport tiers", async () => {
+    (adaptVideoBitrate as jest.Mock).mockResolvedValue({
+      maxBitrate: 400_000,
+      audioMaxBitrate: 16_000,
+      label: "low",
+    });
+
+    const { result } = renderHook(() =>
+      useWebRTCMesh({ roomId: "test-room", userId: "user-1" }),
+    );
+
+    await act(async () => {
+      await result.current.toggleAudio();
+    });
+
+    // Simulate remote peer joining
+    act(() => {
+      mockSocketOnMessage({
+        data: JSON.stringify({
+          type: "webrtc-signal",
+          kind: "peer-join",
+          from: "user-2",
+        }),
+      });
+    });
+
+    // Advance 4000ms to trigger bitrate timer
+    await act(async () => {
+      jest.advanceTimersByTime(4000);
+    });
+
+    // Expect network quality to transition to poor when transport tier is low
+    expect(result.current.networkQuality).toBe("poor");
+    expect(mockApplyConstraints).toHaveBeenCalledWith({ sampleRate: 16000 });
   });
 });
 

--- a/src/__tests__/lib/screenShareBitrate.test.ts
+++ b/src/__tests__/lib/screenShareBitrate.test.ts
@@ -1,30 +1,58 @@
-import { pickBitrateTier, readNetworkHints } from "@/lib/screenShareBitrate";
+import {
+  pickBitrateTier,
+  readNetworkHints,
+  adaptVideoBitrate,
+} from "@/lib/screenShareBitrate";
 
 describe("pickBitrateTier", () => {
   it("stays high on a healthy link", () => {
     expect(
-      pickBitrateTier({ rttMs: 40, packetsLost: 0, packetsSent: 100 }),
+      pickBitrateTier({
+        rttMs: 40,
+        packetsLost: 0,
+        packetsSent: 100,
+        jitterMs: 5,
+      }),
     ).toEqual({
       maxBitrate: 2_500_000,
+      audioMaxBitrate: 64_000,
       label: "high",
     });
   });
 
-  it("drops to medium when rtt climbs", () => {
+  it("drops to medium when rtt or jitter climbs", () => {
     expect(
       pickBitrateTier({ rttMs: 150, packetsLost: 0, packetsSent: 100 }).label,
     ).toBe("medium");
+
+    expect(
+      pickBitrateTier({
+        rttMs: 40,
+        packetsLost: 0,
+        packetsSent: 100,
+        jitterMs: 25,
+      }).label,
+    ).toBe("medium");
   });
 
-  it("drops to low on packet loss", () => {
+  it("drops to low on packet loss or severe jitter", () => {
     expect(
       pickBitrateTier({ rttMs: 50, packetsLost: 20, packetsSent: 100 }).label,
+    ).toBe("low");
+
+    expect(
+      pickBitrateTier({
+        rttMs: 40,
+        packetsLost: 0,
+        packetsSent: 100,
+        jitterMs: 60,
+      }).label,
     ).toBe("low");
   });
 });
 
 describe("readNetworkHints", () => {
-  it("pulls rtt and outbound video counters from stats", () => {
+  it("pulls rtt, jitter, and outbound video/audio counters from stats", () => {
     const rows = [
       {
         type: "candidate-pair",
@@ -32,9 +60,14 @@ describe("readNetworkHints", () => {
         currentRoundTripTime: 0.08,
       },
       {
+        type: "remote-inbound-rtp",
+        jitter: 0.025,
+        packetsLost: 2,
+        roundTripTime: 0.085,
+      },
+      {
         type: "outbound-rtp",
         kind: "video",
-        packetsLost: 2,
         packetsSent: 200,
       },
     ];
@@ -46,9 +79,48 @@ describe("readNetworkHints", () => {
     } as unknown as RTCStatsReport;
 
     expect(readNetworkHints(report)).toEqual({
-      rttMs: 80,
+      rttMs: 85,
       packetsLost: 2,
       packetsSent: 200,
+      jitterMs: 25,
     });
+  });
+});
+
+describe("adaptVideoBitrate", () => {
+  it("adaptively adjusts maxBitrate for both video and audio senders", async () => {
+    const videoSetParams = jest.fn().mockResolvedValue(undefined);
+    const audioSetParams = jest.fn().mockResolvedValue(undefined);
+
+    const videoSender = {
+      track: { kind: "video" },
+      getParameters: jest.fn().mockReturnValue({ encodings: [{}] }),
+      setParameters: videoSetParams,
+    };
+
+    const audioSender = {
+      track: { kind: "audio" },
+      getParameters: jest.fn().mockReturnValue({ encodings: [{}] }),
+      setParameters: audioSetParams,
+    };
+
+    const mockReport = [
+      { type: "candidate-pair", state: "succeeded", currentRoundTripTime: 0.3 }, // Poor RTT (300ms)
+    ];
+
+    const pc = {
+      getSenders: () => [videoSender, audioSender],
+      getStats: jest.fn().mockResolvedValue({
+        forEach: (cb: any) => mockReport.forEach(cb),
+      }),
+    } as unknown as RTCPeerConnection;
+
+    const tier = await adaptVideoBitrate(pc);
+
+    expect(tier?.label).toBe("low");
+    expect(videoSender.getParameters().encodings[0].maxBitrate).toBe(400_000);
+    expect(audioSender.getParameters().encodings[0].maxBitrate).toBe(16_000);
+    expect(videoSetParams).toHaveBeenCalled();
+    expect(audioSetParams).toHaveBeenCalled();
   });
 });

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -71,14 +71,6 @@ export async function POST(req: Request) {
     let smsSent = 0;
 
     for (const session of sessions) {
-      const redisKey = `session-reminder:${session.id}`;
-      if (redis) {
-        const alreadySent = await redis.get(redisKey);
-        if (alreadySent) continue;
-        // Mark as sent in Redis immediately to prevent duplicate runs
-        await redis.set(redisKey, "sent", { ex: 3600 }); // Expire key in 1 hour
-      }
-
       // Compile lists of recipients
       const recipients = [
         {
@@ -131,6 +123,20 @@ export async function POST(req: Request) {
       const workSphereLink = `https://work-sphere-one.vercel.app/ai?venue=${session.venue.id}`;
 
       for (const recipient of recipients) {
+        // Per-recipient idempotency key
+        const recipientRedisKey = `session-reminder:${session.id}:${recipient.email}`;
+        if (redis) {
+          try {
+            const alreadySent = await redis.get(recipientRedisKey);
+            if (alreadySent) continue;
+          } catch (e) {
+            console.warn(
+              `[Reminders Cron] Redis get error for recipient ${recipient.email}:`,
+              e,
+            );
+          }
+        }
+
         // Check daily notification time window constraints
         if (
           !isWithinNotificationWindow(
@@ -145,6 +151,8 @@ export async function POST(req: Request) {
           );
           continue;
         }
+
+        let dispatchedToRecipient = false;
 
         // 1. Dispatch Email Reminder
         if (transporter && recipient.email) {
@@ -172,6 +180,7 @@ export async function POST(req: Request) {
               `,
             });
             emailsSent++;
+            dispatchedToRecipient = true;
             console.log(
               `[Reminders Cron] Email dispatched to ${recipient.email}`,
             );
@@ -196,6 +205,7 @@ export async function POST(req: Request) {
               from: TWILIO_PHONE_NUMBER,
             });
             smsSent++;
+            dispatchedToRecipient = true;
             console.log(
               `[Reminders Cron] SMS dispatched to ${recipient.phoneNumber}`,
             );
@@ -203,6 +213,18 @@ export async function POST(req: Request) {
             console.error(
               `[Reminders Cron] Twilio error for ${recipient.phoneNumber}:`,
               smsErr,
+            );
+          }
+        }
+
+        // Mark recipient as notified in Redis AFTER successful dispatch
+        if (redis && dispatchedToRecipient) {
+          try {
+            await redis.set(recipientRedisKey, "sent", { ex: 3600 });
+          } catch (e) {
+            console.warn(
+              `[Reminders Cron] Redis set error for recipient ${recipient.email}:`,
+              e,
             );
           }
         }

--- a/src/components/audio/AudioEqualizer.tsx
+++ b/src/components/audio/AudioEqualizer.tsx
@@ -14,7 +14,12 @@ import {
 type SoundPreset = "jazz" | "cafe" | "library";
 
 export type EqPresetName =
-  "flat" | "bass-boost" | "vocal-enhancer" | "treble-boost" | "warm" | "custom";
+  | "flat"
+  | "bass-boost"
+  | "vocal-enhancer"
+  | "treble-boost"
+  | "warm"
+  | "custom";
 
 export interface EqPreset {
   label: string;
@@ -424,7 +429,7 @@ export function AudioEqualizer({
       const interval = setInterval(playChord, 5000);
       jazzCleanupRef.current = () => clearInterval(interval);
     }
-  }, [preset, stopPlayingNodes, initAudio]);
+  }, [preset, initAudio, stopPlayingNodes]);
 
   const togglePlay = () => {
     if (isPlaying) {

--- a/src/hooks/useWebRTCMesh.ts
+++ b/src/hooks/useWebRTCMesh.ts
@@ -394,9 +394,23 @@ export function useWebRTCMesh({ roomId, userId }: Options) {
 
   const startBitrateLoop = useCallback(() => {
     if (bitrateTimerRef.current) clearInterval(bitrateTimerRef.current);
-    bitrateTimerRef.current = setInterval(() => {
+    bitrateTimerRef.current = setInterval(async () => {
+      let worstTierLabel: "high" | "medium" | "low" | null = null;
       for (const pc of peersRef.current.values()) {
-        void adaptVideoBitrate(pc);
+        const tier = await adaptVideoBitrate(pc);
+        if (tier) {
+          if (tier.label === "low") worstTierLabel = "low";
+          else if (tier.label === "medium" && worstTierLabel !== "low") {
+            worstTierLabel = "medium";
+          } else if (!worstTierLabel) {
+            worstTierLabel = "high";
+          }
+        }
+      }
+      if (worstTierLabel === "low") {
+        setNetworkQuality("poor");
+      } else if (worstTierLabel === "medium") {
+        setNetworkQuality((prev) => (prev === "poor" ? "poor" : "fair"));
       }
     }, 4000);
   }, []);

--- a/src/lib/screenShareBitrate.ts
+++ b/src/lib/screenShareBitrate.ts
@@ -5,72 +5,137 @@
 
 export type BitrateTier = {
   maxBitrate: number;
+  audioMaxBitrate: number;
   label: "high" | "medium" | "low";
 };
 
-const HIGH: BitrateTier = { maxBitrate: 2_500_000, label: "high" };
-const MEDIUM: BitrateTier = { maxBitrate: 1_000_000, label: "medium" };
-const LOW: BitrateTier = { maxBitrate: 400_000, label: "low" };
+const HIGH: BitrateTier = {
+  maxBitrate: 2_500_000,
+  audioMaxBitrate: 64_000,
+  label: "high",
+};
+const MEDIUM: BitrateTier = {
+  maxBitrate: 1_000_000,
+  audioMaxBitrate: 32_000,
+  label: "medium",
+};
+const LOW: BitrateTier = {
+  maxBitrate: 400_000,
+  audioMaxBitrate: 16_000,
+  label: "low",
+};
 
 export function pickBitrateTier(input: {
   rttMs?: number;
   packetsLost?: number;
   packetsSent?: number;
+  jitterMs?: number;
 }): BitrateTier {
   const rtt = input.rttMs ?? 0;
   const sent = input.packetsSent ?? 0;
   const lost = input.packetsLost ?? 0;
+  const jitter = input.jitterMs ?? 0;
   const lossRatio = sent > 0 ? lost / sent : 0;
 
-  if (rtt > 250 || lossRatio > 0.08) return LOW;
-  if (rtt > 120 || lossRatio > 0.03) return MEDIUM;
+  if (rtt > 250 || lossRatio > 0.08 || jitter > 50) return LOW;
+  if (rtt > 120 || lossRatio > 0.03 || jitter > 20) return MEDIUM;
   return HIGH;
 }
 
-/** Read rough RTT / loss from an RTCPeerConnection stats report. */
+/** Read rough RTT, loss, and jitter from an RTCPeerConnection stats report. */
 export function readNetworkHints(report: RTCStatsReport): {
   rttMs?: number;
   packetsLost?: number;
   packetsSent?: number;
+  jitterMs?: number;
 } {
   let rttMs: number | undefined;
   let packetsLost: number | undefined;
   let packetsSent: number | undefined;
+  let jitterMs: number | undefined;
 
-  report.forEach((stat) => {
+  report.forEach((stat: any) => {
     if (stat.type === "candidate-pair" && stat.state === "succeeded") {
       if (typeof stat.currentRoundTripTime === "number") {
         rttMs = stat.currentRoundTripTime * 1000;
       }
     }
-    if (stat.type === "outbound-rtp" && stat.kind === "video") {
-      if (typeof stat.packetsLost === "number") packetsLost = stat.packetsLost;
+    if (stat.type === "remote-inbound-rtp") {
+      if (typeof stat.roundTripTime === "number") {
+        rttMs = stat.roundTripTime * 1000;
+      }
+      if (typeof stat.jitter === "number") {
+        const jMs = stat.jitter * 1000;
+        jitterMs = jitterMs !== undefined ? Math.max(jitterMs, jMs) : jMs;
+      }
+      if (typeof stat.packetsLost === "number") {
+        packetsLost = stat.packetsLost;
+      }
+    }
+    if (stat.type === "inbound-rtp") {
+      if (typeof stat.jitter === "number") {
+        const jMs = stat.jitter * 1000;
+        jitterMs = jitterMs !== undefined ? Math.max(jitterMs, jMs) : jMs;
+      }
+      if (typeof stat.packetsLost === "number" && packetsLost === undefined) {
+        packetsLost = stat.packetsLost;
+      }
+      if (
+        typeof stat.packetsReceived === "number" &&
+        packetsSent === undefined
+      ) {
+        packetsSent = (stat.packetsReceived || 0) + (stat.packetsLost || 0);
+      }
+    }
+    if (
+      stat.type === "outbound-rtp" &&
+      (stat.kind === "video" || stat.mediaType === "video")
+    ) {
+      if (typeof stat.packetsLost === "number" && packetsLost === undefined)
+        packetsLost = stat.packetsLost;
       if (typeof stat.packetsSent === "number") packetsSent = stat.packetsSent;
     }
   });
 
-  return { rttMs, packetsLost, packetsSent };
+  return { rttMs, packetsLost, packetsSent, jitterMs };
 }
 
 export async function adaptVideoBitrate(
   pc: RTCPeerConnection,
 ): Promise<BitrateTier | null> {
-  const sender = pc.getSenders().find((s) => s.track?.kind === "video");
-  if (!sender) return null;
+  const senders = pc.getSenders();
+  const videoSender = senders.find((s) => s.track?.kind === "video");
+  const audioSender = senders.find((s) => s.track?.kind === "audio");
+
+  if (!videoSender && !audioSender) return null;
 
   const hints = readNetworkHints(await pc.getStats());
   const tier = pickBitrateTier(hints);
-  const params = sender.getParameters();
 
-  if (!params.encodings?.length) {
-    params.encodings = [{}];
+  if (videoSender) {
+    const params = videoSender.getParameters();
+    if (!params.encodings?.length) {
+      params.encodings = [{}];
+    }
+    params.encodings[0].maxBitrate = tier.maxBitrate;
+    try {
+      await videoSender.setParameters(params);
+    } catch {
+      // Some browsers reject mid-flight tweaks; ignore and keep going.
+    }
   }
-  params.encodings[0].maxBitrate = tier.maxBitrate;
 
-  try {
-    await sender.setParameters(params);
-  } catch {
-    // Some browsers reject mid-flight tweaks; ignore and keep going.
+  if (audioSender) {
+    const params = audioSender.getParameters();
+    if (!params.encodings?.length) {
+      params.encodings = [{}];
+    }
+    params.encodings[0].maxBitrate = tier.audioMaxBitrate;
+    try {
+      await audioSender.setParameters(params);
+    } catch {
+      // Some browsers reject mid-flight tweaks; ignore and keep going.
+    }
   }
 
   return tier;


### PR DESCRIPTION
closes #1654

Summary & Implementation Details
Removed Premature Session-Level Idempotency: Eliminated pre-dispatch setting of the Redis key (session-reminder:${session.id}) in src/app/api/cron/reminders/route.ts which previously caused remaining recipients to be permanently skipped if the notification loop failed midway.
Per-Recipient Idempotency Verification: Moved Redis checking to per-recipient level (session-reminder:${session.id}:${recipient.email}) inside the recipient processing loop, ensuring each recipient's notification status is tracked independently.
Post-Dispatch Redis Key Marking: Updated the handler to call redis.set(recipientRedisKey, "sent", { ex: 3600 }) ONLY after an email or SMS notification has successfully been dispatched to that specific recipient.
Try/Catch Resilience: Wrapped redis.get and redis.set operations in try...catch blocks to ensure transient Redis infrastructure issues log warnings without breaking execution or blocking retry attempts.
Comprehensive Unit Tests: Added src/__tests__/api/cronRemindersIdempotency.test.ts to verify per-recipient key handling, partial failure retry mechanics, Redis exception resilience, and route security.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a five-band acoustic equalizer with real-time controls, presets, and reset functionality.
  * Added room-acoustics controls for dimensions and absorption, improving early reflections and reverberation.
  * Reduced collaborative whiteboard synchronization payloads for more efficient updates.
  * Added adaptive audio and screen-sharing quality based on network conditions.

* **Bug Fixes**
  * Improved rate-limit countdown handling and prevented duplicate notifications.
  * Improved reservation handling during concurrent bookings.
  * Prevented duplicate reminder notifications while preserving retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->