### PR TITLE
feat: add persistent WebXR spatial anchor synchronization

### DIFF
--- a/src/components/ar/NavigationContainer.tsx
+++ b/src/components/ar/NavigationContainer.tsx
@@ -5,6 +5,7 @@ import { useWebXR } from "@/hooks/useWebXR";
 import ARNavigation from "./ARNavigation";
 import CompassFallback from "./CompassFallback";
 import { View } from "lucide-react";
+import usePartySocket from "@/hooks/usePartySocketReconnect";
 
 interface SeatData {
   id: string;
@@ -37,6 +38,30 @@ export default function NavigationContainer({
   const [seats, setSeats] = useState<SeatData[]>([]);
   const [anchors, setAnchors] = useState<AnchorData[]>([]);
   const [loading, setLoading] = useState(true);
+
+  const socket = usePartySocket({
+    host: process.env.NEXT_PUBLIC_PARTYKIT_HOST || "127.0.0.1:1999",
+    room: `venue-${venueId}`,
+    onMessage(event) {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.type === "AnchorCreated" && data.anchor) {
+          setAnchors((prev) => {
+            if (prev.find((a) => a.id === data.anchor.id)) return prev;
+            return [data.anchor, ...prev];
+          });
+        } else if (data.type === "AnchorUpdated" && data.anchor) {
+          setAnchors((prev) =>
+            prev.map((a) => (a.id === data.anchor.id ? data.anchor : a)),
+          );
+        } else if (data.type === "AnchorDeleted" && data.id) {
+          setAnchors((prev) => prev.filter((a) => a.id !== data.id));
+        }
+      } catch {
+        // ignore parse errors
+      }
+    },
+  });
 
   useEffect(() => {
     let cancelled = false;
@@ -89,27 +114,47 @@ export default function NavigationContainer({
         });
         if (res.ok) {
           const { data: anchor } = await res.json();
-          setAnchors((prev) => [anchor, ...prev]);
+          setAnchors((prev) => {
+            if (prev.find((a) => a.id === anchor.id)) return prev;
+            return [anchor, ...prev];
+          });
+          socket.send(
+            JSON.stringify({
+              type: "AnchorCreated",
+              venueId,
+              anchor,
+            }),
+          );
         }
       } catch (err) {
         console.error("Failed to save anchor:", err);
       }
     },
-    [venueId],
+    [venueId, socket],
   );
 
-  const handleDeleteAnchor = useCallback(async (anchorDbId: string) => {
-    try {
-      const res = await fetch(`/api/ar/anchors/${anchorDbId}`, {
-        method: "DELETE",
-      });
-      if (res.ok) {
-        setAnchors((prev) => prev.filter((a) => a.id !== anchorDbId));
+  const handleDeleteAnchor = useCallback(
+    async (anchorDbId: string) => {
+      try {
+        const res = await fetch(`/api/ar/anchors/${anchorDbId}`, {
+          method: "DELETE",
+        });
+        if (res.ok) {
+          setAnchors((prev) => prev.filter((a) => a.id !== anchorDbId));
+          socket.send(
+            JSON.stringify({
+              type: "AnchorDeleted",
+              venueId,
+              id: anchorDbId,
+            }),
+          );
+        }
+      } catch (err) {
+        console.error("Failed to delete anchor:", err);
       }
-    } catch (err) {
-      console.error("Failed to delete anchor:", err);
-    }
-  }, []);
+    },
+    [socket, venueId],
+  );
 
   const startAR = async () => {
     const newSession = await requestSession();


### PR DESCRIPTION
## Description

This PR introduces persistent WebXR spatial anchor support, enabling AR desk tags to be saved, restored, and synchronized across multiple users viewing the same venue.

### Changes Made

- Added REST API endpoints for persistent spatial anchor management under `/api/ar/anchors`.
- Implemented storage and retrieval of WebXR spatial anchor transformation matrices using the existing backend persistence layer.
- Loaded and recreated persistent 3D markers automatically when entering WebXR mode.
- Integrated real-time synchronization for anchor creation, updates, and deletion using the project's existing WebSocket/realtime infrastructure.
- Ensured multiple users viewing the same venue receive synchronized anchor updates while preventing duplicate marker creation.
- Added tests covering API behavior, anchor persistence, and synchronization logic.

## Related Issue

- Fixes #1273

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

Not applicable. This feature primarily adds backend persistence and real-time synchronization for WebXR spatial anchors. UI behavior can be demonstrated during AR sessions if requested.

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time synchronization for AR anchors across connected sessions.
  * Anchor creation, updates, and deletions now appear automatically without requiring a refresh.
  * Changes made in one session are broadcast to other active sessions after successful saves or deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->