### PR TITLE
docs: add JSDoc for MultiCityComparison props

### DIFF
--- a/src/components/venues/MultiCityComparison.tsx
+++ b/src/components/venues/MultiCityComparison.tsx
@@ -178,7 +178,14 @@ export function buildComparisonChartData(
   });
 }
 
+/** 
+ *  Props for the MultiCityComparison component.
+ */
 interface MultiCityComparisonProps {
+  /**
+   * Optional list of venues used to initialize the comparison view
+   * before fresh venue data is fetched.
+   */
   initialVenues?: Venue[];
 }
 
@@ -208,7 +215,13 @@ export function MultiCityComparison({
   const [isExportingPdf, setIsExportingPdf] = useState(false);
   const [selectedVenue, setSelectedVenue] = useState<Venue | null>(null);
 
-  // Sync URL search params whenever selectedCities or selectedFilters changes
+  /**
+   * Synchronizes the selected cities and active filters with the URL
+   * search parameters.
+   *
+   * This keeps the comparison state shareable and ensures browser
+   * navigation (back/forward) restores the current selection.
+   */
   const updateUrlParams = useCallback(
     (cities: string[], filters: string[]) => {
       const params = new URLSearchParams(searchParams.toString());
@@ -236,8 +249,11 @@ export function MultiCityComparison({
     },
     [router, searchParams],
   );
-
-  // Synchronize state on browser back/forward navigation when searchParams update externally
+  /**
+   * Updates local component state whenever the URL search parameters
+   * change externally (for example, through browser back/forward
+   * navigation), keeping the UI synchronized with the URL.
+   */
   useEffect(() => {
     const currentParamsString = searchParams.toString();
     if (currentParamsString !== prevParamsString) {


### PR DESCRIPTION
## Description

This PR adds JSDoc documentation to the `MultiCityComparison` component to improve code readability and IDE hover tooltips.

### Changes made:
- Added JSDoc for the `MultiCityComparisonProps` interface.
- Documented the `initialVenues` prop.
- Added detailed JSDoc for URL search parameter synchronization.
- Improved inline documentation without changing component behavior.

## Related Issue

Fixes #1336

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (Not applicable – documentation-only change)
- [ ] New and existing unit tests pass locally with my changes (Not run – documentation-only change)
- [ ] Any dependent changes have been merged and published in downstream modules (Not applicable)

## Screenshots / Screen Recordings (if applicable)

N/A (Documentation-only change)

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved inline documentation for the multi-city comparison component and its URL synchronization behavior.
  * No user-facing functionality or API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->