### PR TITLE
fix: defer WebSocket listeners until after React hydration

### DIFF
--- a/src/__tests__/hooks/useHydrationComplete.test.ts
+++ b/src/__tests__/hooks/useHydrationComplete.test.ts
@@ -1,0 +1,47 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import fs from "fs";
+import path from "path";
+import {
+  useHydrationComplete,
+  useIsHydrated,
+} from "../../hooks/useHydrationComplete";
+
+describe("useHydrationComplete (#1033)", () => {
+  it("reports hydrated on the client via useIsHydrated", () => {
+    const { result } = renderHook(() => useIsHydrated());
+    expect(result.current).toBe(true);
+  });
+
+  it("becomes true only after the hydration effect runs", async () => {
+    const { result } = renderHook(() => useHydrationComplete());
+
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+  });
+});
+
+describe("WebSocket listener deferral contract (#1033)", () => {
+  it("gates EnhancedChatbot message listeners on isHydrated", () => {
+    const chatbot = fs.readFileSync(
+      path.join(__dirname, "../../components/EnhancedChatbot.tsx"),
+      "utf8",
+    );
+
+    expect(chatbot).toMatch(/isHydrated/);
+    expect(chatbot).toMatch(
+      /if\s*\(\s*!isHydrated\s*\|\|\s*!socket\s*\)\s*return/,
+    );
+    expect(chatbot).toMatch(/socket\.addEventListener\(\s*["']message["']/);
+  });
+
+  it("keeps PartySocket closed until hydration in useMultiplayerSession", () => {
+    const realtime = fs.readFileSync(
+      path.join(__dirname, "../../hooks/useRealTime.tsx"),
+      "utf8",
+    );
+
+    expect(realtime).toMatch(/useHydrationComplete/);
+    expect(realtime).toMatch(/startClosed:\s*!isHydrated/);
+  });
+});

--- a/src/components/EnhancedChatbot.tsx
+++ b/src/components/EnhancedChatbot.tsx
@@ -121,7 +121,7 @@ export function EnhancedChatbot({
 }: EnhancedChatbotProps) {
   const { isSignedIn, user } = useUser();
 
-  const { socket } = useMultiplayerSession(roomId || null);
+  const { socket, isHydrated } = useMultiplayerSession(roomId || null);
   const sendSocketMessage = useCallback(
     (data: string) => {
       if (socket && socket.readyState === 1) {
@@ -216,9 +216,10 @@ export function EnhancedChatbot({
   >(null);
   const [favorites, setFavorites] = useState<Set<string>>(new Set());
 
-  // Throttled mouse tracking
+  // Throttled mouse tracking — only after hydration so WS traffic cannot
+  // interleave with App Router streaming chunks (#1033)
   useEffect(() => {
-    if (!socket || !roomId) return;
+    if (!isHydrated || !socket || !roomId) return;
 
     let lastSend = 0;
     const handleMouseMove = (e: MouseEvent) => {
@@ -239,11 +240,11 @@ export function EnhancedChatbot({
 
     window.addEventListener("mousemove", handleMouseMove);
     return () => window.removeEventListener("mousemove", handleMouseMove);
-  }, [socket, roomId, user, sendSocketMessage]);
+  }, [isHydrated, socket, roomId, user, sendSocketMessage]);
 
-  // Handle incoming presence
+  // Handle incoming presence — defer listeners until hydration completes (#1033)
   useEffect(() => {
-    if (!socket) return;
+    if (!isHydrated || !socket) return;
 
     const onMessage = (event: MessageEvent) => {
       try {
@@ -297,7 +298,7 @@ export function EnhancedChatbot({
 
     socket.addEventListener("message", onMessage);
     return () => socket.removeEventListener("message", onMessage);
-  }, [socket, onMapUpdate]);
+  }, [isHydrated, socket, onMapUpdate]);
 
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
 

--- a/src/hooks/useHydrationComplete.ts
+++ b/src/hooks/useHydrationComplete.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect, useState, useSyncExternalStore } from "react";
+
+const emptySubscribe = () => () => {};
+
+/**
+ * True on the client after this component has hydrated; false during SSR (#1033).
+ */
+export function useIsHydrated(): boolean {
+  return useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false,
+  );
+}
+
+/**
+ * True only after React hydration completes (post-useEffect).
+ * Use this to defer WebSocket listeners so App Router streaming chunks are
+ * not interleaved with client setState from push traffic (#1033).
+ */
+export function useHydrationComplete(): boolean {
+  const isHydrated = useIsHydrated();
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (!isHydrated) return;
+    setReady(true);
+  }, [isHydrated]);
+
+  return isHydrated && ready;
+}

--- a/src/hooks/useRealTime.tsx
+++ b/src/hooks/useRealTime.tsx
@@ -11,6 +11,7 @@ import { useAuth } from "@clerk/nextjs";
 import usePartySocket from "@/hooks/usePartySocketReconnect";
 import YProvider from "y-partykit/provider";
 import * as Y from "yjs";
+import { useHydrationComplete } from "@/hooks/useHydrationComplete";
 
 interface VenueUpdate {
   type: "rating" | "availability" | "new_review";
@@ -248,18 +249,15 @@ export function useMultiplayerSession(roomId: string | null) {
   const [yDoc, setYDoc] = useState<Y.Doc | null>(null);
   const { getToken } = useAuth();
   const [token, setToken] = useState<string | null>(null);
-  const [isMounted, setIsMounted] = useState(false);
-
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
+  // Defer PartySocket / Yjs until after App Router hydration (#1033)
+  const isHydrated = useHydrationComplete();
 
   useEffect(() => {
     getToken().then(setToken).catch(console.error);
   }, [getToken]);
 
   useEffect(() => {
-    if (!roomId || token === null) {
+    if (!isHydrated || !roomId || token === null) {
       setProvider(null);
       setYDoc(null);
       return;
@@ -278,19 +276,19 @@ export function useMultiplayerSession(roomId: string | null) {
       newProvider.disconnect();
       doc.destroy();
     };
-  }, [roomId, token]);
+  }, [roomId, token, isHydrated]);
 
   // Use standard websocket for simple presence broadcast
-  // startClosed prevents WebSocket connection during SSR before hydration
+  // startClosed prevents WebSocket connection during SSR / streaming hydration
   const socket = usePartySocket({
     host: "127.0.0.1:1999",
-    room: isMounted && roomId ? roomId : "placeholder",
-    startClosed: !isMounted,
+    room: isHydrated && roomId ? roomId : "placeholder",
+    startClosed: !isHydrated,
     query: token ? { token } : undefined,
     onMessage() {
-      // handled in component
+      // handled in component after hydration
     },
   });
 
-  return { provider, yDoc, socket };
+  return { provider, yDoc, socket, isHydrated };
 }


### PR DESCRIPTION
## Summary
- Add useHydrationComplete to detect when React hydration has finished
- Keep PartySocket/Yjs closed in useMultiplayerSession until hydration completes
- Attach EnhancedChatbot WebSocket message listeners only after hydration so App Router streaming is not interleaved with WS setState
## Test plan
- [ ] Open /ai on a slow network with many PartyKit messages during load
- [ ] Confirm no React streaming / hydration boundary error
- [ ] Confirm presence and chat WS still work after the page settles
- [ ] ./node_modules/.bin/jest src/__tests__/hooks/useHydrationComplete.test.ts --no-coverage --forceExit
Closes #1033

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multiplayer chat reliability during page loading and hydration.
  * Prevented real-time connections and message listeners from starting too early, reducing the risk of missed or interleaved updates.
  * Deferred cursor and presence activity until the application is ready.
* **Tests**
  * Added coverage to verify hydration timing and ensure real-time features remain inactive until hydration completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->