### PR TITLE
 fix(location): add rate limiting, LRU caching, and HTTPS fallback (#1655)

### DIFF
--- a/src/__tests__/api/location.test.ts
+++ b/src/__tests__/api/location.test.ts
@@ -1,7 +1,8 @@
-import { GET } from "@/app/api/location/route";
+import { GET, clearLocationCache } from "@/app/api/location/route";
+import { resetRateLimit } from "@/lib/rateLimit";
 import { NextRequest } from "next/server";
 
-describe("GET /api/location — Multi-Provider Geolocation & Fallback (#1113)", () => {
+describe("GET /api/location — Multi-Provider Geolocation & Fallback (#1113, #1655)", () => {
   const originalFetch = global.fetch;
   const originalAbortSignalTimeout = AbortSignal.timeout;
 
@@ -24,6 +25,8 @@ describe("GET /api/location — Multi-Provider Geolocation & Fallback (#1113)", 
   afterEach(() => {
     global.fetch = originalFetch;
     jest.restoreAllMocks();
+    clearLocationCache();
+    resetRateLimit();
   });
 
   it("returns location data from primary provider ipwho.is when successful", async () => {
@@ -52,8 +55,8 @@ describe("GET /api/location — Multi-Provider Geolocation & Fallback (#1113)", 
     expect(json.country).toBe("IN");
   });
 
-  it("falls back to ip-api.com if ipwho.is fails", async () => {
-    global.fetch = jest
+  it("falls back to ip-api.com over HTTPS if ipwho.is fails", async () => {
+    const fetchMock = jest
       .fn()
       .mockResolvedValueOnce({ ok: false } as any) // ipwho.is fails
       .mockResolvedValueOnce({
@@ -67,6 +70,7 @@ describe("GET /api/location — Multi-Provider Geolocation & Fallback (#1113)", 
           countryCode: "GB",
         }),
       } as any);
+    global.fetch = fetchMock;
 
     const req = new NextRequest("http://localhost:3000/api/location", {
       headers: { "x-forwarded-for": "185.86.151.1" },
@@ -78,6 +82,80 @@ describe("GET /api/location — Multi-Provider Geolocation & Fallback (#1113)", 
     expect(response.status).toBe(200);
     expect(json.source).toBe("ip-api.com");
     expect(json.city).toBe("London");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://ip-api.com/json/185.86.151.1",
+      expect.anything(),
+    );
+  });
+
+  it("caches location result for repeated requests from the same IP", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        success: true,
+        latitude: 40.7128,
+        longitude: -74.006,
+        city: "New York",
+        region: "New York",
+        country_code: "US",
+      }),
+    } as any);
+    global.fetch = fetchMock;
+
+    const req1 = new NextRequest("http://localhost:3000/api/location", {
+      headers: { "x-forwarded-for": "198.51.100.42" },
+    });
+    const res1 = await GET(req1);
+    const json1 = await res1.json();
+
+    const req2 = new NextRequest("http://localhost:3000/api/location", {
+      headers: { "x-forwarded-for": "198.51.100.42" },
+    });
+    const res2 = await GET(req2);
+    const json2 = await res2.json();
+
+    expect(json1.city).toBe("New York");
+    expect(json2.city).toBe("New York");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("enforces rate limiting (10 req/min per IP) and gracefully degrades to default location", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        success: true,
+        latitude: 34.0522,
+        longitude: -118.2437,
+        city: "Los Angeles",
+        region: "California",
+        country_code: "US",
+      }),
+    } as any);
+    global.fetch = fetchMock;
+
+    const testIp = "203.0.113.99";
+
+    // Perform 10 requests (all allowed, first fetches, 2-10 hit cache)
+    for (let i = 0; i < 10; i++) {
+      clearLocationCache(); // clear cache to test rate limit capacity
+      const req = new NextRequest("http://localhost:3000/api/location", {
+        headers: { "x-forwarded-for": testIp },
+      });
+      const res = await GET(req);
+      expect(res.status).toBe(200);
+    }
+
+    // 11th request should exceed rate limit and return DEFAULT_LOCATION
+    clearLocationCache();
+    const excessReq = new NextRequest("http://localhost:3000/api/location", {
+      headers: { "x-forwarded-for": testIp },
+    });
+    const excessRes = await GET(excessReq);
+    const json = await excessRes.json();
+
+    expect(excessRes.status).toBe(200);
+    expect(json.city).toBe("San Francisco");
+    expect(json.source).toBe("default");
   });
 
   it("returns clean default San Francisco location when run on localhost or when all external providers fail", async () => {

--- a/src/app/api/location/route.ts
+++ b/src/app/api/location/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { rateLimit } from "@/lib/rateLimit";
+import { LRUCache } from "@/lib/cache";
 
 const DEFAULT_LOCATION = {
   lat: 37.7749,
@@ -8,6 +10,23 @@ const DEFAULT_LOCATION = {
   country: "US",
   source: "default",
 };
+
+export type LocationResult = {
+  lat: number;
+  lng: number;
+  city: string;
+  region: string;
+  country: string;
+  timezone?: string;
+  source: string;
+};
+
+const LOCATION_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const locationCache = new LRUCache<LocationResult>(1000, LOCATION_CACHE_TTL_MS);
+
+export function clearLocationCache(): void {
+  locationCache.clear();
+}
 
 function isPrivateOrLoopbackIP(ip: string): boolean {
   if (
@@ -30,7 +49,7 @@ function isPrivateOrLoopbackIP(ip: string): boolean {
   return false;
 }
 
-async function fetchIPLocation(rawIp: string | null) {
+async function fetchIPLocation(rawIp: string | null): Promise<LocationResult> {
   const forwardedIp = rawIp ? rawIp.split(",")[0].trim() : "";
   const isPrivate = isPrivateOrLoopbackIP(forwardedIp);
   const targetIp = isPrivate ? "" : forwardedIp;
@@ -64,9 +83,9 @@ async function fetchIPLocation(rawIp: string | null) {
     }
   } catch {}
 
-  // Provider 2: ip-api.com
+  // Provider 2: ip-api.com (HTTPS)
   try {
-    const res = await fetch(`http://ip-api.com/json/${targetIp}`, {
+    const res = await fetch(`https://ip-api.com/json/${targetIp}`, {
       headers: { Accept: "application/json" },
       signal:
         typeof AbortSignal.timeout === "function"
@@ -128,11 +147,30 @@ async function fetchIPLocation(rawIp: string | null) {
   return DEFAULT_LOCATION;
 }
 
-// GET /api/location - Multi-provider IP-based location fallback (#1113)
+// GET /api/location - Multi-provider IP-based location fallback (#1113, #1655)
 export async function GET(req: NextRequest) {
   try {
     const forwarded = req.headers.get("x-forwarded-for");
+    const realIp = req.headers.get("x-real-ip");
+    const forwardedIp = forwarded ? forwarded.split(",")[0].trim() : (realIp || "");
+    const ip = forwardedIp || "127.0.0.1";
+
+    // Rate limiting: 10 requests per minute per IP
+    const identifier = `location:${ip}`;
+    const allowed = await rateLimit(identifier, 10);
+    if (!allowed) {
+      // Graceful degradation on rate limit
+      return NextResponse.json(DEFAULT_LOCATION, { status: 200 });
+    }
+
+    // In-memory cache lookup (10-minute TTL)
+    const cached = locationCache.get(ip);
+    if (cached) {
+      return NextResponse.json(cached, { status: 200 });
+    }
+
     const location = await fetchIPLocation(forwarded);
+    locationCache.set(ip, location);
     return NextResponse.json(location, { status: 200 });
   } catch {
     return NextResponse.json(DEFAULT_LOCATION, { status: 200 });


### PR DESCRIPTION
Summary of Changes
Fixes #1655 by introducing rate limiting, response caching, and security hardening for the unauthenticated /api/location endpoint.

1. Rate Limiting (10 req/min per IP)
Integrated sliding-window rate limiting using @/lib/rateLimit with location:${ip} keying.
Implemented graceful degradation: when a caller exceeds 10 requests per minute, the endpoint returns DEFAULT_LOCATION with status 200 OK to ensure client application resilience while protecting external API quotas.
2. In-Memory LRU Cache (10-minute TTL)
Added an in-memory LRUCache<LocationResult> with 1000-item capacity and 10-minute TTL (600,000 ms) from @/lib/cache.
Re-fetches for identical IPs within 10 minutes hit the cache directly, avoiding redundant external provider requests.