### PR TITLE
feat: add CopyToClipboardButton with toast and legacy fallback

### DIFF
--- a/src/components/ui/CopyToClipboardButton.tsx
+++ b/src/components/ui/CopyToClipboardButton.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import React, { useState } from "react";
+import { Copy, Check } from "lucide-react";
+
+interface CopyToClipboardButtonProps {
+  textToCopy: string;
+  className?: string;
+  label?: string;
+}
+
+export function CopyToClipboardButton({ 
+  textToCopy, 
+  className = "", 
+  label = "Copy Address" 
+}: CopyToClipboardButtonProps) {
+  const [isCopied, setIsCopied] = useState(false);
+  const [showToast, setShowToast] = useState(false);
+
+  // Requirement 4: Fallback for legacy browsers without navigator.clipboard
+  const fallbackCopyTextToClipboard = (text: string) => {
+    const textArea = document.createElement("textarea");
+    textArea.value = text;
+    
+    // Avoid scrolling to bottom on mobile
+    textArea.style.top = "0";
+    textArea.style.left = "0";
+    textArea.style.position = "fixed";
+
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+
+    try {
+      document.execCommand("copy");
+    } catch (err) {
+      console.error("Fallback: Oops, unable to copy", err);
+    }
+
+    document.body.removeChild(textArea);
+  };
+
+  // Requirement 2: Write text using navigator.clipboard
+  const handleCopy = async () => {
+    if (!navigator.clipboard) {
+      fallbackCopyTextToClipboard(textToCopy);
+      triggerFeedback();
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(textToCopy);
+      triggerFeedback();
+    } catch (err) {
+      console.error("Failed to copy text: ", err);
+      // Try fallback if modern API fails for any reason
+      fallbackCopyTextToClipboard(textToCopy);
+      triggerFeedback();
+    }
+  };
+
+  // Requirement 3: Display temporary checkmark and trigger toast feedback
+  const triggerFeedback = () => {
+    setIsCopied(true);
+    setShowToast(true);
+    
+    // Reset back to normal after 2.5 seconds
+    setTimeout(() => {
+      setIsCopied(false);
+      setShowToast(false);
+    }, 2500);
+  };
+
+  return (
+    <>
+      <button
+        onClick={handleCopy}
+        type="button"
+        title="Copy to clipboard"
+        className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+          isCopied 
+            ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400" 
+            : "bg-zinc-100 text-zinc-700 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+        } ${className}`}
+      >
+        {isCopied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+        <span>{isCopied ? "Copied!" : label}</span>
+      </button>
+
+      {/* Self-contained Toast Notification */}
+      {showToast && (
+        <div className="fixed bottom-6 right-6 z-50 flex items-center gap-2 px-4 py-3 text-sm font-medium text-white bg-zinc-900 dark:bg-zinc-100 dark:text-black rounded-lg shadow-xl animate-in fade-in slide-in-from-bottom-5 duration-300">
+          <Check className="w-4 h-4 text-green-400 dark:text-green-600" />
+          Address copied to clipboard
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
Description
This PR introduces a new CopyToClipboardButton UI component that allows users to quickly copy venue addresses with a single click. It utilizes navigator.clipboard.writeText() for modern browsers and includes a robust fallback method using document.execCommand('copy') for legacy support. To ensure a smooth user experience, the component provides instant visual feedback by temporarily toggling the copy icon to a checkmark and triggering a beautifully animated, self-contained toast notification ("Address copied to clipboard").
Related Issue
Fixes #1833
Checklist
[x] My code follows the style guidelines of this project
[x] I have performed a self-review of my own code
[x] I have commented my code, particularly in hard-to-understand areas
[x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a button for copying addresses or other text to the clipboard.
  * Displays a temporary “Copied!” confirmation and toast notification after a copy attempt.
  * Supports clipboard copying across modern and legacy browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->