### PR TITLE
feat: add dark mode theme toggle keyboard shortcut (Cmd/Ctrl + Shift + L)

### DIFF
--- a/src/__tests__/components/ThemeToggle.test.tsx
+++ b/src/__tests__/components/ThemeToggle.test.tsx
@@ -63,4 +63,25 @@ describe("ThemeToggle", () => {
     expect(btn).toHaveAttribute("aria-checked", "true");
     expect(btn).toHaveAttribute("data-active-theme", "cyberpunk");
   });
+
+  it("toggles theme on Cmd/Ctrl + Shift + L keyboard shortcut", () => {
+    render(
+      <ThemeProvider initialTheme="light">
+        <ThemeToggle />
+      </ThemeProvider>,
+    );
+    const btn = screen.getByRole("switch");
+    expect(btn).toHaveAttribute("data-active-theme", "light");
+
+    // Simulate Ctrl + Shift + L
+    const event = new KeyboardEvent("keydown", {
+      key: "L",
+      ctrlKey: true,
+      shiftKey: true,
+      bubbles: true,
+    });
+    window.dispatchEvent(event);
+
+    expect(btn).toHaveAttribute("data-active-theme", "dark");
+  });
 });

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,9 +1,27 @@
 "use client";
+import { useEffect } from "react";
 import { Sun, Moon, Zap } from "lucide-react";
 import { useTheme } from "./ThemeProvider";
 
 export function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const isShortcut =
+        (e.metaKey || e.ctrlKey) &&
+        e.shiftKey &&
+        (e.key === "L" || e.key === "l");
+
+      if (isShortcut) {
+        e.preventDefault();
+        toggleTheme();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [toggleTheme]);
 
   const labelFor = (t: string) =>
     t === "light"
@@ -12,6 +30,8 @@ export function ThemeToggle() {
         ? "Switch to cyberpunk mode"
         : "Switch to light mode";
 
+  const tooltipTitle = `${labelFor(theme)} (Cmd/Ctrl + Shift + L)`;
+
   return (
     <button
       role="switch"
@@ -19,8 +39,8 @@ export function ThemeToggle() {
       onClick={toggleTheme}
       data-active-theme={theme}
       className="p-2 cursor-pointer bg-zinc-100 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl text-zinc-600 dark:text-zinc-400 hover:bg-[var(--primary-accent,#2563eb)] hover:text-white transition-all active:scale-95"
-      title={labelFor(theme)}
-      aria-label={labelFor(theme)}
+      title={tooltipTitle}
+      aria-label={tooltipTitle}
     >
       {theme === "light" && <Sun className="w-4 h-4" />}
       {theme === "dark" && <Moon className="w-4 h-4" />}


### PR DESCRIPTION
Closes #1755

## Summary of Changes

This PR introduces a global keyboard shortcut enabling users to seamlessly toggle application theme modes (Light, Dark, Cyberpunk) using `Cmd + Shift + L` (macOS) or `Ctrl + Shift + L` (Windows/Linux).

### Key Modifications
- **ThemeToggle Component** (`src/components/ThemeToggle.tsx`):
  - Registered a global `keydown` event listener targeting `Cmd/Ctrl + Shift + L` to cycle through available themes (`light` -> `dark` -> `cyberpunk`).
  - Updated the button tooltip `title` and `aria-label` attribute to display the keyboard shortcut hint: `"Switch to [mode] (Cmd/Ctrl + Shift + L)"`.
- **ThemeProvider Integration**: Theme preference updates automatically persist to both `localStorage` and the `worksphere-theme` cookie with standard 1-year expiration.
- **Unit Testing** (`src/__tests__/components/ThemeToggle.test.tsx`): Added automated Jest test verifying keyboard shortcut dispatching and theme state transition.

## Verification
- Ran Jest test suite `src/__tests__/components/ThemeToggle.test.tsx`.
- Verified keyboard shortcut cycling across all 3 theme modes with cookie and class list persistence.
