### PR TITLE
feat: implement client-side telemetry handling with navigator.sendBea…

### DIFF
--- a/src/lib/clientTelemetry.ts
+++ b/src/lib/clientTelemetry.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import { TelemetryRecord } from "./telemetryQueue";
+
+const STORAGE_KEY = "worksphere:telemetry:unsent";
+
+export function enqueueClientTelemetry(record: TelemetryRecord) {
+  flushToServer(record);
+}
+
+function persistFailed(record: TelemetryRecord) {
+  if (typeof window === "undefined") return;
+  try {
+    const existingStr = localStorage.getItem(STORAGE_KEY);
+    const existing: TelemetryRecord[] = existingStr
+      ? JSON.parse(existingStr)
+      : [];
+    existing.push(record);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(existing));
+  } catch (err) {
+    console.error("[clientTelemetry] Failed to persist", err);
+  }
+}
+
+export function retryFailedTelemetry() {
+  if (typeof window === "undefined") return;
+  try {
+    const existingStr = localStorage.getItem(STORAGE_KEY);
+    if (!existingStr) return;
+    localStorage.removeItem(STORAGE_KEY);
+    const records = JSON.parse(existingStr) as TelemetryRecord[];
+    records.forEach(flushToServer);
+  } catch (err) {
+    console.error("[clientTelemetry] Failed to retry", err);
+  }
+}
+
+function flushToServer(record: TelemetryRecord) {
+  const url = `/api/venues/${encodeURIComponent(record.venueId)}/telemetry`;
+
+  if (
+    typeof document !== "undefined" &&
+    document.visibilityState === "hidden"
+  ) {
+    // Page is unloading or backgrounded, use sendBeacon
+    const blob = new Blob([JSON.stringify(record)], {
+      type: "application/json",
+    });
+    const success = navigator.sendBeacon(url, blob);
+    if (!success) {
+      persistFailed(record);
+    }
+  } else {
+    // Normal runtime, use fetch
+    fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(record),
+      keepalive: true,
+    }).catch(() => {
+      persistFailed(record);
+    });
+  }
+}
+
+if (typeof window !== "undefined") {
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") {
+      retryFailedTelemetry();
+    }
+  });
+
+  // Retry on startup
+  window.addEventListener("load", () => {
+    retryFailedTelemetry();
+  });
+}


### PR DESCRIPTION
## Description

This PR improves telemetry reliability during page unload by introducing a client-side telemetry handler that leverages `navigator.sendBeacon` to reduce the likelihood of dropped telemetry events.

### Changes Made

- Added a dedicated client-side telemetry module for handling telemetry dispatch.
- Used `navigator.sendBeacon` during page unload to improve delivery reliability.
- Added a fallback mechanism that persists unsent telemetry events to `localStorage` when delivery fails.
- Implemented automatic retry of persisted telemetry when the application becomes active again.
- Preserved normal telemetry delivery during regular application usage.

## Related Issue

- Fixes #1287

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

Not applicable. This change affects telemetry handling and does not introduce any UI changes.

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable client telemetry delivery with automatic retries when sending fails.
  * Telemetry is queued locally for later delivery when the page is unavailable or being closed.
  * Queued telemetry is automatically retried when the page loads or becomes visible again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->