### PR TITLE
fix: prevent leaflet marker flicker during rapid zoom (closes #1979)

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -782,6 +782,29 @@ const Map = ({
     });
   }, [iconUrl]);
 
+  // Memoize the rendered CircleMarker JSX to prevent unnecessary SVG re-renders
+  // and micro-flickering on every Map.tsx update (e.g. cursor socket events)
+  const memoizedSeatRings = useMemo(() => {
+    return spiderfiedMarkers
+      .filter((marker) => !marker.id.includes("dest"))
+      .map((marker) => {
+        const seat = getAvailability(marker.id);
+        return (
+          <CircleMarker
+            key={`seat-ring-${marker.id}`}
+            center={[marker.renderedLat, marker.renderedLng]}
+            radius={16}
+            pathOptions={{
+              color: SEAT_RING_COLORS[seat.status],
+              weight: 3,
+              opacity: 0.9,
+              fillOpacity: 0,
+            }}
+          />
+        );
+      });
+  }, [spiderfiedMarkers, getAvailability]);
+
   const center: [number, number] = [latitude, longitude];
   const tileUrl =
     theme === "light"
@@ -1096,26 +1119,7 @@ const Map = ({
           </LayersControl.Overlay>
 
           <LayersControl.Overlay name="Seat Availability">
-            <LayerGroup>
-              {spiderfiedMarkers
-                .filter((marker) => !marker.id.includes("dest"))
-                .map((marker) => {
-                  const seat = getAvailability(marker.id);
-                  return (
-                    <CircleMarker
-                      key={`seat-ring-${marker.id}`}
-                      center={[marker.renderedLat, marker.renderedLng]}
-                      radius={16}
-                      pathOptions={{
-                        color: SEAT_RING_COLORS[seat.status],
-                        weight: 3,
-                        opacity: 0.9,
-                        fillOpacity: 0,
-                      }}
-                    />
-                  );
-                })}
-            </LayerGroup>
+            <LayerGroup>{memoizedSeatRings}</LayerGroup>
           </LayersControl.Overlay>
         </LayersControl>
 
@@ -1124,6 +1128,7 @@ const Map = ({
         <ZoomWatcher
           onZoomSettled={handleZoomSettled}
           onZoomStart={handleZoomStart}
+          delay={250}
         />
         <ResizeWatcher />
         <WebGLContextWatcher />


### PR DESCRIPTION
## Description

This PR fixes the visual flickering of Leaflet markers when rapidly zooming the venue map.

## Changes Made

- Increased the zoom settle debounce to prevent repeated marker collapse and expansion during continuous zoom interactions.
- Memoized the seat availability `CircleMarker` rendering to reduce unnecessary SVG re-renders during unrelated state updates.
- Kept the existing clustering, spiderfication, and marker behavior unchanged.

## Scope

- Modified only `src/components/Map.tsx`
- No business logic changes
- No API changes
- No dependency changes
- No clustering algorithm changes

## Testing

- ✅ ESLint passed
- ✅ TypeScript checks passed
- ✅ Verified rapid zoom no longer causes marker flickering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved map rendering efficiency for seat availability indicators.
  * Preserved existing seat availability filtering and visual styling.

* **User Experience**
  * Adjusted map zoom update timing to provide smoother behavior during navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->