### PR TITLE
fix(a11y): add aria-labels and descriptive alt text for venue cards and icon buttons

### DIFF
--- a/src/components/VenueCard.tsx
+++ b/src/components/VenueCard.tsx
@@ -452,7 +452,7 @@ export function VenueCard({
         >
           <Image
             src={photos[photoIndex]}
-            alt={venue.name}
+            alt={"Photo of " + venue.name}
             fill
             className="object-cover"
             unoptimized // External URLs from Foursquare
@@ -539,6 +539,7 @@ export function VenueCard({
           <button
             onClick={handleFavorite}
             disabled={isSavingFavorite}
+            aria-label={isFavorited ? `Remove ${venue.name} from favorites` : `Add ${venue.name} to favorites`}
             className={`p-2 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed ${
               enableTransition ? "transition-colors duration-300" : ""
             } ${

--- a/src/components/chat/ChatMessages.tsx
+++ b/src/components/chat/ChatMessages.tsx
@@ -401,6 +401,7 @@ export function VenueChatCard({
             </button>
             <button
               onClick={() => onToggleFavorite(venue)}
+              aria-label={isFavorited ? "Remove from favorites" : "Save to favorites"}
               className={`p-1.5 rounded-lg border active:scale-[0.95] ${
                 enableTransition ? "transition-all duration-300" : ""
               } ${
@@ -653,6 +654,7 @@ export function VenueChatCard({
                       );
                       onToggleFavorite(venue);
                     }}
+                    aria-label={isFavorited ? "Remove from favorites" : "Save to favorites"}
                     className={`flex-1 flex items-center justify-center gap-1 px-2 py-2 text-[10px] uppercase font-black tracking-tighter rounded-lg ${
                       enableTransition ? "transition-all duration-300" : ""
                     } ${

--- a/src/components/chat/VenueDetailDialog.tsx
+++ b/src/components/chat/VenueDetailDialog.tsx
@@ -967,7 +967,7 @@ export function VenueDetailDialog({
             // eslint-disable-next-line @next/next/no-img-element
             <img
               src={displayPhoto}
-              alt={venue.name}
+              alt={"Photo of " + venue.name}
               className="w-full h-full object-cover cursor-pointer hover:scale-105 transition-all duration-500"
               onClick={() => setLightboxIndex(0)}
               onError={() => setImageError(true)}
@@ -991,6 +991,7 @@ export function VenueDetailDialog({
             </button>
             <button
               onClick={onClose}
+              aria-label="Close venue details"
               className="p-3 bg-white/10 hover:bg-white/20 backdrop-blur-md text-white rounded-full shadow-2xl border border-white/20 transition-all font-bold active:scale-90"
             >
               <X className="w-6 h-6" />
@@ -1797,6 +1798,7 @@ export function VenueDetailDialog({
                 <div className="flex gap-3">
                   <button
                     onClick={() => onToggleFavorite(venue)}
+                    aria-label={isFavorited ? `Remove ${venue.name} from favorites` : `Save ${venue.name} to favorites`}
                     className={`flex-1 flex items-center justify-center gap-2 font-black uppercase tracking-widest py-3 px-6 rounded-2xl border-2 ${
                       enableTransition ? "transition-all duration-300" : ""
                     } ${
@@ -1823,6 +1825,7 @@ export function VenueDetailDialog({
                   )}
                   <button
                     onClick={handleShare}
+                    aria-label={"Share " + venue.name}
                     className="flex-1 flex items-center justify-center gap-2 bg-black/40 border-2 border-white/10 text-zinc-200 hover:bg-black/60 font-black uppercase tracking-widest py-3 px-6 rounded-2xl transition-all shadow-md active:scale-[0.98]"
                   >
                     {copied ? (

--- a/src/components/social/VenueShareButton.tsx
+++ b/src/components/social/VenueShareButton.tsx
@@ -39,6 +39,7 @@ export function VenueShareButton({ venueId, venueName }: Props) {
     <button
       type="button"
       onClick={share}
+      aria-label={"Share " + venueName}
       className="inline-flex items-center justify-center gap-2 rounded-lg bg-violet-600 px-3 py-2 text-sm font-medium text-white transition hover:bg-violet-500"
     >
       <Share2 className="h-4 w-4" />


### PR DESCRIPTION
## Description

Adds ARIA labels and descriptive alt text to venue images and icon-only buttons across venue cards, detail dialogs, share buttons, and chat messages to ensure screen readers can properly navigate the application.

## Related Issue

Closes #1363

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

N/A — accessibility attributes only, no visual changes.

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No
