### PR TITLE
feat: add pull-to-refresh for venue listings

### DIFF
--- a/src/components/EnhancedChatbot.tsx
+++ b/src/components/EnhancedChatbot.tsx
@@ -832,7 +832,51 @@ export function EnhancedChatbot({
     },
     [isLoading],
   );
+   const handleRefreshVenues = async () => {
+  if (!location) return;
 
+  const params = new URLSearchParams({
+    lat: String(location.lat),
+    lng: String(location.lng),
+    radius: "5000",
+  });
+
+  Object.entries(filters).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== false) {
+      params.set(key, String(value));
+    }
+  });
+
+  const response = await apiFetch(`/api/venues?${params.toString()}`);
+
+  if (!response.ok) {
+    throw new Error("Failed to refresh venues");
+  }
+
+  const data = await response.json();
+
+  const refreshedVenues: Venue[] = (data.venues ?? []).map(
+    (venue: any) => ({
+      ...venue,
+      lat: Number(venue.latitude),
+      lng: Number(venue.longitude),
+    }),
+  );
+
+  setMessages((prev) => {
+    const latestVenueMessageIndex = prev.findLastIndex(
+      (message) => message.venues && message.venues.length > 0,
+    );
+
+    if (latestVenueMessageIndex === -1) return prev;
+
+    return prev.map((message, index) =>
+      index === latestVenueMessageIndex
+        ? { ...message, venues: refreshedVenues }
+        : message,
+    );
+  });
+};
   // Main submit
   const handleInputChange = (val: string) => {
     const safeVal = typeof val === "string" ? val : "";
@@ -1268,6 +1312,7 @@ export function EnhancedChatbot({
         }}
         onSuggestionClick={handleSuggestionClick}
         initialSuggestions={INITIAL_SUGGESTIONS}
+        onRefreshVenues={handleRefreshVenues}
       />
 
       {/* Voice Control Settings Toggle Area */}

--- a/src/components/chat/ChatMessages.tsx
+++ b/src/components/chat/ChatMessages.tsx
@@ -718,6 +718,7 @@ interface VenueListingsProps {
   onOpenDetails: (venue: Venue) => void;
   onBook: (venue: Venue) => void;
   onLoadMore?: () => Promise<void>;
+  onRefresh?: () => Promise<void>;
 }
 
 export function VenueListings({
@@ -729,10 +730,16 @@ export function VenueListings({
   onOpenDetails,
   onBook,
   onLoadMore,
+  onRefresh,
 }: VenueListingsProps) {
   const [viewMode, setViewMode] = useState<"card" | "list">("card");
   const containerRef = useRef<HTMLDivElement>(null);
+  const touchStartY = useRef<number | null>(null);
+  const [pullDistance, setPullDistance] = useState(0);
+  const [isRefreshing, setIsRefreshing] = useState(false);
 
+  const PULL_THRESHOLD = 70;
+  const MAX_PULL_DISTANCE = 100;
   const [selectedVenues, setSelectedVenues] = useState<Venue[]>([]);
 
   // Apply preference reranking
@@ -891,9 +898,76 @@ export function VenueListings({
       onOpenDetails(venue);
     }
   };
+  const handleTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
+  if (!onRefresh || isRefreshing) return;
 
+  const scrollContainer = containerRef.current?.closest(
+    ".overflow-y-auto",
+  ) as HTMLElement | null;
+
+  if (scrollContainer?.scrollTop === 0) {
+    touchStartY.current = e.touches[0].clientY;
+  }
+};
+
+const handleTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
+  if (touchStartY.current === null || isRefreshing) return;
+
+  const distance = e.touches[0].clientY - touchStartY.current;
+
+  if (distance > 0) {
+    setPullDistance(Math.min(distance * 0.5, MAX_PULL_DISTANCE));
+  }
+};
+
+const handleTouchEnd = async () => {
+  if (touchStartY.current === null) return;
+
+  const shouldRefresh = pullDistance >= PULL_THRESHOLD;
+
+  touchStartY.current = null;
+  setPullDistance(0);
+
+  if (!shouldRefresh || !onRefresh || isRefreshing) return;
+
+  setIsRefreshing(true);
+
+  try {
+    await onRefresh();
+  } finally {
+    setIsRefreshing(false);
+  }
+};
   return (
-    <div className="space-y-3 pl-2" ref={containerRef}>
+  <div
+    className="space-y-3 pl-2"
+    ref={containerRef}
+    onTouchStart={handleTouchStart}
+    onTouchMove={handleTouchMove}
+    onTouchEnd={handleTouchEnd}
+  >
+    {(pullDistance > 0 || isRefreshing) && (
+        <div
+          className="flex items-center justify-center overflow-hidden transition-all duration-200"
+          style={{
+            height: isRefreshing ? 40 : Math.min(pullDistance, 40),
+          }}
+          aria-live="polite"
+        >
+          {isRefreshing ? (
+            <Loader2
+              className="h-5 w-5 animate-spin text-zinc-500"
+              aria-label="Refreshing venues"
+            />
+          ) : (
+            <span className="text-[10px] font-bold uppercase tracking-wider text-zinc-400">
+              {pullDistance >= PULL_THRESHOLD
+                ? "Release to refresh"
+                : "Pull to refresh"}
+            </span>
+          )}
+        </div>
+      )}
       <div className="flex items-center justify-between border-b border-zinc-100 dark:border-zinc-800 pb-2 mb-1">
         <p className="text-[10px] uppercase font-black tracking-widest text-zinc-400">
           Recommended Venues ({blendedResults.length})
@@ -1016,6 +1090,7 @@ interface MessageListProps {
   onBook: (venue: Venue) => void;
   onSuggestionClick: (s: string) => void;
   initialSuggestions: string[];
+  onRefreshVenues?: () => Promise<void>;
 }
 
 export function MessageList({
@@ -1033,6 +1108,7 @@ export function MessageList({
   onBook,
   onSuggestionClick,
   initialSuggestions,
+  onRefreshVenues,
 }: MessageListProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
 
@@ -1244,6 +1320,7 @@ export function MessageList({
               onRateVenue={onRateVenue}
               onOpenDetails={onOpenDetails}
               onBook={onBook}
+              onRefresh={onRefreshVenues}
             />
           )}
         </div>


### PR DESCRIPTION
## Description

Implements a native-feeling pull-to-refresh gesture for mobile venue listings.

When the user performs a downward touch swipe while the venue listing is at the top, the UI displays pull/release feedback and a loading spinner. Once the refresh threshold is reached, fresh venue data is fetched using the current location and active filters, and the latest venue cards are updated on completion.

## Related Issue

Closes #676

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

> Note: Local ESLint and Jest execution is currently blocked by the repository's existing TypeScript 7 compatibility issue with `typescript-eslint`/Next.js. `git diff --check` passes successfully.

## Screenshots / Screen Recordings (if applicable)

N/A

## Breaking Changes

- [ ] Yes (please describe below)
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pull-to-refresh support for venue listings in chat.
  * Refreshing retrieves the latest venues using the current location and active filters.
  * Added loading feedback while venue results are being refreshed.
  * Updated the latest venue list without changing venue results in earlier messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->