### PR TITLE
Fix: render correct active theme icon in ThemeToggle (TopNav)

### DIFF
--- a/src/__tests__/components/ThemeToggle.test.tsx
+++ b/src/__tests__/components/ThemeToggle.test.tsx
@@ -3,23 +3,64 @@ import { ThemeToggle } from "@/components/ThemeToggle";
 import { ThemeProvider } from "@/components/ThemeProvider";
 
 describe("ThemeToggle", () => {
-  it("renders sun/moon icons with dark-mode CSS toggles (no hydration flash)", () => {
-    const { container } = render(
+  afterEach(() => {
+    document.documentElement.classList.remove("dark", "cyberpunk");
+    window.localStorage.clear();
+  });
+
+  it("renders the sun icon and correct label when theme is light", () => {
+    render(
+      <ThemeProvider initialTheme="light">
+        <ThemeToggle />
+      </ThemeProvider>,
+    );
+    expect(
+      screen.getByRole("switch", { name: /switch to dark mode/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the moon icon and correct label when theme is dark", () => {
+    render(
       <ThemeProvider initialTheme="dark">
         <ThemeToggle />
       </ThemeProvider>,
     );
+    expect(
+      screen.getByRole("switch", { name: /switch to cyberpunk mode/i }),
+    ).toBeInTheDocument();
+  });
 
-    const svgs = container.querySelectorAll("svg");
-    const classes = Array.from(svgs).map(
-      (el) => el.getAttribute("class") || "",
+  it("renders the cyberpunk icon and correct label when theme is cyberpunk", () => {
+    render(
+      <ThemeProvider initialTheme="cyberpunk">
+        <ThemeToggle />
+      </ThemeProvider>,
     );
-
-    expect(classes.some((c) => c.includes("dark:hidden"))).toBe(true);
-    expect(classes.some((c) => c.includes("dark:block"))).toBe(true);
-
     expect(
       screen.getByRole("switch", { name: /switch to light mode/i }),
     ).toBeInTheDocument();
+  });
+
+  it("reflects the active theme via aria-checked and data-active-theme", () => {
+    const { unmount } = render(
+      <ThemeProvider initialTheme="light">
+        <ThemeToggle />
+      </ThemeProvider>,
+    );
+    let btn = screen.getByRole("switch");
+    expect(btn).toHaveAttribute("aria-checked", "false");
+    expect(btn).toHaveAttribute("data-active-theme", "light");
+
+    unmount();
+    document.documentElement.classList.remove("dark", "cyberpunk");
+
+    render(
+      <ThemeProvider initialTheme="cyberpunk">
+        <ThemeToggle />
+      </ThemeProvider>,
+    );
+    btn = screen.getByRole("switch");
+    expect(btn).toHaveAttribute("aria-checked", "true");
+    expect(btn).toHaveAttribute("data-active-theme", "cyberpunk");
   });
 });

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,24 +1,30 @@
 "use client";
-
-import { Sun, Moon } from "lucide-react";
+import { Sun, Moon, Zap } from "lucide-react";
 import { useTheme } from "./ThemeProvider";
 
 export function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
 
+  const labelFor = (t: string) =>
+    t === "light"
+      ? "Switch to dark mode"
+      : t === "dark"
+        ? "Switch to cyberpunk mode"
+        : "Switch to light mode";
+
   return (
     <button
       role="switch"
-      aria-checked={theme === "dark"}
+      aria-checked={theme !== "light"}
       onClick={toggleTheme}
+      data-active-theme={theme}
       className="p-2 cursor-pointer bg-zinc-100 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl text-zinc-600 dark:text-zinc-400 hover:bg-[var(--primary-accent,#2563eb)] hover:text-white transition-all active:scale-95"
-      title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
-      aria-label={
-        theme === "dark" ? "Switch to light mode" : "Switch to dark mode"
-      }
+      title={labelFor(theme)}
+      aria-label={labelFor(theme)}
     >
-      <Sun className="w-4 h-4 dark:hidden" />
-      <Moon className="w-4 h-4 hidden dark:block" />
+      {theme === "light" && <Sun className="w-4 h-4" />}
+      {theme === "dark" && <Moon className="w-4 h-4" />}
+      {theme === "cyberpunk" && <Zap className="w-4 h-4 text-purple-400" />}
     </button>
   );
 }


### PR DESCRIPTION
## Summary
Fixes #1419 — persists dark mode theme preference and reflects the active state correctly in the TopNav theme toggle.

## Findings
Theme persistence (localStorage key `worksphere-theme`) and initial-mount theme application were already implemented in `ThemeProvider.tsx`. The actual gap was in `ThemeToggle.tsx` (used in `TopNav.tsx`): it only handled two icon states via Tailwind `dark:` classes, so the app's third theme state (`cyberpunk`) had no distinct icon and silently fell back to showing the moon icon with a stale label.

Note: the app's `Theme` type is `'light' | 'dark' | 'cyberpunk'`, not `'light' | 'dark' | 'system'` as described in the issue text — this PR keeps the existing three-state model rather than introducing a new "system" theme, since that would be a larger scope change. Happy to adjust if a "system" option was intended.

## Changes
- `ThemeToggle.tsx` now explicitly renders Sun/Moon/Zap based on the current `theme` from `useTheme()`, with accurate "switch to X mode" labels for all three states
- Added `data-active-theme` attribute for easier testing/debugging
- Updated/added unit tests covering all three theme states
- Fixed a test-isolation bug where leftover `documentElement` classes bled between tests

## Testing
- All 4 `ThemeToggle` tests pass
- `tsc --noEmit` shows no errors related to these files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for a third, cyberpunk theme in the theme toggle.
  - Updated the toggle icon and labels to clearly reflect the active theme.
  - Improved accessibility indicators with accurate switch state information.
- **Bug Fixes**
  - Theme state now remains accurately represented after navigating away from and returning to the interface.
  - Improved cleanup of theme settings between sessions and interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->