### PR TITLE
feat: implement client-side PDF signature validation worker (closes #1266)

### DIFF
--- a/src/hooks/usePdfSignatureVerifier.ts
+++ b/src/hooks/usePdfSignatureVerifier.ts
@@ -6,6 +6,8 @@ import type {
   SignatureVerificationResult,
   VerificationStatus,
 } from "@/types/pdfSignature";
+import { extractSignatures } from "@/lib/pdf-verify/pdfSignatureExtractor";
+import { fetchCaRootsPem } from "@/lib/pdf-verify/caRoots";
 
 export interface UsePdfSignatureVerifierReturn {
   status: VerificationStatus;
@@ -32,17 +34,8 @@ export function usePdfSignatureVerifier(): UsePdfSignatureVerifierReturn {
     return () => {
       abortRef.current = true;
       if (workerRef.current) {
-        try {
-          workerRef.current.postMessage({ type: "terminate" });
-        } catch {
-          // Worker may already be dead
-        }
-        setTimeout(() => {
-          if (workerRef.current) {
-            workerRef.current.terminate();
-            workerRef.current = null;
-          }
-        }, 100);
+        workerRef.current.terminate();
+        workerRef.current = null;
       }
     };
   }, []);
@@ -50,15 +43,8 @@ export function usePdfSignatureVerifier(): UsePdfSignatureVerifierReturn {
   const reset = useCallback(() => {
     abortRef.current = true;
     if (workerRef.current) {
-      try {
-        workerRef.current.postMessage({ type: "terminate" });
-      } catch {
-        // Ignore
-      }
-      setTimeout(() => {
-        workerRef.current?.terminate();
-        workerRef.current = null;
-      }, 100);
+      workerRef.current.terminate();
+      workerRef.current = null;
     }
     setStatus("idle");
     setProgress(0);
@@ -78,10 +64,35 @@ export function usePdfSignatureVerifier(): UsePdfSignatureVerifierReturn {
     try {
       if (workerRef.current) {
         workerRef.current.terminate();
+        workerRef.current = null;
       }
 
+      setProgress(10);
+      const arrayBuffer = await file.arrayBuffer();
+      if (abortRef.current) return;
+
+      const pdfBytes = new Uint8Array(arrayBuffer);
+      setProgress(30);
+
+      const extractedSignatures = extractSignatures(pdfBytes);
+      if (abortRef.current) return;
+
+      if (extractedSignatures.length === 0) {
+        setStatus("unsigned");
+        setProgress(100);
+        return;
+      }
+
+      setProgress(50);
+      setSignatures(extractedSignatures);
+      setStatus("verifying");
+
+      const sig = extractedSignatures[0];
+      const caRoots = await fetchCaRootsPem();
+      if (abortRef.current) return;
+
       const worker = new Worker(
-        new URL("../workers/pdfSignature.worker.ts", import.meta.url),
+        new URL("../workers/pdfVerify.worker.ts", import.meta.url),
         { type: "module" },
       );
       workerRef.current = worker;
@@ -89,35 +100,29 @@ export function usePdfSignatureVerifier(): UsePdfSignatureVerifierReturn {
       worker.onmessage = (event) => {
         if (abortRef.current) return;
 
-        const {
-          type,
-          progress: p,
-          signatures: sigs,
-          results,
-          error: err,
-        } = event.data;
+        const { action, result: res, error: err } = event.data;
 
-        if (type === "progress") {
-          setProgress(p);
-          if (p === 50) {
-            setStatus("verifying");
-          }
-        } else if (type === "result") {
-          if (sigs && sigs.length === 0) {
-            setStatus("unsigned");
-            worker.terminate();
-            workerRef.current = null;
-            return;
-          }
-          if (results && results.length > 0) {
-            const firstResult = results[0];
-            setSignatures(results.map((r: any) => r.signature));
-            setResult(firstResult.result);
-            setStatus(firstResult.result.valid ? "verified" : "invalid");
+        if (action === "ready") {
+          worker.postMessage({
+            action: "verify",
+            id: "verify-1",
+            payload: {
+              pdfBytes,
+              cmsBlob: sig.contents,
+              byteRange: sig.byteRange,
+              caRoots,
+            },
+          });
+          setProgress(75);
+        } else if (action === "result") {
+          setProgress(100);
+          if (res) {
+            setResult(res);
+            setStatus(res.valid ? "verified" : "invalid");
           }
           worker.terminate();
           workerRef.current = null;
-        } else if (type === "error") {
+        } else if (action === "error") {
           setError(err || "Verification failed");
           setStatus("error");
           worker.terminate();
@@ -133,29 +138,11 @@ export function usePdfSignatureVerifier(): UsePdfSignatureVerifierReturn {
         workerRef.current = null;
       };
 
-      const chunkSize = 1024 * 1024; // 1 MB
-      const totalBytes = file.size;
-
-      for (let i = 0; i < totalBytes; i += chunkSize) {
-        if (abortRef.current) break;
-        const blob = file.slice(i, i + chunkSize);
-        const arrayBuffer = await blob.arrayBuffer();
-
-        worker.postMessage(
-          {
-            type: "chunk",
-            payload: { chunk: arrayBuffer },
-          },
-          [arrayBuffer],
-        );
-
-        const currentProgress = Math.floor(((i + blob.size) / totalBytes) * 40); // 0-40% for loading
-        setProgress(currentProgress);
-      }
-
-      if (!abortRef.current) {
-        worker.postMessage({ type: "verify" });
-      }
+      worker.postMessage({
+        action: "init",
+        id: "init-1",
+        payload: { wasmUrl: "/pdf-verify.js" },
+      });
     } catch (err) {
       if (abortRef.current) return;
       const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Description

Integrates `pdfVerify.worker.ts` into the receipt verification flow to asynchronously validate digital signatures on the client-side. The PDF signatures and root CAs are extracted before offloading the cryptographic verification (via WebAssembly OpenSSL) to the Web Worker, ensuring the main thread remains responsive.

## Related Issue

Closes #1266

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (excluding pre-existing failures in unrelated suites)
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF signature verification reliability.
  * Enhanced handling of embedded signatures and certificate authorities during verification.
  * Simplified verification worker cleanup to prevent lingering processes.
  * Updated verification progress handling for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->