### PR TITLE
fix(offline): prevent infinite re-render loop on multi-tab storage sync events

### DIFF
--- a/src/__tests__/lib/favoriteTagSync.test.ts
+++ b/src/__tests__/lib/favoriteTagSync.test.ts
@@ -10,6 +10,8 @@ import {
   subscribeTagSyncChannel,
   TAG_SYNC_LOCK_NAME,
   TAG_SYNC_CHANNEL_NAME,
+  TAG_STATE_HASH_KEY,
+  computeFavoriteTagStateHash,
 } from "@/lib/favoriteTagSync";
 import { prisma } from "@/lib/prisma";
 
@@ -287,6 +289,58 @@ describe("Client-side Offline Sync", () => {
         data: { name: "Locked Tag" },
         timestamp: Date.now(),
       });
+    });
+  });
+
+  describe("Multi-Tab Storage Event Sync Loop Prevention (#1389)", () => {
+    beforeEach(() => {
+      window.localStorage.clear();
+      jest.clearAllMocks();
+    });
+
+    it("ignores storage mutations matching the current tab's state hash", async () => {
+      // 1. Queue a mutation so we have a non-empty state
+      await queueFavoriteTagMutation("tag-loop-1", "CREATE", {
+        name: "Loop Tag",
+      });
+      const currentHash = await computeFavoriteTagStateHash();
+
+      // Mock fetch - if sync is triggered, fetch would be called
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+
+      // 2. Simulate storage event from another tab sending the SAME hash
+      const storageEvent = new StorageEvent("storage", {
+        key: TAG_STATE_HASH_KEY,
+        newValue: currentHash,
+      });
+      window.dispatchEvent(storageEvent);
+
+      // Allow async events to propagate
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("triggers sync when receiving a storage event with a different state hash", async () => {
+      // Mock fetch to simulate successful sync
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+
+      // Queue a mutation so there is something in the queue to process
+      await queueFavoriteTagMutation("tag-loop-2", "CREATE", {
+        name: "New Loop Tag",
+      });
+      jest.clearAllMocks(); // Clear fetch calls from queueing phase
+
+      // Simulate storage event from another tab with a DIFFERENT hash
+      const storageEvent = new StorageEvent("storage", {
+        key: TAG_STATE_HASH_KEY,
+        newValue: "some-different-hash-abc",
+      });
+      window.dispatchEvent(storageEvent);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/lib/favoriteTagSync.ts
+++ b/src/lib/favoriteTagSync.ts
@@ -55,6 +55,33 @@ import { getDB, TAG_STORE_NAME, MAX_SYNC_RETRIES } from "./offlineStore";
 
 export const TAG_SYNC_LOCK_NAME = "worksphere:favorite-tags-sync-lock";
 export const TAG_SYNC_CHANNEL_NAME = "worksphere:favorite-tags-sync-channel";
+export const TAG_STATE_HASH_KEY = "worksphere:favorite-tags-state-hash";
+
+export async function computeFavoriteTagStateHash(): Promise<string> {
+  const mutations = await getQueuedTagMutations();
+  const serialized = mutations
+    .map(
+      (m) =>
+        `${m.id ?? ""}:${m.tagId}:${m.operation}:${JSON.stringify(m.data)}`,
+    )
+    .join("|");
+
+  let hash = 5381;
+  for (let i = 0; i < serialized.length; i++) {
+    hash = (hash * 33) ^ serialized.charCodeAt(i);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+export async function updateFavoriteTagStateHash(): Promise<void> {
+  if (typeof window === "undefined" || !window.localStorage) return;
+  try {
+    const hash = await computeFavoriteTagStateHash();
+    window.localStorage.setItem(TAG_STATE_HASH_KEY, hash);
+  } catch (err) {
+    console.warn("Failed to update favorite tags state hash:", err);
+  }
+}
 
 export interface TagSyncEventPayload {
   type: "TAG_MUTATION" | "TAG_DEQUEUED" | "TAG_SYNC_COMPLETE";
@@ -180,6 +207,8 @@ export async function queueFavoriteTagMutation(
         data,
         timestamp: Date.now(),
       });
+
+      await updateFavoriteTagStateHash();
     } catch (err) {
       console.error("Failed to queue offline tag mutation:", err);
     }
@@ -223,6 +252,8 @@ export async function dequeueTagMutation(id: number): Promise<void> {
         type: "TAG_DEQUEUED",
         timestamp: Date.now(),
       });
+
+      await updateFavoriteTagStateHash();
     } catch (err) {
       console.error("Failed to dequeue tag mutation:", err);
     }
@@ -377,10 +408,23 @@ export async function processTagMutationsQueue(): Promise<void> {
         type: "TAG_SYNC_COMPLETE",
         timestamp: Date.now(),
       });
+
+      await updateFavoriteTagStateHash();
     } catch (e) {
       console.error("[Tag Sync] processQueue failed:", e);
     } finally {
       isProcessing = false;
+    }
+  });
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", async (event) => {
+    if (event.key === TAG_STATE_HASH_KEY && event.newValue) {
+      const currentHash = await computeFavoriteTagStateHash();
+      if (currentHash !== event.newValue) {
+        processTagMutationsQueue();
+      }
     }
   });
 }


### PR DESCRIPTION
Fixes #1389
Closes #1389

### Description
This PR resolves the infinite re-sync/re-render loop in `favoriteTagSync.ts` triggered when local storage change events cause duplicate sync triggers across open application tabs.

### Key Changes
1. **Local State Hash Tracking**:
   - Introduced a deterministic state hashing function `computeFavoriteTagStateHash()` which builds a unique hash representing the current tab's IndexedDB queue mutations.
   - Updated `localStorage` under key `worksphere:favorite-tags-state-hash` with the computed state hash on every queue, dequeue, and sync complete event.
2. **Redundant Sync Loop Prevention**:
   - Registered a window `"storage"` event listener to intercept database changes made by other tabs.
   - Compares the incoming event payload value against the current tab's state hash. If the hashes are equal, it ignores the event and suppresses redundant execution (breaking the loop).
3. **Unit Testing Simulation**:
   - Added unit test cases to `favoriteTagSync.test.ts` to simulate cross-tab `"storage"` events.
   - Verified that if the state hash matches the current state, duplicate sync runs are successfully ignored. If the hash differs, the sync process is triggered appropriately.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of offline favorite tag changes across multiple open tabs.
  * Prevented redundant network synchronization when tabs already have matching state.
  * Ensured pending changes trigger only the necessary synchronization operation in other tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->