### PR TITLE
Replace absolute documentation link with repository-relative path

### DIFF
--- a/docs/RATE_LIMITING.md
+++ b/docs/RATE_LIMITING.md
@@ -43,7 +43,7 @@ UPSTASH_REDIS_REST_TOKEN="your_upstash_rest_token_here"
 
 ### Connecting the Application
 
-The rate-limiting utility is implemented in [rateLimit.ts](file:///c:/Users/HP/Downloads/WorkSphere-main%20%281%29/WorkSphere-main/src/lib/rateLimit.ts). The client connection is established dynamically when environment variables are present:
+The rate-limiting utility is implemented in [`src/lib/rateLimit.ts`](../src/lib/rateLimit.ts). The client connection is established dynamically when environment variables are present:
 
 1. **Lazy Initialization**: It imports `@upstash/ratelimit` and `@upstash/redis` dynamically at runtime. This prevents build-time compilation errors when Redis credentials are not configured.
 2. **Algorithm**: It uses the **Sliding Window** rate-limiting algorithm (`Ratelimit.slidingWindow(limitPerMinute, "1 m")`) to block bursts of requests smoothly over a rolling 1-minute window.


### PR DESCRIPTION
## Summary
This PR replaces a machine-specific absolute file path in `docs/RATE_LIMITING.md` with a repository-relative link.

## Changes
* Replaced the local `file:///` path that pointed to a developer's machine.
* Updated the link to use a repository-relative reference to `src/lib/rateLimit.ts`.
* Improved documentation portability so the link works for all contributors.

## Testing
* Verified the repository-relative link points to the correct file within the project structure.

closes #2090 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the rate-limiting guide with a repository-relative reference to the implementation.
  * Preserved existing guidance on lazy initialization and environment-based connection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->