### PR TITLE
fix(hooks): clean up Bluetooth advertisement listeners (Closes #2133)

### DIFF
--- a/src/hooks/useArrivalDetection.ts
+++ b/src/hooks/useArrivalDetection.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { Vector3 } from "../types/ar";
 import { calculateDistance } from "../lib/math";
 
@@ -107,7 +107,10 @@ export function useArrivalDetection(
   const [checkedIn, setCheckedIn] = useState<boolean>(false);
   const [isCheckingIn, setIsCheckingIn] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
-  const [bluetoothDevice, setBluetoothDevice] = useState<any>(null);
+  const advertisementListenerRef = useRef<{
+    device: any;
+    listener: (event: any) => void;
+  } | null>(null);
 
   // Extract options if not in vector mode
   const options: UseArrivalDetectionOptions = isVectorMode
@@ -231,7 +234,6 @@ export function useArrivalDetection(
       const device = await (navigator as any).bluetooth.requestDevice(
         scanOptions,
       );
-      setBluetoothDevice(device);
 
       const handleAdvertisement = (event: any) => {
         const deviceRssi = event.rssi ?? null;
@@ -244,10 +246,41 @@ export function useArrivalDetection(
         }
       };
 
+      if (advertisementListenerRef.current) {
+        const { device: oldDevice, listener: oldListener } =
+          advertisementListenerRef.current;
+        oldDevice.removeEventListener("advertisementreceived", oldListener);
+        if (oldDevice.unwatchAdvertisements && oldDevice !== device) {
+          oldDevice.unwatchAdvertisements().catch((err: any) => {
+            console.warn(
+              "Failed to unwatch advertisements when replacing device:",
+              err,
+            );
+          });
+        }
+      }
+      advertisementListenerRef.current = {
+        device,
+        listener: handleAdvertisement,
+      };
+
       device.addEventListener("advertisementreceived", handleAdvertisement);
 
       if (device.watchAdvertisements) {
-        await device.watchAdvertisements();
+        try {
+          await device.watchAdvertisements();
+        } catch (watchErr) {
+          device.removeEventListener(
+            "advertisementreceived",
+            handleAdvertisement,
+          );
+          if (
+            advertisementListenerRef.current?.listener === handleAdvertisement
+          ) {
+            advertisementListenerRef.current = null;
+          }
+          throw watchErr;
+        }
       } else {
         // Fallback for browsers supporting requestDevice but not watchAdvertisements
         setRssi(-70);
@@ -261,11 +294,23 @@ export function useArrivalDetection(
   // Bluetooth cleanup
   useEffect(() => {
     return () => {
-      if (bluetoothDevice) {
-        // Clean up device or listener if watchAdvertisements was started
+      if (advertisementListenerRef.current) {
+        const { device: oldDevice, listener: oldListener } =
+          advertisementListenerRef.current;
+        oldDevice.removeEventListener("advertisementreceived", oldListener);
+        if (oldDevice.unwatchAdvertisements) {
+          // Fire-and-forget to avoid unhandled promise rejection in cleanup
+          oldDevice.unwatchAdvertisements().catch((err: any) => {
+            console.warn(
+              "Failed to unwatch advertisements during cleanup:",
+              err,
+            );
+          });
+        }
+        advertisementListenerRef.current = null;
       }
     };
-  }, [bluetoothDevice]);
+  }, []);
 
   // 4. One-tap Check-In Confirmation callback
   const confirmCheckIn = useCallback(async () => {


### PR DESCRIPTION
## Overview

This PR fixes a memory leak in `useArrivalDetection` by ensuring `advertisementreceived` event listeners are always cleaned up correctly.

## Root Cause

The `useArrivalDetection` hook registered an `advertisementreceived` event listener when Bluetooth scanning started, but never removed it. Because the listener callback was created dynamically inside `scanBluetooth`, its reference was lost after registration, making proper cleanup impossible.

This could result in:

- Event listeners remaining attached after component unmount.
- Duplicate listeners being registered after repeated scans.
- Multiple callbacks firing for a single advertisement event.
- Potential memory leaks and unnecessary state updates.

## Implementation

- Added a `useRef` to track both the active `BluetoothDevice` instance and its associated listener.
- Ensured any existing listener is removed from the correct device before registering a new one.
- Added unmount cleanup that removes the tracked listener from the tracked device.
- Stopped advertisement watching during cleanup using `unwatchAdvertisements()` where supported.
- Added error handling so that if `watchAdvertisements()` fails, the listener is immediately removed and the tracked references remain consistent.
- Added low-level warning logs for advertisement cleanup failures instead of silently swallowing errors.

## Why this approach

The fix is intentionally minimal and isolated to `useArrivalDetection.ts`.

It does not change the hook's public API or existing behaviour. Instead, it uses a stable `useRef` to keep track of the active device and listener, ensuring `removeEventListener()` is always called with the exact callback reference on the correct `BluetoothDevice` instance.

## Validation

The implementation was verified by:

- ✅ `npm run lint`
- ✅ `npx tsc --noEmit`
- ✅ Reviewing listener lifecycle during repeated scans
- ✅ Verifying cleanup on component unmount
- ✅ Confirming duplicate listeners cannot accumulate

## Files Changed

- `src/hooks/useArrivalDetection.ts`

## Summary

This change fixes Bluetooth advertisement listener leaks while keeping the implementation small, maintainable, and consistent with existing React cleanup patterns used throughout the project.

Closes #2133


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth arrival detection when switching between nearby devices.
  * Prevented stale advertisement listeners from remaining active.
  * Added safer handling when starting or stopping Bluetooth advertisement monitoring.
  * Ensured Bluetooth listeners are properly cleaned up when detection ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->