### PR TITLE
fix(pdf): validate ByteRange before extracting signed bytes

### DIFF
--- a/src/lib/pdf-verify/__tests__/pdfSignatureExtractor.test.ts
+++ b/src/lib/pdf-verify/__tests__/pdfSignatureExtractor.test.ts
@@ -134,3 +134,18 @@ describe("getSignedBytes", () => {
     expect(result.length).toBe(0);
   });
 });
+
+it("returns empty array when ByteRange exceeds PDF bounds", () => {
+  const data = new Uint8Array([1, 2, 3, 4, 5]);
+
+  const byteRange = {
+    offset1: 0,
+    length1: 3,
+    offset2: 20,
+    length2: 5,
+  };
+
+  const result = getSignedBytes(data, byteRange);
+
+  expect(result.length).toBe(0);
+});

--- a/src/lib/pdf-verify/pdfSignatureExtractor.ts
+++ b/src/lib/pdf-verify/pdfSignatureExtractor.ts
@@ -157,10 +157,25 @@ export function extractSignatures(pdfBytes: Uint8Array): PdfSignatureInfo[] {
   return signatures;
 }
 
+function isValidByteRange(pdfBytes: Uint8Array, byteRange: ByteRange): boolean {
+  return (
+    byteRange.offset1 >= 0 &&
+    byteRange.length1 >= 0 &&
+    byteRange.offset2 >= 0 &&
+    byteRange.length2 >= 0 &&
+    byteRange.offset1 + byteRange.length1 <= pdfBytes.length &&
+    byteRange.offset2 + byteRange.length2 <= pdfBytes.length
+  );
+}
+
 export function getSignedBytes(
   pdfBytes: Uint8Array,
   byteRange: ByteRange,
 ): Uint8Array {
+  if (!isValidByteRange(pdfBytes, byteRange)) {
+    return new Uint8Array(0);
+  }
+
   const totalLength = byteRange.length1 + byteRange.length2;
   const result = new Uint8Array(totalLength);
   result.set(


### PR DESCRIPTION
## Description

This PR fixes a buffer bounds issue in the PDF signature extractor by validating `ByteRange` values before extracting signed bytes.

If a PDF contains malformed or out-of-bounds `ByteRange` offsets (such as in complex scanned multi-page receipts), the extractor now safely returns an empty result instead of causing a buffer bounds error.

A regression test has also been added to verify this behaviour.

## Related Issue

Fixes #1986

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

N/A (non-UI change)

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF signature processing by validating byte ranges before extracting signed content.
  * Invalid or out-of-bounds ranges now return an empty result instead of potentially producing incorrect data.

* **Tests**
  * Added coverage for byte ranges that extend beyond the PDF data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->