### PR TITLE
feat: implement AI chat message history export to Markdown & PDF

### DIFF
--- a/src/__tests__/lib/chatExport.test.ts
+++ b/src/__tests__/lib/chatExport.test.ts
@@ -1,0 +1,60 @@
+import { formatChatHistoryMarkdown, generateChatPdfReport } from "@/lib/chatExport";
+import { Message } from "@/components/chat/ChatMessages";
+
+describe("Chat Export Formatting", () => {
+  const sampleMessages: Message[] = [
+    {
+      id: "msg-1",
+      role: "user",
+      content: "Find quiet cafes with fast WiFi in San Francisco",
+    },
+    {
+      id: "msg-2",
+      role: "assistant",
+      content: "Here are some top workspace recommendations in San Francisco:",
+      venues: [
+        {
+          id: "v1",
+          name: "Blue Bottle Coffee",
+          category: "cafe",
+          address: "66 Mint St, San Francisco, CA",
+          wifiSpeed: 150,
+          hasOutlets: true,
+          noiseLevel: "quiet",
+          lat: 37.7825,
+          lng: -122.4048,
+        },
+      ],
+    },
+  ];
+
+  describe("formatChatHistoryMarkdown", () => {
+    it("formats chat history with user messages, AI recommendations, and map details into markdown", () => {
+      const md = formatChatHistoryMarkdown(sampleMessages);
+
+      expect(md).toContain("# WorkSphere AI Chat Conversation Export");
+      expect(md).toContain("### User");
+      expect(md).toContain("Find quiet cafes with fast WiFi in San Francisco");
+      expect(md).toContain("### WorkSphere AI");
+      expect(md).toContain("Here are some top workspace recommendations in San Francisco:");
+      expect(md).toContain("**Blue Bottle Coffee** (cafe)");
+      expect(md).toContain("66 Mint St, San Francisco, CA");
+      expect(md).toContain("150 Mbps");
+      expect(md).toContain("Power Outlets: Yes");
+      expect(md).toContain("Noise Level: quiet");
+      expect(md).toContain("https://maps.google.com/?q=37.7825,-122.4048");
+    });
+  });
+
+  describe("generateChatPdfReport", () => {
+    it("generates a valid PDF byte array from conversation history", async () => {
+      const pdfBytes = await generateChatPdfReport(sampleMessages);
+
+      expect(pdfBytes).toBeInstanceOf(Uint8Array);
+      expect(pdfBytes.length).toBeGreaterThan(0);
+      // PDF header magic bytes %PDF-
+      const header = String.fromCharCode(...pdfBytes.slice(0, 5));
+      expect(header).toBe("%PDF-");
+    });
+  });
+});

--- a/src/components/EnhancedChatbot.tsx
+++ b/src/components/EnhancedChatbot.tsx
@@ -31,6 +31,10 @@ import {
   applyPendingConversationEdits,
   flushConversationEditQueue,
 } from "@/lib/offlineStorage";
+import {
+  formatChatHistoryMarkdown,
+  generateChatPdfReport,
+} from "@/lib/chatExport";
 
 // Types
 
