### PR TITLE
feat: add animated amenity filter chips to venue search drawer

### DIFF
--- a/src/__tests__/components/VenueSearchDrawer.test.tsx
+++ b/src/__tests__/components/VenueSearchDrawer.test.tsx
@@ -4,7 +4,7 @@ import "@testing-library/jest-dom";
 import { VenueSearchDrawer } from "@/components/venues/VenueSearchDrawer";
 
 describe("VenueSearchDrawer Component (#1429)", () => {
-  it("resets all filter parameters and sets amenity checkboxes to false on 'Clear Filters'", () => {
+  it("resets all filter parameters and clears amenity chips on 'Clear Filters'", () => {
     const handleSearchChange = jest.fn();
     const handleAmenitiesChange = jest.fn();
     const handleNoiseLevelChange = jest.fn();
@@ -34,21 +34,22 @@ describe("VenueSearchDrawer Component (#1429)", () => {
     const searchInput = screen.getByTestId("search-input") as HTMLInputElement;
     expect(searchInput.value).toBe("Coffee Shop");
 
-    const wifiCheckbox = screen.getByTestId("amenity-wifi") as HTMLInputElement;
-    const outletsCheckbox = screen.getByTestId(
-      "amenity-outlets",
-    ) as HTMLInputElement;
-    const quietCheckbox = screen.getByTestId(
-      "amenity-quiet",
-    ) as HTMLInputElement;
-    const ergonomicCheckbox = screen.getByTestId(
-      "amenity-ergonomic",
-    ) as HTMLInputElement;
-
-    expect(wifiCheckbox.checked).toBe(true);
-    expect(outletsCheckbox.checked).toBe(true);
-    expect(quietCheckbox.checked).toBe(true);
-    expect(ergonomicCheckbox.checked).toBe(false);
+    expect(screen.getByTestId("amenity-wifi")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByTestId("amenity-outlets")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByTestId("amenity-quiet")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByTestId("amenity-ergonomic")).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
 
     // Click 'Clear Filters' button
     const clearBtn = screen.getByTestId("clear-filters-btn");
@@ -63,27 +64,24 @@ describe("VenueSearchDrawer Component (#1429)", () => {
     expect(handleClearFilters).toHaveBeenCalledTimes(1);
   });
 
-  it("resets internal uncontrolled filter checkboxes to false when cleared", () => {
+  it("toggles amenity chips with animated active state and clears them", () => {
     render(<VenueSearchDrawer isOpen={true} onClose={jest.fn()} />);
 
-    // Toggle WiFi and Outlets checkboxes on
-    const wifiCheckbox = screen.getByTestId("amenity-wifi") as HTMLInputElement;
-    const outletsCheckbox = screen.getByTestId(
-      "amenity-outlets",
-    ) as HTMLInputElement;
+    const wifiChip = screen.getByTestId("amenity-wifi");
+    const outletsChip = screen.getByTestId("amenity-outlets");
 
-    fireEvent.click(wifiCheckbox);
-    fireEvent.click(outletsCheckbox);
+    fireEvent.click(wifiChip);
+    fireEvent.click(outletsChip);
 
-    expect(wifiCheckbox.checked).toBe(true);
-    expect(outletsCheckbox.checked).toBe(true);
+    expect(wifiChip).toHaveAttribute("aria-pressed", "true");
+    expect(outletsChip).toHaveAttribute("aria-pressed", "true");
+    expect(wifiChip.className).toMatch(/scale-105/);
+    expect(wifiChip.className).toMatch(/bg-blue-600/);
 
-    // Click 'Clear Filters'
     const clearBtn = screen.getByTestId("clear-filters-btn");
     fireEvent.click(clearBtn);
 
-    // Assert all checkboxes are reset to false
-    expect(wifiCheckbox.checked).toBe(false);
-    expect(outletsCheckbox.checked).toBe(false);
+    expect(wifiChip).toHaveAttribute("aria-pressed", "false");
+    expect(outletsChip).toHaveAttribute("aria-pressed", "false");
   });
 });

--- a/src/components/venues/VenueSearchDrawer.tsx
+++ b/src/components/venues/VenueSearchDrawer.tsx
@@ -200,33 +200,31 @@ export function VenueSearchDrawer({
           </div>
         </div>
 
-        {/* Amenity Checkboxes */}
+        {/* Amenity filter chips (#2177) */}
         <div className="space-y-2">
           <label className="block text-xs font-bold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
             Amenities & Features
           </label>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          <div className="flex flex-wrap gap-2">
             {AMENITIES_LIST.map((item) => {
-              const isChecked = amenities.includes(item.id);
+              const isActive = amenities.includes(item.id);
               return (
-                <label
+                <button
                   key={item.id}
-                  className={`flex items-center gap-2.5 p-2.5 rounded-xl border text-xs font-bold transition-all cursor-pointer ${
-                    isChecked
-                      ? "bg-blue-50 dark:bg-blue-950/40 border-blue-500 text-blue-700 dark:text-blue-300"
-                      : "bg-zinc-50 dark:bg-zinc-950/60 border-zinc-200 dark:border-zinc-800 text-zinc-700 dark:text-zinc-300"
+                  type="button"
+                  id={`amenity-${item.id}`}
+                  data-testid={`amenity-${item.id}`}
+                  aria-pressed={isActive}
+                  aria-label={item.label}
+                  onClick={() => handleToggleAmenity(item.id)}
+                  className={`px-3.5 py-1.5 rounded-full text-xs font-bold border transition-all duration-200 ease-out origin-center ${
+                    isActive
+                      ? "scale-105 bg-blue-600 text-white border-blue-600 shadow-md shadow-blue-500/25"
+                      : "scale-100 bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-300 border-zinc-200 dark:border-zinc-700 hover:border-blue-400/60"
                   }`}
                 >
-                  <input
-                    type="checkbox"
-                    id={`amenity-${item.id}`}
-                    data-testid={`amenity-${item.id}`}
-                    checked={isChecked}
-                    onChange={() => handleToggleAmenity(item.id)}
-                    className="w-4 h-4 rounded text-blue-600 focus:ring-blue-500 border-zinc-300 dark:border-zinc-700"
-                  />
-                  <span>{item.label}</span>
-                </label>
+                  {item.label}
+                </button>
               );
             })}
           </div>


### PR DESCRIPTION

## Summary
- Replace venue amenity checkboxes in VenueSearchDrawer with pill-shaped filter chips
- Animate selected chips with scale-up and background-fill transitions
- Update unit tests to assert aria-pressed active state

## Test plan
- [ ] Open the venue search/filter drawer and toggle amenities
- [ ] Confirm chips scale up and fill when selected
- [ ] Confirm Clear Filters resets chips
- [ ] ./node_modules/.bin/jest src/__tests__/components/VenueSearchDrawer.test.tsx --no-coverage --forceExit

Closes #2177
