### PR TITLE
fix(crdt): replay notes outbox updates atomically

### DIFF
--- a/src/lib/crdt/notesOutbox.ts
+++ b/src/lib/crdt/notesOutbox.ts
@@ -129,6 +129,7 @@ export async function flushNotesOutbox(
   const db = await getNotesCrdtDb();
   const pending = await db.getAllFromIndex(OUTBOX_STORE, "by-room", roomId);
   const conflicts: NotesOutboxConflict[] = [];
+  const entriesToFlush: NotesOutboxEntry[] = [];
 
   for (const entry of pending) {
     const entryDoc = new Y.Doc();
@@ -147,10 +148,25 @@ export async function flushNotesOutbox(
       textBefore !== "" && textBefore !== entryText && textBefore !== textAfter;
 
     if (!isConflicting) {
-      Y.applyUpdate(doc, new Uint8Array(entry.update), "outbox-flush");
-      if (entry.id != null) await db.delete(OUTBOX_STORE, entry.id);
+      entriesToFlush.push(entry);
     } else {
-      conflicts.push({ entry, textBefore, textAfter });
+      conflicts.push({
+        entry,
+        textBefore,
+        textAfter,
+      });
+    }
+  }
+
+  doc.transact(() => {
+    for (const entry of entriesToFlush) {
+      Y.applyUpdate(doc, new Uint8Array(entry.update), "outbox-flush");
+    }
+  }, "outbox-flush");
+
+  for (const entry of entriesToFlush) {
+    if (entry.id != null) {
+      await db.delete(OUTBOX_STORE, entry.id);
     }
   }
 


### PR DESCRIPTION
## Description

### What changed
- Wrapped non-conflicting Yjs outbox replay operations inside a single `Y.Doc.transact()` call during reconnect.
- Collected all pending non-conflicting updates before applying them to avoid interleaving with concurrent remote WebSocket updates.
- Preserved existing conflict detection and conflict resolution behaviour while ensuring successful updates are replayed atomically.
- Continued persisting the latest document state and cleaning up flushed outbox entries after the transaction completes.

### Why
Previously, queued offline updates were replayed one by one during reconnection. If remote PartyKit updates arrived while the outbox was being flushed, the replay could interleave with incoming updates, temporarily causing duplicate note insertions or inconsistent intermediate document states.

Applying all non-conflicting updates within a single Yjs transaction eliminates this race condition and ensures the outbox is replayed atomically.

---

## Related Issue

Fixes #1973

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

---

## Screenshots / Screen Recordings (if applicable)

Not applicable. This change affects the CRDT synchronisation logic and does not introduce any UI changes.

---

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of queued note updates by applying compatible changes together.
  * Preserved conflict detection and resolution details while ensuring conflicting updates remain available for review.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->