### PR TITLE
fix: halt God Rays render loop on WebGL context loss

### DIFF
--- a/src/__tests__/hooks/useGodRaysRenderer.contextLoss.test.ts
+++ b/src/__tests__/hooks/useGodRaysRenderer.contextLoss.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Unit tests for VenueGodRays / useGodRaysRenderer WebGL context-loss recovery (#1288).
+ */
+
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useGodRaysRenderer } from "../../hooks/useGodRaysRenderer";
+
+function createMockGl(): WebGL2RenderingContext {
+  const gl = {
+    VERTEX_SHADER: 0x8b31,
+    FRAGMENT_SHADER: 0x8b30,
+    ARRAY_BUFFER: 0x8892,
+    STATIC_DRAW: 0x88e4,
+    COLOR_BUFFER_BIT: 0x4000,
+    BLEND: 0x0be2,
+    SRC_ALPHA: 0x0302,
+    ONE_MINUS_SRC_ALPHA: 0x0303,
+    TRIANGLES: 0x0004,
+    COMPILE_STATUS: 0x8b81,
+    LINK_STATUS: 0x8b82,
+    createShader: jest.fn(() => ({})),
+    shaderSource: jest.fn(),
+    compileShader: jest.fn(),
+    getShaderParameter: jest.fn(() => true),
+    getShaderInfoLog: jest.fn(() => ""),
+    deleteShader: jest.fn(),
+    createProgram: jest.fn(() => ({})),
+    attachShader: jest.fn(),
+    linkProgram: jest.fn(),
+    getProgramParameter: jest.fn(() => true),
+    getProgramInfoLog: jest.fn(() => ""),
+    deleteProgram: jest.fn(),
+    useProgram: jest.fn(),
+    createVertexArray: jest.fn(() => ({})),
+    createBuffer: jest.fn(() => ({})),
+    bindVertexArray: jest.fn(),
+    bindBuffer: jest.fn(),
+    bufferData: jest.fn(),
+    getAttribLocation: jest.fn(() => 0),
+    enableVertexAttribArray: jest.fn(),
+    vertexAttribPointer: jest.fn(),
+    getUniformLocation: jest.fn(() => ({})),
+    deleteBuffer: jest.fn(),
+    deleteVertexArray: jest.fn(),
+    viewport: jest.fn(),
+    clearColor: jest.fn(),
+    clear: jest.fn(),
+    enable: jest.fn(),
+    blendFunc: jest.fn(),
+    uniform2f: jest.fn(),
+    uniform1f: jest.fn(),
+    drawArrays: jest.fn(),
+    isContextLost: jest.fn(() => false),
+  };
+  return gl as unknown as WebGL2RenderingContext;
+}
+
+describe("useGodRaysRenderer WebGL context loss (#1288)", () => {
+  let mockGl: WebGL2RenderingContext;
+  let rafCallbacks: FrameRequestCallback[];
+  let nextRafId: number;
+
+  beforeEach(() => {
+    mockGl = createMockGl();
+    rafCallbacks = [];
+    nextRafId = 1;
+
+    jest
+      .spyOn(HTMLCanvasElement.prototype, "getContext")
+      .mockImplementation(() => mockGl as unknown as RenderingContext);
+
+    jest.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      rafCallbacks.push(cb);
+      return nextRafId++;
+    });
+    jest.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {
+      rafCallbacks = [];
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    const banner = document.getElementById("webgl-recovery-banner");
+    if (banner?.parentNode) banner.parentNode.removeChild(banner);
+  });
+
+  it("sets context-lost flag and stops scheduling frames on webglcontextlost", async () => {
+    const { result } = renderHook(() =>
+      useGodRaysRenderer({ sunX: 0.5, sunY: 0.5, animate: true }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.canvas).not.toBeNull();
+    });
+
+    const canvas = result.current.canvas!;
+    expect(result.current.isContextLost).toBe(false);
+    expect(rafCallbacks.length).toBeGreaterThan(0);
+
+    act(() => {
+      const lost = new Event("webglcontextlost", {
+        cancelable: true,
+        bubbles: true,
+      });
+      canvas.dispatchEvent(lost);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isContextLost).toBe(true);
+    });
+
+    const pendingAfterLoss = rafCallbacks.length;
+    act(() => {
+      // Drain any leftover callbacks — they must not re-queue while lost
+      const pending = [...rafCallbacks];
+      rafCallbacks = [];
+      for (const cb of pending) {
+        cb(performance.now());
+      }
+    });
+
+    expect(result.current.isContextLost).toBe(true);
+    expect(rafCallbacks.length).toBe(0);
+    expect(pendingAfterLoss).toBeGreaterThanOrEqual(0);
+  });
+
+  it("clears context-lost flag and re-inits GL on webglcontextrestored", async () => {
+    const { result } = renderHook(() =>
+      useGodRaysRenderer({ sunX: 0.5, sunY: 0.5, animate: true }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.canvas).not.toBeNull();
+    });
+
+    const canvas = result.current.canvas!;
+
+    act(() => {
+      canvas.dispatchEvent(
+        new Event("webglcontextlost", { cancelable: true, bubbles: true }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.isContextLost).toBe(true);
+    });
+
+    const createProgramCalls = (mockGl.createProgram as jest.Mock).mock.calls
+      .length;
+
+    act(() => {
+      canvas.dispatchEvent(
+        new Event("webglcontextrestored", { cancelable: true, bubbles: true }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.isContextLost).toBe(false);
+    });
+
+    // Shaders / program re-created on restore
+    expect(
+      (mockGl.createProgram as jest.Mock).mock.calls.length,
+    ).toBeGreaterThan(createProgramCalls);
+    expect(rafCallbacks.length).toBeGreaterThan(0);
+  });
+});

