### PR TITLE
fix(ui): improve dark mode contrast for floorplan desk status badges

### DIFF
--- a/src/components/floorplan/FloorPlanViewer3D.tsx
+++ b/src/components/floorplan/FloorPlanViewer3D.tsx
@@ -144,7 +144,7 @@ export default function FloorPlanViewer3D({
                 x={seat.x + seat.width / 2}
                 y={seat.y + seat.height / 2 + 4}
                 textAnchor="middle"
-                fill="#ffffff"
+                fill="#000000"
                 fontSize="11"
                 fontWeight="bold"
                 className="pointer-events-none"


### PR DESCRIPTION
### Summary

Updates seat label text in `FloorPlanViewer3D` to use black (`#000000`) instead of white (`#ffffff`) to improve WCAG AA contrast across the current floorplan colour palette.

## Why

The floorplan implementation has since been refactored into `FloorPlanViewer3D` with a new colour palette. While the graphical elements already satisfy contrast requirements, the white seat labels do not achieve the required 4.5:1 contrast ratio on several seat colours.

Using black text provides WCAG AA-compliant contrast across all current seat states while keeping the change minimal.

## Testing

- `npm run lint`
- `npx tsc --noEmit` (only existing upstream TypeScript issues remain)

Closes #1971

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated seat labels in the 3D floor plan viewer to use black text for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->