@@ -207,7 +211,46 @@ export function EnhancedChatbot({
     stopSpeaking,
   } = useSpeechSynthesis();
   const [showVoiceSettings, setShowVoiceSettings] = useState(false);
-  const lastReadMsgId = useRef<string | null>(null);
+  const [isExportingChatPdf, setIsExportingChatPdf] = useState(false);
+
+  const handleExportMarkdown = () => {
+    if (messages.length === 0) return;
+    const mdContent = formatChatHistoryMarkdown(messages);
+    const blob = new Blob([mdContent], {
+      type: "text/markdown;charset=utf-8;",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `worksphere-chat-export-${new Date().toISOString().slice(0, 10)}.md`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  const handleExportPdf = async () => {
+    if (messages.length === 0) return;
+    setIsExportingChatPdf(true);
+    try {
+      const pdfBytes = await generateChatPdfReport(messages);
+      const blob = new Blob([pdfBytes.buffer as ArrayBuffer], {
+        type: "application/pdf",
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `worksphere-chat-export-${new Date().toISOString().slice(0, 10)}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error("Failed to export chat PDF:", err);
+    } finally {
+      setIsExportingChatPdf(false);
+    }
+  };
 
   // Conversations & favorites
   const [conversations, setConversations] = useState<Conversation[]>([]);
@@ -1259,6 +1302,29 @@ export function EnhancedChatbot({
               </button>
             )}
           </div>
+
+          <div className="flex items-center gap-2" aria-label="Export Conversation">
+            <span className="text-[10px] font-bold uppercase tracking-wider text-zinc-400 hidden sm:inline">
+              Export Chat:
+            </span>
+            <button
+              onClick={handleExportMarkdown}
+              disabled={messages.length === 0}
+              className="text-[11px] font-bold px-2.5 py-1 bg-zinc-200 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300 rounded-lg hover:bg-zinc-300 dark:hover:bg-zinc-700 disabled:opacity-40 transition-colors"
+              title="Export conversation history to Markdown (.md)"
+            >
+              .MD
+            </button>
+            <button
+              onClick={handleExportPdf}
+              disabled={messages.length === 0 || isExportingChatPdf}
+              className="text-[11px] font-bold px-2.5 py-1 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-40 transition-colors"
+              title="Export conversation history to PDF (.pdf)"
+            >
+              {isExportingChatPdf ? "Exporting…" : ".PDF"}
+            </button>
+          </div>
+
           {showVoiceSettings && (
             <div className="flex items-center gap-4 text-xs">
               <label className="flex items-center gap-1 cursor-pointer text-zinc-700 dark:text-zinc-300">

--- a/src/lib/chatExport.ts
+++ b/src/lib/chatExport.ts
@@ -1,0 +1,132 @@
+import { PDFDocument, rgb, StandardFonts } from "pdf-lib";
+import { Message } from "@/components/chat/ChatMessages";
+
+export function formatChatHistoryMarkdown(messages: Message[]): string {
+  const lines: string[] = [];
+  lines.push("# WorkSphere AI Chat Conversation Export");
+  lines.push(`*Exported on ${new Date().toLocaleString()}*\n`);
+  lines.push("---\n");
+
+  messages.forEach((msg) => {
+    const roleName = msg.role === "user" ? "User" : "WorkSphere AI";
+    lines.push(`### ${roleName}`);
+    lines.push(`${msg.content}\n`);
+
+    if (msg.venues && msg.venues.length > 0) {
+      lines.push("**Recommended Venues:**");
+      msg.venues.forEach((v) => {
+        lines.push(`- **${v.name}** (${v.category || "Venue"})`);
+        if (v.address) lines.push(`  - Address: ${v.address}`);
+        if (v.wifiSpeed) lines.push(`  - Wi-Fi: ${v.wifiSpeed} Mbps`);
+        lines.push(`  - Power Outlets: ${v.hasOutlets ? "Yes" : "No"}`);
+        if (v.noiseLevel) lines.push(`  - Noise Level: ${v.noiseLevel}`);
+        lines.push(
+          `  - Map Location: https://maps.google.com/?q=${v.lat},${v.lng}`,
+        );
+      });
+      lines.push("");
+    }
+  });
+
+  return lines.join("\n");
+}
+
+export async function generateChatPdfReport(
+  messages: Message[],
+): Promise<Uint8Array> {
+  const pdfDoc = await PDFDocument.create();
+  let page = pdfDoc.addPage([595, 842]);
+  const fontBold = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
+  const fontReg = await pdfDoc.embedFont(StandardFonts.Helvetica);
+
+  const { height } = page.getSize();
+  let y = height - 50;
+
+  page.drawText("WorkSphere AI Chat Conversation Export", {
+    x: 40,
+    y,
+    size: 16,
+    font: fontBold,
+    color: rgb(0.1, 0.1, 0.1),
+  });
+  y -= 20;
+
+  page.drawText(`Exported on: ${new Date().toLocaleDateString()}`, {
+    x: 40,
+    y,
+    size: 10,
+    font: fontReg,
+    color: rgb(0.4, 0.4, 0.4),
+  });
+  y -= 30;
+
+  for (const msg of messages) {
+    if (y < 80) {
+      page = pdfDoc.addPage([595, 842]);
+      y = 790;
+    }
+
+    const roleName = msg.role === "user" ? "User:" : "WorkSphere AI:";
+    page.drawText(roleName, {
+      x: 40,
+      y,
+      size: 12,
+      font: fontBold,
+      color: msg.role === "user" ? rgb(0.2, 0.4, 0.8) : rgb(0.1, 0.6, 0.3),
+    });
+    y -= 18;
+
+    const contentLines = (msg.content || "").split("\n");
+    for (const line of contentLines) {
+      if (y < 80) {
+        page = pdfDoc.addPage([595, 842]);
+        y = 790;
+      }
+      const safeLine = line.slice(0, 85);
+      page.drawText(safeLine, {
+        x: 50,
+        y,
+        size: 10,
+        font: fontReg,
+        color: rgb(0.2, 0.2, 0.2),
+      });
+      y -= 15;
+    }
+
+    if (msg.venues && msg.venues.length > 0) {
+      y -= 5;
+      if (y < 80) {
+        page = pdfDoc.addPage([595, 842]);
+        y = 790;
+      }
+
+      page.drawText("Recommended Venues:", {
+        x: 50,
+        y,
+        size: 10,
+        font: fontBold,
+        color: rgb(0.3, 0.3, 0.3),
+      });
+      y -= 15;
+
+      for (const v of msg.venues) {
+        if (y < 80) {
+          page = pdfDoc.addPage([595, 842]);
+          y = 790;
+        }
+        const venueText = `• ${v.name} (${v.category || "Venue"}) - ${v.address || "No address"}`;
+        page.drawText(venueText.slice(0, 80), {
+          x: 60,
+          y,
+          size: 9,
+          font: fontReg,
+          color: rgb(0.3, 0.3, 0.3),
+        });
+        y -= 14;
+      }
+    }
+    y -= 15;
+  }
+
+  return await pdfDoc.save();
+}


### PR DESCRIPTION
Closes #1760

## Summary of Changes

This PR adds multi-format export functionality (.md and .pdf) for AI chatbot conversation history in `EnhancedChatbot.tsx`, allowing users to download structured summaries of recommended venue lists and conversation notes.

### Key Modifications
- **Chat Export Module** (`src/lib/chatExport.ts`):
  - `formatChatHistoryMarkdown(messages: Message[])`: Converts conversation history into clean GitHub-Flavored Markdown with structured sections for user prompts, AI responses, venue details (Wi-Fi speed, noise level, power outlets), and Google Maps links.
  - `generateChatPdfReport(messages: Message[])`: Uses `pdf-lib` to construct a multi-page PDF document formatting chat messages and venue recommendations.
- **EnhancedChatbot Component** (`src/components/EnhancedChatbot.tsx`):
  - Integrated an **Export Chat** action menu in the footer controls bar featuring `.MD` and `.PDF` download triggers.
- **Automated Tests** (`src/__tests__/lib/chatExport.test.ts`): Added unit tests verifying Markdown string formatting and valid PDF byte array output structure (`%PDF-` header).

## Verification
- Ran Jest test suite `src/__tests__/lib/chatExport.test.ts`.
- Verified `.md` and `.pdf` export generation with venue recommendation lists and map links.