--- a/src/hooks/useGodRaysRenderer.ts
+++ b/src/hooks/useGodRaysRenderer.ts
@@ -52,8 +52,10 @@ export function useGodRaysRenderer(options: GodRaysOptions) {
   const [isSupported, setIsSupported] = useState<boolean>(true);
   const [fps, setFps] = useState<number>(60);
   const [canvas, setCanvas] = useState<HTMLCanvasElement | null>(null);
+  const [isContextLost, setIsContextLost] = useState(false);
 
   const animFrameIdRef = useRef<number | null>(null);
+  const contextLostRef = useRef(false);
   const glRef = useRef<WebGL2RenderingContext | null>(null);
   const programRef = useRef<WebGLProgram | null>(null);
   const vaoRef = useRef<WebGLVertexArrayObject | null>(null);
@@ -233,26 +235,26 @@ export function useGodRaysRenderer(options: GodRaysOptions) {
 
   const cleanupWebGL = useCallback(() => {
     const gl = glRef.current;
-    if (gl) {
+    // Skip GL deletes when context is already lost — objects are invalid (#1288)
+    if (gl && typeof gl.isContextLost === "function" && !gl.isContextLost()) {
       if (programRef.current) {
         gl.deleteProgram(programRef.current);
-        programRef.current = null;
       }
       for (const s of shadersRef.current) {
         gl.deleteShader(s);
       }
-      shadersRef.current = [];
-
       if (bufferRef.current) {
         gl.deleteBuffer(bufferRef.current);
-        bufferRef.current = null;
       }
       if (vaoRef.current) {
         gl.deleteVertexArray(vaoRef.current);
-        vaoRef.current = null;
       }
-      glRef.current = null;
     }
+    programRef.current = null;
+    shadersRef.current = [];
+    bufferRef.current = null;
+    vaoRef.current = null;
+    glRef.current = null;
   }, []);
 
   useEffect(() => {
@@ -265,15 +267,24 @@ export function useGodRaysRenderer(options: GodRaysOptions) {
     const initialized = initWebGL(el);
     if (!initialized) return;
 
-    const cleanupContextRecovery = attachWebGLContextRecovery(el, () => {
-      initWebGL(el);
-    });
-
     const startTime = performance.now();
     let frameCount = 0;
     let fpsTimer = startTime;
 
+    const stopRenderLoop = () => {
+      if (animFrameIdRef.current !== null) {
+        cancelAnimationFrame(animFrameIdRef.current);
+        animFrameIdRef.current = null;
+      }
+    };
+
     const renderFrame = (now: number) => {
+      // Halt draws while context is lost to avoid recovery re-render loops (#1288)
+      if (contextLostRef.current) {
+        animFrameIdRef.current = null;
+        return;
+      }
+
       const gl = glRef.current;
       const program = programRef.current;
       const vao = vaoRef.current;
@@ -321,23 +332,47 @@ export function useGodRaysRenderer(options: GodRaysOptions) {
         }
       }
 
-      if (animate) {
+      if (animate && !contextLostRef.current) {
         animFrameIdRef.current = requestAnimationFrame(renderFrame);
+      } else {
+        animFrameIdRef.current = null;
       }
     };
 
-    if (animate) {
-      animFrameIdRef.current = requestAnimationFrame(renderFrame);
-    } else {
-      renderFrame(performance.now());
-    }
+    const startRenderLoop = () => {
+      stopRenderLoop();
+      if (animate) {
+        animFrameIdRef.current = requestAnimationFrame(renderFrame);
+      } else {
+        renderFrame(performance.now());
+      }
+    };
+
+    const cleanupContextRecovery = attachWebGLContextRecovery(
+      el,
+      () => {
+        // Clean re-init of programs / buffers after webglcontextrestored (#1288)
+        cleanupWebGL();
+        const ok = initWebGL(el);
+        if (!ok) return;
+        contextLostRef.current = false;
+        setIsContextLost(false);
+        startRenderLoop();
+      },
+      () => {
+        contextLostRef.current = true;
+        setIsContextLost(true);
+        stopRenderLoop();
+      },
+    );
+
+    startRenderLoop();
 
     return () => {
-      if (animFrameIdRef.current !== null) {
-        cancelAnimationFrame(animFrameIdRef.current);
-      }
+      stopRenderLoop();
       cleanupContextRecovery();
       cleanupWebGL();
+      contextLostRef.current = false;
     };
   }, [initWebGL, cleanupWebGL, animate, resolutionScale]);
 
@@ -345,5 +380,6 @@ export function useGodRaysRenderer(options: GodRaysOptions) {
     isSupported,
     fps,
     canvas,
+    isContextLost,
   };
 }

--- a/src/lib/webgl/contextManager.ts
+++ b/src/lib/webgl/contextManager.ts
@@ -42,6 +42,7 @@ export function attachWebGLContextRecovery(
   onRestoreCallback?: (
     gl: WebGLRenderingContext | WebGL2RenderingContext,
   ) => void,
+  onLostCallback?: () => void,
 ): () => void {
   const manager = new WebGLContextRecoveryManager(canvas, {
     onRestore: (gl) => {
@@ -49,6 +50,7 @@ export function attachWebGLContextRecovery(
         onRestoreCallback(gl);
       }
     },
+    onLost: onLostCallback,
   });
   return () => manager.destroy();
 }


### PR DESCRIPTION
## Summary
- Add isContextLost flag to pause VenueGodRays / useGodRaysRenderer rAF until webglcontextrestored
- Cleanly dispose and re-initialize shader programs and buffers on restore
- Add unit tests that simulate WebGL context loss and restoration
## Test plan
- [ ] Open a venue with God Rays enabled, force WebGL context loss, confirm no infinite re-render / FPS thrash
- [ ] Confirm rays resume after context restore
- [ ] ./node_modules/.bin/jest src/__tests__/hooks/useGodRaysRenderer.contextLoss.test.ts --no-coverage --forceExit
Closes #1288

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added WebGL context-loss detection and recovery for the god rays renderer.
  - Rendering pauses automatically when the graphics context is lost and resumes after restoration.
  - Exposed an `isContextLost` status for displaying or responding to graphics interruptions.

- **Bug Fixes**
  - Prevented invalid WebGL cleanup operations while the context is unavailable.
  - Ensured WebGL resources and rendering state are reinitialized after recovery.

- **Tests**
  - Added coverage for context-loss handling, recovery, and render-loop scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->