### PR TITLE
fix: prevent push notification subscription hijacking with ownership check (#2152)

### DIFF
--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -27,6 +27,17 @@ export async function POST(req: NextRequest) {
 
     const userAgent = req.headers.get("user-agent") ?? null;
 
+    const existing = await prisma.pushSubscription.findUnique({
+      where: { endpoint },
+      select: { userId: true },
+    });
+    if (existing && existing.userId !== userId) {
+      return NextResponse.json(
+        { error: "Endpoint already registered to another user" },
+        { status: 409 },
+      );
+    }
+
     await prisma.pushSubscription.upsert({
       where: { endpoint },
       update: {


### PR DESCRIPTION
﻿## Description

This PR prevents push notification subscription hijacking by verifying endpoint ownership before upserting.

The push subscribe endpoint used an upsert keyed by endpoint URL, unconditionally overwriting userId. If an attacker discovered another user's push endpoint URL (via database leak, server logs, or SSRF), they could steal their subscription — push notifications intended for the victim would be encrypted with the attacker's keys instead.

This PR adds an ownership check before the upsert: if the endpoint already exists and belongs to a different user, it returns 409 Conflict instead of overwriting.

---

## Related Issue

* Closes #2152

---

## Component(s) Affected

* [x] Backend (src/app/api/push/subscribe/route.ts)
* [ ] Frontend
* [ ] Mobile app
* [ ] Docs only
* [ ] CI / tooling

---

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor
* [ ] Tests
* [ ] Other:

---

## Testing Performed

### Commands executed

* [x] npm run build

### Manually verified

* Confirmed subscription creation works for new endpoints
* Confirmed re-subscribing with same endpoint and same user works
* Confirmed hijacking attempt (different userId, same endpoint) returns 409
* Confirmed existing subscriptions are not disrupted

### Edge cases considered

* Endpoint URL collision between different users
* Re-subscription by legitimate owner after token rotation
* Missing endpoint in existing subscriptions

---

## API Documentation

New 409 response when endpoint is already registered to another user.

---

## Checklist

* [x] I have read CONTRIBUTING.md
* [ ] I rebased/merged the latest main into this branch
* [x] I tested my changes locally
* [x] I removed debug prints and unused imports
* [x] This PR is scoped to one logical change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a push notification endpoint from being registered to multiple accounts.
  * Added a clear conflict response when an endpoint is already associated with another account.
  * Preserved existing authentication, rate limiting, and error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->