### PR TITLE
fix: use server clock instead of client-controlled check-in timestamps (#2150)

### DIFF
--- a/src/app/api/sync/route.ts
+++ b/src/app/api/sync/route.ts
@@ -59,19 +59,20 @@ export async function POST(req: NextRequest) {
       for (const checkIn of checkIns) {
         if (!checkIn.venueId || !checkIn.timestamp) continue;
 
+        const now = new Date();
         await prisma.checkIn.upsert({
           where: {
             userId_venueId: { userId, venueId: checkIn.venueId },
           },
           update: {
-            createdAt: new Date(checkIn.timestamp),
-            expiresAt: new Date(checkIn.timestamp + 4 * 60 * 60 * 1000),
+            createdAt: now,
+            expiresAt: new Date(now.getTime() + 4 * 60 * 60 * 1000),
           },
           create: {
             userId,
             venueId: checkIn.venueId,
-            createdAt: new Date(checkIn.timestamp),
-            expiresAt: new Date(checkIn.timestamp + 4 * 60 * 60 * 1000),
+            createdAt: now,
+            expiresAt: new Date(now.getTime() + 4 * 60 * 60 * 1000),
           },
         });
       }


### PR DESCRIPTION
﻿## Description

This PR replaces client-controlled check-in timestamps with the server clock in the sync endpoint.

The sync endpoint was using checkIn.timestamp directly from the client in Prisma upsert calls for createdAt and expiresAt. This allowed attackers to backdate check-ins to manipulate activity streaks, create fraudulent attendance records for dates never visited, or set future timestamps for check-ins that haven't happened yet.

This PR replaces all 
ew Date(checkIn.timestamp) with 
ew Date() (server clock), ensuring check-in timestamps are always authoritative.

---

## Related Issue

* Closes #2150

---

## Component(s) Affected

* [x] Backend (src/app/api/sync/route.ts)
* [ ] Frontend
* [ ] Mobile app
* [ ] Docs only
* [ ] CI / tooling

---

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor
* [ ] Tests
* [ ] Other:

---

## Testing Performed

### Commands executed

* [x] npm run build

### Manually verified

* Confirmed check-ins now use server clock instead of client timestamp
* Confirmed upsert logic is unchanged (same structure, only timestamp source changed)
* Confirmed expiry is calculated from server time (4 hours from now)

### Edge cases considered

* Backdated timestamps from malicious clients
* Future timestamps from malicious clients
* Client/server clock skew
* Multiple rapid check-ins to same venue

---

## API Documentation

Not applicable. Request/response models unchanged.

---

## Checklist

* [x] I have read CONTRIBUTING.md
* [ ] I rebased/merged the latest main into this branch
* [x] I tested my changes locally
* [x] I removed debug prints and unused imports
* [x] This PR is scoped to one logical change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Check-ins now receive consistent server-generated creation and expiration times during synchronization.
  * Check-in expiration is calculated as four hours from the synchronization time, improving timestamp reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->