### PR TITLE
fix(pwa): store and clean up auto-dismiss timeout in useOfflineSyncNotice (closes #1657)

### DIFF
--- a/src/__tests__/hooks/useOfflineSyncNotice.test.tsx
+++ b/src/__tests__/hooks/useOfflineSyncNotice.test.tsx
@@ -1,0 +1,232 @@
+import {
+  render,
+  screen,
+  act,
+  fireEvent,
+  renderHook,
+} from "@testing-library/react";
+import { useOfflineSyncNotice, OfflineSyncNotice } from "@/hooks/usePWA";
+import "@testing-library/jest-dom";
+
+describe("useOfflineSyncNotice & OfflineSyncNotice", () => {
+  let messageListener: ((event: MessageEvent) => void) | null = null;
+  let mockAddEventListener: jest.Mock;
+  let mockRemoveEventListener: jest.Mock;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    messageListener = null;
+    mockAddEventListener = jest.fn((evt: string, listener: EventListener) => {
+      if (evt === "message") {
+        messageListener = listener as (event: MessageEvent) => void;
+      }
+    });
+    mockRemoveEventListener = jest.fn();
+
+    Object.defineProperty(navigator, "serviceWorker", {
+      value: {
+        addEventListener: mockAddEventListener,
+        removeEventListener: mockRemoveEventListener,
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  test("attaches and detaches serviceWorker message listener", () => {
+    const { unmount } = renderHook(() => useOfflineSyncNotice());
+
+    expect(mockAddEventListener).toHaveBeenCalledWith(
+      "message",
+      expect.any(Function),
+    );
+    expect(messageListener).not.toBeNull();
+
+    unmount();
+    expect(mockRemoveEventListener).toHaveBeenCalledWith(
+      "message",
+      expect.any(Function),
+    );
+  });
+
+  test("surfaces notice on OFFLINE_SYNC_FAILED message and auto-dismisses after 4000ms", () => {
+    const { result } = renderHook(() => useOfflineSyncNotice());
+
+    expect(result.current.notice).toBeNull();
+
+    act(() => {
+      messageListener?.({
+        data: {
+          type: "OFFLINE_SYNC_FAILED",
+          venueId: "v123",
+          action: "ADD",
+          attempts: 3,
+        },
+      } as MessageEvent);
+    });
+
+    expect(result.current.notice).toEqual({
+      type: "OFFLINE_SYNC_FAILED",
+      venueId: "v123",
+      action: "ADD",
+      attempts: 3,
+    });
+
+    // Fast-forward 3999ms - notice should still be present
+    act(() => {
+      jest.advanceTimersByTime(3999);
+    });
+    expect(result.current.notice).not.toBeNull();
+
+    // Fast-forward to 4000ms - notice should be auto-dismissed
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(result.current.notice).toBeNull();
+  });
+
+  test("clears previous timeout when a new failure message arrives", () => {
+    const { result } = renderHook(() => useOfflineSyncNotice());
+
+    // First failure message arrives
+    act(() => {
+      messageListener?.({
+        data: {
+          type: "OFFLINE_SYNC_FAILED",
+          venueId: "v1",
+          action: "ADD",
+          attempts: 3,
+        },
+      } as MessageEvent);
+    });
+
+    // 2 seconds elapse
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(result.current.notice?.venueId).toBe("v1");
+
+    // Second failure message arrives at t=2000ms
+    act(() => {
+      messageListener?.({
+        data: {
+          type: "OFFLINE_SYNC_FAILED",
+          venueId: "v2",
+          action: "REMOVE",
+          attempts: 5,
+        },
+      } as MessageEvent);
+    });
+
+    expect(result.current.notice?.venueId).toBe("v2");
+
+    // Advance 2.5 seconds (t=4500ms total, 2500ms since second message)
+    // If the first timer was not cleared, notice would have been cleared at t=4000ms.
+    act(() => {
+      jest.advanceTimersByTime(2500);
+    });
+    expect(result.current.notice?.venueId).toBe("v2");
+
+    // Advance remaining 1500ms (t=4000ms since second message)
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    expect(result.current.notice).toBeNull();
+  });
+
+  test("dismiss() cancels pending timeout and clears notice immediately", () => {
+    const { result } = renderHook(() => useOfflineSyncNotice());
+
+    act(() => {
+      messageListener?.({
+        data: {
+          type: "OFFLINE_SYNC_FAILED",
+          venueId: "v100",
+          action: "ADD",
+          attempts: 2,
+        },
+      } as MessageEvent);
+    });
+
+    expect(result.current.notice).not.toBeNull();
+
+    // Manual dismiss at 1000ms
+    act(() => {
+      result.current.dismiss();
+    });
+
+    expect(result.current.notice).toBeNull();
+
+    // Advancing past 4000ms should not cause any extra state updates or errors
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    expect(result.current.notice).toBeNull();
+  });
+
+  test("clears timeout on unmount to prevent memory leaks and state updates on unmounted component", () => {
+    const { result, unmount } = renderHook(() => useOfflineSyncNotice());
+
+    act(() => {
+      messageListener?.({
+        data: {
+          type: "OFFLINE_SYNC_FAILED",
+          venueId: "v999",
+          action: "ADD",
+          attempts: 1,
+        },
+      } as MessageEvent);
+    });
+
+    expect(result.current.notice).not.toBeNull();
+
+    // Unmount while 4s timer is pending
+    unmount();
+
+    // Fast-forward past 4000ms - no timer should throw or cause warnings
+    expect(() => {
+      act(() => {
+        jest.advanceTimersByTime(5000);
+      });
+    }).not.toThrow();
+  });
+
+  test("renders OfflineSyncNotice component and handles user dismiss click", () => {
+    render(<OfflineSyncNotice />);
+
+    expect(
+      screen.queryByText(/Couldn't sync your changes/i),
+    ).not.toBeInTheDocument();
+
+    // Trigger failure message
+    act(() => {
+      messageListener?.({
+        data: {
+          type: "OFFLINE_SYNC_FAILED",
+          venueId: "venue-xyz",
+          action: "ADD",
+          attempts: 3,
+        },
+      } as MessageEvent);
+    });
+
+    expect(screen.getByText(/Couldn't sync your changes/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/We couldn't save that favorite after 3 attempts/i),
+    ).toBeInTheDocument();
+
+    // User clicks dismiss button
+    const dismissBtn = screen.getByRole("button", { name: /Dismiss/i });
+    fireEvent.click(dismissBtn);
+
+    expect(
+      screen.queryByText(/Couldn't sync your changes/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/hooks/usePWA.tsx
+++ b/src/hooks/usePWA.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { X, Download, Sparkles } from "lucide-react";
 import { purgeStaleWeights } from "@/lib/federated/weightDb";
 
@@ -291,8 +291,21 @@ function isPushNavigateMessage(data: unknown): data is PushNavigateMessage {
  * been removed from the outbox. Surfaces this to the user instead of the
  * action just silently disappearing. (Issue #712)
  */
-function useOfflineSyncNotice() {
+export function useOfflineSyncNotice() {
   const [notice, setNotice] = useState<OfflineSyncFailureMessage | null>(null);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const clearPendingTimeout = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  const dismiss = useCallback(() => {
+    clearPendingTimeout();
+    setNotice(null);
+  }, [clearPendingTimeout]);
 
   useEffect(() => {
     if (!("serviceWorker" in navigator)) return;
@@ -300,7 +313,11 @@ function useOfflineSyncNotice() {
     const handleMessage = (event: MessageEvent) => {
       if (isOfflineSyncFailureMessage(event.data)) {
         setNotice(event.data);
-        setTimeout(() => setNotice(null), 4000);
+        clearPendingTimeout();
+        timeoutRef.current = setTimeout(() => {
+          setNotice(null);
+          timeoutRef.current = null;
+        }, 4000);
       }
       if (isPushNavigateMessage(event.data)) {
         window.location.href = event.data.url;
@@ -326,10 +343,11 @@ function useOfflineSyncNotice() {
     navigator.serviceWorker.addEventListener("message", handleMessage);
     return () => {
       navigator.serviceWorker.removeEventListener("message", handleMessage);
+      clearPendingTimeout();
     };
-  }, []);
+  }, [clearPendingTimeout]);
 
-  return { notice, dismiss: () => setNotice(null) };
+  return { notice, dismiss };
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR resolves issue #1657 by fixing memory leaks, unmounted state update warnings, and UI flickering in the `useOfflineSyncNotice` hook in `src/hooks/usePWA.tsx`.

## Problem & Context

Previously, `useOfflineSyncNotice` called `setTimeout(() => setNotice(null), 4000)` whenever an `OFFLINE_SYNC_FAILED` message was received, without storing or managing the timeout reference:
- Unmounting the component within 4 seconds resulted in React "Can't perform state update on unmounted component" warnings and closure memory leaks.
- Receiving multiple `OFFLINE_SYNC_FAILED` messages in rapid succession created multiple concurrent timers without clearing prior ones, leading to accumulated timers firing prematurely and causing UI flickering.
- Manually clicking the notice's dismiss button (`dismiss()`) cleared the state but left the pending 4s auto-dismiss timer active, causing extra re-renders or unmounted state updates later.

## Solution Details

1. **Timeout Reference via `useRef`**: Added `timeoutRef = useRef<NodeJS.Timeout | null>(null)` to store the active auto-dismiss timer ID.
2. **Prior Timer Clearance**: Implemented `clearPendingTimeout()`, which cancels any existing pending timeout prior to scheduling a new 4s timer when an `OFFLINE_SYNC_FAILED` message arrives.
3. **Effect Cleanup**: Updated the `useEffect` cleanup function to call `clearPendingTimeout()`, ensuring all pending timers are cancelled when the component unmounts.
4. **Dismiss Cleanup**: Updated `dismiss()` to invoke `clearPendingTimeout()`, preventing pending auto-dismiss timers from executing after manual dismissal.

## Verification & Testing

Added comprehensive unit tests in `src/__tests__/hooks/useOfflineSyncNotice.test.tsx` covering:
- Auto-dismiss after 4000ms.
- Pre-existing timer cancellation when subsequent failure messages arrive before 4000ms.
- Cancellation of pending timers when `dismiss()` is called.
- Timer cleanup on unmount preventing unmounted state updates.
- Rendering of `<OfflineSyncNotice />` and user dismiss button interaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline sync failure notifications so repeated failures reset the dismissal timer correctly.
  * Ensured notifications can be dismissed immediately and clean up reliably when no longer needed.

* **Tests**
  * Added comprehensive coverage for notification display, dismissal, automatic timeout behavior, repeated failures, and lifecycle cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->