### PR TITLE
fix: normalize multi-line SAML certificates (closes #1714)

### DIFF
--- a/src/__tests__/lib/auth/sso/samlValidator.test.ts
+++ b/src/__tests__/lib/auth/sso/samlValidator.test.ts
@@ -1,0 +1,132 @@
+import { validateSamlAssertion } from "@/lib/auth/sso/samlValidator";
+import { SignedXml } from "xml-crypto";
+
+jest.mock("xml-crypto", () => {
+  return {
+    SignedXml: jest.fn().mockImplementation(() => {
+      return {
+        keyInfoProvider: null as any,
+        loadSignature: jest.fn(),
+        checkSignature: jest.fn(),
+        validationErrors: ["Signature verification failed"],
+      };
+    }),
+  };
+});
+
+describe("SAML Certificate Validation (#1714)", () => {
+  const mockXml = `
+    <Response>
+      <Assertion>
+        <Conditions NotBefore="2020-01-01T00:00:00Z" NotOnOrAfter="2099-01-01T00:00:00Z">
+          <AudienceRestriction>
+            <Audience>http://sp.example.com</Audience>
+          </AudienceRestriction>
+        </Conditions>
+        <Subject>
+          <NameID>user@example.com</NameID>
+        </Subject>
+        <AttributeStatement>
+          <Attribute Name="email">
+            <AttributeValue>user@example.com</AttributeValue>
+          </Attribute>
+        </AttributeStatement>
+        <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+          <SignatureValue>dummy</SignatureValue>
+        </Signature>
+      </Assertion>
+    </Response>
+  `;
+
+  const singleLineCert = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Y3r";
+  const multiLineCert = `
+-----BEGIN CERTIFICATE-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Y3r
+-----END CERTIFICATE-----
+  `;
+  const whitespaceCert = `
+    -----BEGIN CERTIFICATE-----
+    MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+    MIIBCgKCAQEA0Y3r
+    -----END CERTIFICATE-----
+  `;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should normalize and validate multi-line PEM certificates successfully", () => {
+    const mockSignedXmlInstance = {
+      keyInfoProvider: null as any,
+      loadSignature: jest.fn(),
+      checkSignature: jest.fn().mockReturnValue(true),
+      validationErrors: [],
+    };
+    (SignedXml as unknown as jest.Mock).mockReturnValueOnce(mockSignedXmlInstance);
+
+    const result = validateSamlAssertion(mockXml, multiLineCert, "http://sp.example.com");
+
+    expect(result.nameId).toBe("user@example.com");
+    expect(result.attributes.email).toBe("user@example.com");
+
+    const keyInfo = mockSignedXmlInstance.keyInfoProvider.getKeyInfo();
+    const key = mockSignedXmlInstance.keyInfoProvider.getKey();
+
+    expect(keyInfo).toContain("MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Y3r");
+    expect(keyInfo).not.toContain("-----BEGIN CERTIFICATE-----");
+    expect(keyInfo).not.toContain("\n");
+
+    const keyString = key.toString();
+    expect(keyString).toContain("-----BEGIN CERTIFICATE-----");
+    expect(keyString).toContain("MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Y3r");
+    expect(keyString).toContain("-----END CERTIFICATE-----");
+  });
+
+  it("should normalize whitespace-heavy certs and reformat them correctly", () => {
+    const mockSignedXmlInstance = {
+      keyInfoProvider: null as any,
+      loadSignature: jest.fn(),
+      checkSignature: jest.fn().mockReturnValue(true),
+      validationErrors: [],
+    };
+    (SignedXml as unknown as jest.Mock).mockReturnValueOnce(mockSignedXmlInstance);
+
+    const result = validateSamlAssertion(mockXml, whitespaceCert, "http://sp.example.com");
+
+    expect(result.nameId).toBe("user@example.com");
+
+    const keyInfo = mockSignedXmlInstance.keyInfoProvider.getKeyInfo();
+    expect(keyInfo).toBe("<X509Data><X509Certificate>MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Y3r</X509Certificate></X509Data>");
+  });
+
+  it("should maintain compatibility with single-line certificates", () => {
+    const mockSignedXmlInstance = {
+      keyInfoProvider: null as any,
+      loadSignature: jest.fn(),
+      checkSignature: jest.fn().mockReturnValue(true),
+      validationErrors: [],
+    };
+    (SignedXml as unknown as jest.Mock).mockReturnValueOnce(mockSignedXmlInstance);
+
+    const result = validateSamlAssertion(mockXml, singleLineCert, "http://sp.example.com");
+
+    expect(result.nameId).toBe("user@example.com");
+
+    const keyInfo = mockSignedXmlInstance.keyInfoProvider.getKeyInfo();
+    expect(keyInfo).toContain(singleLineCert);
+  });
+
+  it("should reject invalid/unmatching signatures", () => {
+    const mockSignedXmlInstance = {
+      keyInfoProvider: null as any,
+      loadSignature: jest.fn(),
+      checkSignature: jest.fn().mockReturnValue(false),
+      validationErrors: ["Signature check returned false"],
+    };
+    (SignedXml as unknown as jest.Mock).mockReturnValueOnce(mockSignedXmlInstance);
+
+    expect(() => {
+      validateSamlAssertion(mockXml, singleLineCert, "http://sp.example.com");
+    }).toThrow("SAML Signature validation failed: Signature check returned false");
+  });
+});

--- a/src/lib/auth/sso/samlValidator.ts
+++ b/src/lib/auth/sso/samlValidator.ts
@@ -26,14 +26,19 @@ export function validateSamlAssertion(
     throw new Error("Invalid SAML: No signature found");
   }
 
+  const normalizedCert = expectedCert
+    .replace(/-----BEGIN CERTIFICATE-----/g, "")
+    .replace(/-----END CERTIFICATE-----/g, "")
+    .replace(/\s+/g, "");
+
   const sig = new SignedXml();
   // Provide the certificate to the verifier
   sig.keyInfoProvider = {
     getKeyInfo: () =>
-      `<X509Data><X509Certificate>${expectedCert}</X509Certificate></X509Data>`,
+      `<X509Data><X509Certificate>${normalizedCert}</X509Certificate></X509Data>`,
     getKey: () =>
       Buffer.from(
-        `-----BEGIN CERTIFICATE-----\n${expectedCert.replace(/(.{64})/g, "$1\n")}\n-----END CERTIFICATE-----`,
+        `-----BEGIN CERTIFICATE-----\n${normalizedCert.replace(/(.{64})/g, "$1\n")}\n-----END CERTIFICATE-----`,
       ),
   };
 


### PR DESCRIPTION
## Description

This PR fixes SAML 2.0 certificate validation for multi-line PEM certificates by normalizing certificate input before signature verification.

### Changes Made
- Normalized certificate strings by removing:
  - `-----BEGIN CERTIFICATE-----`
  - `-----END CERTIFICATE-----`
  - Whitespace, tabs, carriage returns, and newline characters.
- Updated the SAML key provider to use the normalized certificate during signature validation.
- Added unit tests covering:
  - Multi-line PEM certificate validation.
  - Single-line certificate compatibility.
  - Invalid certificate rejection.

## Related Issue

Fixes #1714

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

N/A (Backend authentication logic only)

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No