### PR TITLE
fix: resolve PDF venue name text truncation (closes #1857)

### DIFF
--- a/src/__tests__/lib/pdfGenerator.test.ts
+++ b/src/__tests__/lib/pdfGenerator.test.ts
@@ -1,5 +1,6 @@
 import { generateReceiptPdf, generateTaxExportPdf } from "@/lib/pdfGenerator";
 import fs from "fs";
+import { PDFDocument } from "pdf-lib";
 
 jest.mock("fs", () => {
   const actualFs = jest.requireActual("fs");
@@ -69,6 +70,25 @@ describe("PDF Generator", () => {
       const pdfBytes = await generateReceiptPdf(mathBooking);
       expect(pdfBytes).toBeInstanceOf(Uint8Array);
       expect(pdfBytes.length).toBeGreaterThan(0);
+    });
+
+    it("should generate a receipt with a long venue name (80+ chars) wrapped correctly without errors", async () => {
+      const longVenueBooking = {
+        ...mockBooking,
+        venue: {
+          name: "The Quantum Cafe, Hub and Science Space Laboratories of the Greater Metropolitan Area Development Center",
+          category: "cafe",
+          address: "123 Science Way",
+        },
+      };
+
+      const pdfBytes = await generateReceiptPdf(longVenueBooking);
+      expect(pdfBytes).toBeInstanceOf(Uint8Array);
+      expect(pdfBytes.length).toBeGreaterThan(0);
+
+      // Load PDF and verify it has exactly 1 page
+      const doc = await PDFDocument.load(pdfBytes);
+      expect(doc.getPageCount()).toBe(1);
     });
   });
 

--- a/src/app/api/bookings/[bookingId]/download/route.ts
+++ b/src/app/api/bookings/[bookingId]/download/route.ts
@@ -199,13 +199,24 @@ export async function GET(
       { x: 50, y: yPosition, size: 10, font },
     );
     yPosition -= 18;
-    drawSafeText(`VENUE: ${booking.venue.name}`, {
-      x: 50,
-      y: yPosition,
-      size: 10,
-      font,
-    });
-    yPosition -= 18;
+    const venueText = `VENUE: ${booking.venue.name}`;
+    const venueLines = breakTextIntoLines(
+      venueText,
+      [" ", ",", "-"],
+      495, // max width (595 - 50 - 50 = 495)
+      (t) => font.widthOfTextAtSize(t, 10),
+    );
+
+    for (const line of venueLines) {
+      drawSafeText(line, {
+        x: 50,
+        y: yPosition,
+        size: 10,
+        font,
+      });
+      yPosition -= 12;
+    }
+    yPosition -= 6;
     drawSafeText(
       `CATEGORY: ${booking.venue.category?.toUpperCase() || "WORKSPACE"}`,
       { x: 50, y: yPosition, size: 10, font },

--- a/src/lib/adminAnalyticsPdfExport.ts
+++ b/src/lib/adminAnalyticsPdfExport.ts
@@ -7,6 +7,7 @@
 import { PDFDocument, StandardFonts, rgb } from "pdf-lib";
 import { drawSafeText, safeText } from "@/lib/pdfHelpers";
 import type { AnalyticsExportData } from "./adminAnalyticsCsvExport";
+import { truncateText } from "./multiCityPdfExport";
 
 export async function generateAnalyticsPdfReport(
   data: AnalyticsExportData,
@@ -281,9 +282,7 @@ export async function generateAnalyticsPdfReport(
     }
 
     const rankStr = String(index + 1).padStart(2, "0");
-    const nameStr = safeText(
-      venue.name.length > 28 ? `${venue.name.slice(0, 26)}...` : venue.name,
-    );
+    const nameStr = truncateText(venue.name, bold, 8, 180);
     const catStr = safeText(venue.category);
     const ratingStr =
       venue.rating != null && !isNaN(venue.rating)

--- a/src/lib/multiCityPdfExport.ts
+++ b/src/lib/multiCityPdfExport.ts
@@ -15,7 +15,7 @@ function safeWidthOfTextAtSize(text: string, font: any, size: number): number {
   }
 }
 
-function truncateText(
+export function truncateText(
   text: string,
   font: any,
   size: number,

--- a/src/lib/pdfGenerator.ts
+++ b/src/lib/pdfGenerator.ts
@@ -3,6 +3,7 @@ import {
   rgb,
   StandardFonts,
   PDFPageDrawTextOptions,
+  breakTextIntoLines,
 } from "pdf-lib";
 import { safeText } from "./pdfHelpers";
 import { sanitizeMathSymbols } from "./pdfUtils";
@@ -166,13 +167,24 @@ export async function generateTaxExportPdf(
       { x: 50, y: py, size: 10, font },
     );
     py -= 18;
-    drawText(page, `VENUE: ${safeText(booking.venue.name)}`, {
-      x: 50,
-      y: py,
-      size: 10,
-      font,
-    });
-    py -= 18;
+    const venueText = `VENUE: ${safeText(booking.venue.name)}`;
+    const venueLines = breakTextIntoLines(
+      venueText,
+      [" ", ",", "-"],
+      495,
+      (t) => font.widthOfTextAtSize(t, 10),
+    );
+
+    for (const line of venueLines) {
+      drawText(page, line, {
+        x: 50,
+        y: py,
+        size: 10,
+        font,
+      });
+      py -= 12;
+    }
+    py -= 6;
     drawText(
       page,
       `CATEGORY: ${safeText(booking.venue.category?.toUpperCase() || "WORKSPACE")}`,
@@ -371,13 +383,24 @@ export async function generateReceiptPdf(booking: any): Promise<Uint8Array> {
     font,
   });
   yPosition -= 18;
-  drawText(`VENUE: ${booking.venue.name}`, {
-    x: 50,
-    y: yPosition,
-    size: 10,
-    font,
-  });
-  yPosition -= 18;
+  const venueText = `VENUE: ${booking.venue.name}`;
+  const venueLines = breakTextIntoLines(
+    venueText,
+    [" ", ",", "-"],
+    495,
+    (t) => font.widthOfTextAtSize(t, 10),
+  );
+
+  for (const line of venueLines) {
+    drawText(line, {
+      x: 50,
+      y: yPosition,
+      size: 10,
+      font,
+    });
+    yPosition -= 12;
+  }
+  yPosition -= 6;
   drawText(
     `CATEGORY: ${booking.venue.category?.toUpperCase() || "WORKSPACE"}`,
     { x: 50, y: yPosition, size: 10, font },


### PR DESCRIPTION
## Description

This PR fixes PDF receipt rendering for long venue names by preventing text truncation and overflow.

### Changes Made
- Added dynamic text wrapping using pdf-lib font metrics.
- Preserved existing receipt layout, spacing, and typography.
- Applied wrapping logic to receipt PDF generation.
- Reused the existing text truncation helper where appropriate.
- Added a unit test verifying successful PDF generation with an 80+ character venue name.

## Related Issue

Closes #1857

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

N/A (Backend/PDF generation changes only)

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Long venue names now wrap across multiple lines in booking receipts and tax-export PDFs.
  * Improved venue-name truncation in analytics PDF exports for better readability.
  * Confirmed long venue names render correctly without creating extra receipt pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->