### PR TITLE
docs: clarify current TypeScript build behavior

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -246,4 +246,5 @@ Before pushing changes to GitHub, you **MUST** verify that all the checks below 
 
 ### 2. Vercel Build Verification
 Vercel builds use `npm run build` which runs `prisma generate && next build`. If this step fails locally, it **will** fail on Vercel deployment. Make sure you run `npm run build` successfully before submitting your PR!
- 
+
+> **Note:** The current production build does **not** invoke `tsc` as a separate build step. For complete TypeScript type checking, run `npx tsc --noEmit` in addition to `npm run build` before opening a pull request.


### PR DESCRIPTION
## Description

This PR clarifies the current TypeScript build behavior in the contribution guide.

### Changes made
- Added a note explaining that `npm run build` runs `prisma generate` followed by `next build`.
- Clarified that the production build does not invoke `tsc` as a separate build step.
- Documented that contributors should run `npx tsc --noEmit` alongside `npm run build` for complete TypeScript type checking before opening a pull request.

## Related Issue

Fixes #2095

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

N/A (Documentation-only change)

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the build verification checklist for contributors.
  * Added a separate TypeScript check alongside the production build command before submitting changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->