### PR TITLE
fix(security): add email+IP-scoped rate limiting to auth endpoints (verify-otp, resend-otp, forgot-password)

### DIFF
--- a/src/__tests__/api/forgot-password.test.ts
+++ b/src/__tests__/api/forgot-password.test.ts
@@ -1,0 +1,80 @@
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/auth/forgot-password/route";
+import { resetRateLimit } from "@/lib/rateLimit";
+
+describe("POST /api/auth/forgot-password", () => {
+  beforeEach(() => {
+    resetRateLimit();
+  });
+
+  function makeRequest(body: unknown, ip?: string) {
+    return new NextRequest("http://localhost/api/auth/forgot-password", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(ip ? { "x-forwarded-for": ip } : {}),
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it("should return 200 on valid request under rate limit", async () => {
+    const req = makeRequest({ email: "test@example.com" });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+  });
+
+  it("should return 400 for invalid email", async () => {
+    const req = makeRequest({ email: "not-an-email" });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("should rate limit after 3 attempts per email+IP in 5-minute window", async () => {
+    const body = { email: "ratelimit@example.com" };
+
+    for (let i = 0; i < 3; i++) {
+      const req = makeRequest(body, "10.0.0.1");
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+    }
+
+    const req = makeRequest(body, "10.0.0.1");
+    const res = await POST(req);
+    expect(res.status).toBe(429);
+
+    const data = await res.json();
+    expect(data.error).toContain("Too many password reset requests");
+  });
+
+  it("should track different email+IP combinations separately", async () => {
+    const req1 = makeRequest({ email: "user1@example.com" }, "10.0.0.1");
+    expect((await POST(req1)).status).toBe(200);
+    const req2 = makeRequest({ email: "user2@example.com" }, "10.0.0.2");
+    expect((await POST(req2)).status).toBe(200);
+
+    for (let i = 0; i < 3; i++) {
+      await POST(makeRequest({ email: "user1@example.com" }, "10.0.0.1"));
+    }
+
+    const blocked = makeRequest({ email: "user1@example.com" }, "10.0.0.1");
+    expect((await POST(blocked)).status).toBe(429);
+
+    const allowed = makeRequest({ email: "user2@example.com" }, "10.0.0.2");
+    expect((await POST(allowed)).status).toBe(200);
+  });
+
+  it("should return 429 with Retry-After header when rate limited", async () => {
+    const body = { email: "retry@example.com" };
+
+    for (let i = 0; i < 3; i++) {
+      await POST(makeRequest(body, "10.0.0.3"));
+    }
+
+    const res = await POST(makeRequest(body, "10.0.0.3"));
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBeTruthy();
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("3");
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("0");
+  });
+});

--- a/src/__tests__/api/verify-otp.test.ts
+++ b/src/__tests__/api/verify-otp.test.ts
@@ -1,0 +1,97 @@
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/auth/verify-otp/route";
+import { resetRateLimit } from "@/lib/rateLimit";
+
+jest.mock("@/lib/csrf", () => ({
+  verifyCsrfToken: jest.fn().mockResolvedValue(true),
+  CSRF_COOKIE_NAME: "csrf-token",
+  CSRF_HEADER_NAME: "x-csrf-token",
+}));
+
+describe("POST /api/auth/verify-otp", () => {
+  beforeEach(() => {
+    resetRateLimit();
+    jest.clearAllMocks();
+  });
+
+  function makeRequest(body: unknown, ip?: string) {
+    return new NextRequest("http://localhost/api/auth/verify-otp", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(ip ? { "x-forwarded-for": ip } : {}),
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it("should return 200 on valid request under rate limit", async () => {
+    const req = makeRequest({ email: "test@example.com", otp: "123456" });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.message).toBe("Verification successful.");
+  });
+
+  it("should return 400 for invalid email", async () => {
+    const req = makeRequest({ email: "not-an-email", otp: "123456" });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("should return 400 for non-digit OTP", async () => {
+    const req = makeRequest({ email: "test@example.com", otp: "abc" });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("should rate limit after 5 attempts per email+IP", async () => {
+    const body = { email: "ratelimit@example.com", otp: "123456" };
+
+    for (let i = 0; i < 5; i++) {
+      const req = makeRequest(body, "10.0.0.1");
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+    }
+
+    const req = makeRequest(body, "10.0.0.1");
+    const res = await POST(req);
+    expect(res.status).toBe(429);
+
+    const data = await res.json();
+    expect(data.error).toContain("Too many verification attempts");
+  });
+
+  it("should track different email+IP combinations separately", async () => {
+    const req1 = makeRequest({ email: "user1@example.com", otp: "123456" }, "10.0.0.1");
+    expect((await POST(req1)).status).toBe(200);
+
+    const req2 = makeRequest({ email: "user2@example.com", otp: "123456" }, "10.0.0.2");
+    expect((await POST(req2)).status).toBe(200);
+
+    for (let i = 0; i < 5; i++) {
+      const r = makeRequest({ email: "user1@example.com", otp: "123456" }, "10.0.0.1");
+      await POST(r);
+    }
+
+    const blocked = makeRequest({ email: "user1@example.com", otp: "123456" }, "10.0.0.1");
+    expect((await POST(blocked)).status).toBe(429);
+
+    const allowed = makeRequest({ email: "user2@example.com", otp: "123456" }, "10.0.0.2");
+    expect((await POST(allowed)).status).toBe(200);
+  });
+
+  it("should return 429 with Retry-After header when rate limited", async () => {
+    const body = { email: "retry@example.com", otp: "123456" };
+
+    for (let i = 0; i < 5; i++) {
+      await POST(makeRequest(body, "10.0.0.3"));
+    }
+
+    const res = await POST(makeRequest(body, "10.0.0.3"));
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBeTruthy();
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("5");
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("0");
+  });
+});

--- a/src/__tests__/lib/rateLimit.test.ts
+++ b/src/__tests__/lib/rateLimit.test.ts
@@ -122,6 +122,55 @@ describe("microTimestampMember", () => {
   });
 });
 
+describe("custom window duration", () => {
+  beforeEach(() => {
+    resetRateLimit();
+  });
+
+  it("should allow requests within a custom 5-minute window", async () => {
+    const key = "custom-window-test";
+    const fiveMinMs = 300_000;
+
+    for (let i = 0; i < 3; i++) {
+      expect(await rateLimit(key, 3, fiveMinMs)).toBe(true);
+    }
+
+    expect(await rateLimit(key, 3, fiveMinMs)).toBe(false);
+  });
+
+  it("should track different windows independently per key", async () => {
+    const key1 = "window-a";
+    const key2 = "window-b";
+
+    for (let i = 0; i < 3; i++) {
+      await rateLimit(key1, 3, 60_000);
+    }
+
+    expect(await rateLimit(key1, 3, 60_000)).toBe(false);
+    expect(await rateLimit(key2, 3, 60_000)).toBe(true);
+  });
+
+  it("should return correct info for custom window", async () => {
+    const key = "info-custom-window";
+    const fiveMinMs = 300_000;
+
+    let info = await getRateLimitInfo(key, 3, fiveMinMs);
+    expect(info?.remaining).toBe(3);
+
+    await rateLimit(key, 3, fiveMinMs);
+    info = await getRateLimitInfo(key, 3, fiveMinMs);
+    expect(info?.count).toBe(1);
+    expect(info?.remaining).toBe(2);
+
+    for (let i = 0; i < 2; i++) {
+      await rateLimit(key, 3, fiveMinMs);
+    }
+    info = await getRateLimitInfo(key, 3, fiveMinMs);
+    expect(info?.isLimited).toBe(true);
+    expect(info?.remaining).toBe(0);
+  });
+});
+
 describe("Redis sliding window atomic MULTI (ZREMRANGEBYSCORE + ZCARD)", () => {
   beforeEach(() => {
     resetRedisScripts();

--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -18,42 +18,10 @@ const forgotPasswordSchema = z.object({
  * the email exists in the database. This prevents account enumeration attacks
  * where an attacker could probe for valid emails.
  */
+const FIVE_MINUTES_MS = 300_000;
+
 export async function POST(req: NextRequest) {
-  // 1. Identify the caller
-  const ip =
-    req.headers.get("x-forwarded-for")?.split(",")[0].trim() ??
-    req.headers.get("x-real-ip") ??
-    "anonymous";
-
-  const identifier = `forgot-password:${ip}`;
-
-  // 2. Rate limit — 3 requests per 1-minute sliding window
-  const allowed = await rateLimit(identifier, 3);
-
-  if (!allowed) {
-    const info = await getRateLimitInfo(identifier, 3);
-    const retryAfter = info?.resetTime
-      ? Math.ceil((info.resetTime - Date.now()) / 1000)
-      : 60;
-
-    return NextResponse.json(
-      {
-        error:
-          "Too many password reset requests. Please wait before trying again.",
-        retryAfter,
-      },
-      {
-        status: 429,
-        headers: {
-          "Retry-After": String(retryAfter),
-          "X-RateLimit-Limit": "3",
-          "X-RateLimit-Remaining": "0",
-        },
-      },
-    );
-  }
-
-  // 3. Validate request body
+  // 1. Validate request body (must happen before rate limiting to extract email)
   let body: unknown;
   try {
     body = await req.json();
@@ -73,6 +41,40 @@ export async function POST(req: NextRequest) {
   }
 
   const { email } = validation.data;
+
+  // 2. Identify the caller
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0].trim() ??
+    req.headers.get("x-real-ip") ??
+    "anonymous";
+
+  const identifier = `forgot-password:${email}:${ip}`;
+
+  // 3. Rate limit — 3 requests per 5-minute sliding window per email+IP
+  const allowed = await rateLimit(identifier, 3, FIVE_MINUTES_MS);
+
+  if (!allowed) {
+    const info = await getRateLimitInfo(identifier, 3, FIVE_MINUTES_MS);
+    const retryAfter = info?.resetTime
+      ? Math.ceil((info.resetTime - Date.now()) / 1000)
+      : 300;
+
+    return NextResponse.json(
+      {
+        error:
+          "Too many password reset requests. Please wait before trying again.",
+        retryAfter,
+      },
+      {
+        status: 429,
+        headers: {
+          "Retry-After": String(retryAfter),
+          "X-RateLimit-Limit": "3",
+          "X-RateLimit-Remaining": "0",
+        },
+      },
+    );
+  }
 
   // 4. Trigger password reset (stub — integrate with Clerk / Nodemailer / etc.)
   // In a real implementation:

--- a/src/app/api/auth/resend-otp/route.ts
+++ b/src/app/api/auth/resend-otp/route.ts
@@ -34,41 +34,7 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  // 2. Identify the caller (prefer IP, fall back to forwarded header)
-  const ip =
-    req.headers.get("x-forwarded-for")?.split(",")[0].trim() ??
-    req.headers.get("x-real-ip") ??
-    "anonymous";
-
-  const identifier = `resend-otp:${ip}`;
-
-  // 3. Rate limit — 3 requests per 1-minute sliding window
-  const allowed = await rateLimit(identifier, 3);
-
-  if (!allowed) {
-    const info = await getRateLimitInfo(identifier, 3);
-    const retryAfter = info?.resetTime
-      ? Math.ceil((info.resetTime - Date.now()) / 1000)
-      : 60;
-
-    return NextResponse.json(
-      {
-        error:
-          "Too many OTP requests. Please wait before requesting a new code.",
-        retryAfter,
-      },
-      {
-        status: 429,
-        headers: {
-          "Retry-After": String(retryAfter),
-          "X-RateLimit-Limit": "3",
-          "X-RateLimit-Remaining": "0",
-        },
-      },
-    );
-  }
-
-  // 4. Validate request body
+  // 2. Validate request body (must happen before rate limiting to extract email)
   let body: unknown;
   try {
     body = await req.json();
@@ -88,6 +54,40 @@ export async function POST(req: NextRequest) {
   }
 
   const { email } = validation.data;
+
+  // 3. Identify the caller (prefer IP, fall back to forwarded header)
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0].trim() ??
+    req.headers.get("x-real-ip") ??
+    "anonymous";
+
+  const identifier = `resend-otp:${email}:${ip}`;
+
+  // 4. Rate limit — 1 request per 60-second sliding window per email+IP
+  const allowed = await rateLimit(identifier, 1);
+
+  if (!allowed) {
+    const info = await getRateLimitInfo(identifier, 1);
+    const retryAfter = info?.resetTime
+      ? Math.ceil((info.resetTime - Date.now()) / 1000)
+      : 60;
+
+    return NextResponse.json(
+      {
+        error:
+          "Too many OTP requests. Please wait before requesting a new code.",
+        retryAfter,
+      },
+      {
+        status: 429,
+        headers: {
+          "Retry-After": String(retryAfter),
+          "X-RateLimit-Limit": "1",
+          "X-RateLimit-Remaining": "0",
+        },
+      },
+    );
+  }
 
   // 5. Delegate to OTP service (stub — integrate with Clerk / Twilio / etc.)
   // In a real implementation:

--- a/src/app/api/auth/verify-otp/route.ts
+++ b/src/app/api/auth/verify-otp/route.ts
@@ -38,15 +38,33 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  // 2. Identify the caller
+  // 2. Validate request body (must happen before rate limiting to extract email)
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const validation = verifyOtpSchema.safeParse(body);
+  if (!validation.success) {
+    const errors = validation.error.flatten().fieldErrors;
+    const message =
+      errors.email?.[0] ?? errors.otp?.[0] ?? "Validation failed.";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  const { email, otp: _otp } = validation.data;
+
+  // 3. Identify the caller
   const ip =
     req.headers.get("x-forwarded-for")?.split(",")[0].trim() ??
     req.headers.get("x-real-ip") ??
     "anonymous";
 
-  const identifier = `verify-otp:${ip}`;
+  const identifier = `verify-otp:${email}:${ip}`;
 
-  // 2. Rate limit — 5 requests per 1-minute sliding window
+  // 4. Rate limit — 5 requests per 1-minute sliding window per email+IP
   const allowed = await rateLimit(identifier, 5);
 
   if (!allowed) {
@@ -71,24 +89,6 @@ export async function POST(req: NextRequest) {
       },
     );
   }
-
-  // 3. Validate request body
-  let body: unknown;
-  try {
-    body = await req.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
-  }
-
-  const validation = verifyOtpSchema.safeParse(body);
-  if (!validation.success) {
-    const errors = validation.error.flatten().fieldErrors;
-    const message =
-      errors.email?.[0] ?? errors.otp?.[0] ?? "Validation failed.";
-    return NextResponse.json({ error: message }, { status: 400 });
-  }
-
-  const { email, otp: _otp } = validation.data;
 
   // 4. Verify OTP (stub — integrate with Clerk / Redis / TOTP / etc.)
   // In a real implementation:

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -5,7 +5,7 @@
  * Development: Falls back to an in-memory sliding window automatically
  */
 
-const WINDOW_MS = 60_000;
+const DEFAULT_WINDOW_MS = 60_000;
 
 let redisClient: any = null;
 
@@ -40,14 +40,15 @@ function getRedisClient() {
 async function upstashRateLimit(
   identifier: string,
   limit: number,
+  windowMs: number = DEFAULT_WINDOW_MS,
 ): Promise<boolean> {
   const redis = getRedisClient();
-  if (!redis) return memRateLimit(identifier, limit);
+  if (!redis) return memRateLimit(identifier, limit, windowMs);
 
   try {
     const now = Date.now();
-    const windowStart = now - WINDOW_MS;
-    const windowSeconds = Math.ceil(WINDOW_MS / 1000);
+    const windowStart = now - windowMs;
+    const windowSeconds = Math.ceil(windowMs / 1000);
     const key = `worksphere:ratelimit:${identifier}`;
     const member = microTimestampMember(
       Math.floor(now / 1000),
@@ -71,7 +72,7 @@ async function upstashRateLimit(
 
     return true;
   } catch {
-    return memRateLimit(identifier, limit);
+    return memRateLimit(identifier, limit, windowMs);
   }
 }
 
@@ -121,13 +122,13 @@ if (!globalCleanup.__rateLimitCleanupTimer) {
   globalCleanup.__rateLimitCleanupTimer.unref?.();
 }
 
-function memRateLimit(identifier: string, limit: number): boolean {
+function memRateLimit(identifier: string, limit: number, windowMs: number = DEFAULT_WINDOW_MS): boolean {
   const now = Date.now();
 
   const entry = memStore.get(identifier);
 
   if (!entry || now > entry.resetTime) {
-    memStore.set(identifier, { count: 1, resetTime: now + WINDOW_MS });
+    memStore.set(identifier, { count: 1, resetTime: now + windowMs });
     return true;
   }
 
@@ -140,13 +141,14 @@ function memRateLimit(identifier: string, limit: number): boolean {
 function memGetInfo(
   identifier: string,
   limit: number,
+  windowMs: number = DEFAULT_WINDOW_MS,
 ): { count: number; remaining: number; resetTime: number; isLimited: boolean } {
   const entry = memStore.get(identifier);
   if (!entry || Date.now() > entry.resetTime) {
     return {
       count: 0,
       remaining: limit,
-      resetTime: Date.now() + WINDOW_MS,
+      resetTime: Date.now() + windowMs,
       isLimited: false,
     };
   }
@@ -167,27 +169,29 @@ function memGetInfo(
 export async function rateLimit(
   identifier: string,
   limit = 10,
+  windowMs: number = DEFAULT_WINDOW_MS,
 ): Promise<boolean> {
   if (
     process.env.UPSTASH_REDIS_REST_URL &&
     process.env.UPSTASH_REDIS_REST_TOKEN
   ) {
-    return upstashRateLimit(identifier, limit);
+    return upstashRateLimit(identifier, limit, windowMs);
   }
 
-  return memRateLimit(identifier, limit);
+  return memRateLimit(identifier, limit, windowMs);
 }
 
 export async function getRateLimitInfo(
   identifier: string,
   limit = 10,
+  windowMs: number = DEFAULT_WINDOW_MS,
 ): Promise<{
   count: number;
   remaining: number;
   resetTime: number;
   isLimited: boolean;
 } | null> {
-  return memGetInfo(identifier, limit);
+  return memGetInfo(identifier, limit, windowMs);
 }
 
 /** Reset in-memory rate limit (useful in tests). */


### PR DESCRIPTION
## Description

Adds per-email+IP rate limiting to three auth endpoints (verify-otp, resend-otp, forgot-password) using the existing Upstash Redis rate limiting infrastructure. The rate limit library is extended with custom window duration support for route-specific windows (e.g., 5 minutes for forgot-password).

Previously these endpoints only tracked IP; now the rate limit key includes the target email combined with the caller IP, preventing cross-account abuse and SMS/email bombing while allowing legitimate retries per user.

## Related Issue

Closes #1362

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots / Screen Recordings (if applicable)

N/A — backend-only changes.

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No
