### PR TITLE
fix(ui): improve dark mode contrast for floorplan desk status badges

### DIFF
--- a/src/app/reserve/[venueId]/reservation-client.tsx
+++ b/src/app/reserve/[venueId]/reservation-client.tsx
@@ -390,10 +390,10 @@ export default function ReservationClient({ venue }: { venue: Venue }) {
                   const fill = !seat.available
                     ? "#3f3f46"
                     : active
-                      ? "#8b5cf6"
+                      ? "#7c3aed"
                       : seat.type === "MEETING_ROOM"
-                        ? "#155e75"
-                        : "#166534";
+                        ? "#06b6d4"
+                        : "#22c55e";
 
                   return (
                     <g
@@ -410,14 +410,20 @@ export default function ReservationClient({ venue }: { venue: Venue }) {
                         height={seat.height}
                         rx="10"
                         fill={fill}
-                        stroke={active ? "#c4b5fd" : "#52525b"}
+                        stroke={
+                          active
+                            ? "#c4b5fd"
+                            : !seat.available
+                              ? "#71717a"
+                              : fill
+                        }
                         strokeWidth={active ? 3 : 1}
                       />
                       <text
                         x={seat.x + seat.width / 2}
                         y={seat.y + seat.height / 2 + 4}
                         textAnchor="middle"
-                        fill="white"
+                        fill={!seat.available || active ? "#ffffff" : "#000000"}
                         fontSize="12"
                         fontWeight="600"
                       >
@@ -430,9 +436,9 @@ export default function ReservationClient({ venue }: { venue: Venue }) {
             </div>
 
             <div className="mt-5 flex flex-wrap gap-4 text-xs text-zinc-400">
-              <Legend color="bg-green-800" label="Available desk" />
-              <Legend color="bg-cyan-800" label="Available room" />
-              <Legend color="bg-violet-500" label="Selected" />
+              <Legend color="bg-green-500" label="Available desk" />
+              <Legend color="bg-cyan-500" label="Available room" />
+              <Legend color="bg-violet-600" label="Selected" />
               <Legend color="bg-zinc-700" label="Taken" />
             </div>
           </section>


### PR DESCRIPTION
## Description



Improves the contrast of desk status badges in the interactive floorplan viewer for the dark-themed reservation page to better satisfy WCAG AA accessibility requirements.

### Changes

- Updated desk status badge colours for improved contrast.
- Updated badge text colours for better readability.
- Updated SVG stroke colours where appropriate.
- Updated the floorplan legend to match the new badge colours.
- Preserved existing layout, rendering logic, interactions, and SVG geometry.

### Accessibility

All badge text/background combinations now meet or exceed the WCAG AA minimum contrast ratio of 4.5:1.

## Related Issue

Closes #1971

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated seat-map colors and outlines for clearer selected, available, and unavailable states.
  * Improved seat label contrast for better readability.
  * Refreshed legend colors for available desks, available rooms, and selected seats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->