### PR TITLE
fix: support aesgcm and aes128gcm WebPush encodings for Safari iOS

### DIFF
--- a/src/__tests__/lib/webPushContentEncoding.test.ts
+++ b/src/__tests__/lib/webPushContentEncoding.test.ts
@@ -1,0 +1,52 @@
+import {
+  resolveWebPushContentEncoding,
+  WEBPUSH_CONTENT_ENCODINGS,
+} from "../../lib/webPushContentEncoding";
+
+describe("resolveWebPushContentEncoding (#1032)", () => {
+  it("uses aesgcm for Apple web push endpoints", () => {
+    expect(
+      resolveWebPushContentEncoding({
+        endpoint: "https://web.push.apple.com/QABC123",
+      }),
+    ).toBe(WEBPUSH_CONTENT_ENCODINGS.AES_GCM);
+  });
+
+  it("uses aesgcm for Safari iOS user agents", () => {
+    expect(
+      resolveWebPushContentEncoding({
+        endpoint: "https://fcm.googleapis.com/fcm/send/abc",
+        userAgent:
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1",
+      }),
+    ).toBe(WEBPUSH_CONTENT_ENCODINGS.AES_GCM);
+  });
+
+  it("uses aes128gcm for Chromium / FCM subscriptions", () => {
+    expect(
+      resolveWebPushContentEncoding({
+        endpoint:
+          "https://fcm.googleapis.com/fcm/send/d61c5u920dw:APA91bExample",
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+      }),
+    ).toBe(WEBPUSH_CONTENT_ENCODINGS.AES_128_GCM);
+  });
+
+  it("uses aes128gcm for Firefox / Mozilla endpoints", () => {
+    expect(
+      resolveWebPushContentEncoding({
+        endpoint: "https://updates.push.services.mozilla.com/wpush/v2/gAAAA",
+        userAgent:
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0",
+      }),
+    ).toBe(WEBPUSH_CONTENT_ENCODINGS.AES_128_GCM);
+  });
+
+  it("exposes both supported WebPush encodings", () => {
+    expect(Object.values(WEBPUSH_CONTENT_ENCODINGS).sort()).toEqual([
+      "aes128gcm",
+      "aesgcm",
+    ]);
+  });
+});

--- a/src/lib/pushNotifications.ts
+++ b/src/lib/pushNotifications.ts
@@ -1,5 +1,6 @@
 import webPush from "web-push";
 import { prisma } from "@/lib/prisma";
+import { resolveWebPushContentEncoding } from "@/lib/webPushContentEncoding";
 
 const VAPID_PUBLIC_KEY = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY ?? "";
 const VAPID_PRIVATE_KEY = process.env.VAPID_PRIVATE_KEY ?? "";
@@ -62,7 +63,16 @@ export async function sendPushNotification(
     };
 
     try {
-      await webPush.sendNotification(pushSubscription, notificationPayload);
+      // Safari iOS 17.4: aes128gcm decrypt fails → blank notifications (#1032).
+      // Prefer aesgcm for Apple/Safari; aes128gcm for other push services.
+      const contentEncoding = resolveWebPushContentEncoding({
+        endpoint: sub.endpoint,
+        userAgent: sub.userAgent,
+      });
+
+      await webPush.sendNotification(pushSubscription, notificationPayload, {
+        contentEncoding,
+      });
       await prisma.pushSubscription.update({
         where: { id: sub.id },
         data: { lastUsedAt: new Date() },

--- a/src/lib/webPushContentEncoding.ts
+++ b/src/lib/webPushContentEncoding.ts
@@ -1,0 +1,46 @@
+/**
+ * WebPush Content-Encoding selection (#1032).
+ *
+ * Safari iOS 17.4 PWAs fail to decrypt `aes128gcm` payloads (blank title/body).
+ * The backend must support both encodings and pick per subscription.
+ */
+
+export const WEBPUSH_CONTENT_ENCODINGS = {
+  AES_GCM: "aesgcm",
+  AES_128_GCM: "aes128gcm",
+} as const;
+
+export type WebPushContentEncoding =
+  (typeof WEBPUSH_CONTENT_ENCODINGS)[keyof typeof WEBPUSH_CONTENT_ENCODINGS];
+
+export type ResolveWebPushEncodingInput = {
+  endpoint: string;
+  userAgent?: string | null;
+};
+
+/**
+ * Resolve Content-Encoding for a push subscription.
+ * Apple Push / Safari iOS → aesgcm; everyone else → RFC 8291 aes128gcm.
+ */
+export function resolveWebPushContentEncoding(
+  input: ResolveWebPushEncodingInput,
+): WebPushContentEncoding {
+  const endpoint = input.endpoint ?? "";
+  const ua = input.userAgent ?? "";
+
+  const isApplePushService =
+    /web\.push\.apple\.com/i.test(endpoint) ||
+    /\.push\.apple\.com/i.test(endpoint);
+
+  // iPhone/iPad Safari (and CriOS still reports Mobile/...Safari)
+  const isSafariIos =
+    /iPhone|iPad|iPod/i.test(ua) &&
+    /WebKit/i.test(ua) &&
+    !/Chrome|Chromium|Edg|Firefox/i.test(ua);
+
+  if (isApplePushService || isSafariIos) {
+    return WEBPUSH_CONTENT_ENCODINGS.AES_GCM;
+  }
+
+  return WEBPUSH_CONTENT_ENCODINGS.AES_128_GCM;
+}


### PR DESCRIPTION
## Summary
- Resolve WebPush `Content-Encoding` per subscription: `aesgcm` for Apple/Safari iOS, `aes128gcm` for other push services
- Pass the chosen encoding into `web-push` so iOS 17.4 PWAs no longer show blank title/body after decrypt failure
- Add unit coverage for encoding selection
## Test plan
- [ ] Subscribe to push from an iOS Safari PWA and send a notification with title/body
- [ ] Confirm notification shows title and body (not blank)
- [ ] Confirm Chromium/FCM subscriptions still receive payloads with `aes128gcm`
- [ ] `npm test -- --testPathPattern=webPushContentEncoding --no-coverage`
Closes #1032

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web push notification delivery for Safari on iOS by selecting the appropriate content encoding.
  * Preserved compatible encoding behavior for Chromium, Firefox, and other supported browsers.

* **Tests**
  * Added coverage for encoding selection across Apple, Safari, Chromium, and Firefox push scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->