### PR TITLE
feat: add recently viewed venues

### DIFF
--- a/src/__tests__/components/RecentlyViewedTracker.test.tsx
+++ b/src/__tests__/components/RecentlyViewedTracker.test.tsx
@@ -1,0 +1,83 @@
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import {
+  RecentlyViewedTracker,
+  RECENTLY_VIEWED_STORAGE_KEY,
+  type RecentlyViewedVenue,
+} from "@/components/venues/RecentlyViewedTracker";
+
+const createVenue = (
+  id: string,
+  name = `Venue ${id}`,
+): RecentlyViewedVenue => ({
+  id,
+  name,
+  address: `${id} Main Street`,
+  category: "cafe",
+  imageUrl: null,
+});
+
+describe("RecentlyViewedTracker", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("stores a viewed venue in localStorage", () => {
+    const venue = createVenue("1", "Tech Hub");
+
+    render(<RecentlyViewedTracker venue={venue} />);
+
+    expect(
+      JSON.parse(localStorage.getItem(RECENTLY_VIEWED_STORAGE_KEY) || "[]"),
+    ).toEqual([venue]);
+  });
+
+  it("keeps the newest venue first", () => {
+    render(<RecentlyViewedTracker venue={createVenue("1")} />);
+    render(<RecentlyViewedTracker venue={createVenue("2")} />);
+
+    const stored = JSON.parse(
+      localStorage.getItem(RECENTLY_VIEWED_STORAGE_KEY) || "[]",
+    );
+
+    expect(stored.map((venue: RecentlyViewedVenue) => venue.id)).toEqual([
+      "2",
+      "1",
+    ]);
+  });
+
+  it("moves an already-viewed venue to the top without duplicating it", () => {
+    render(<RecentlyViewedTracker venue={createVenue("1")} />);
+    render(<RecentlyViewedTracker venue={createVenue("2")} />);
+    render(
+      <RecentlyViewedTracker venue={createVenue("1", "Updated Venue 1")} />,
+    );
+
+    const stored = JSON.parse(
+      localStorage.getItem(RECENTLY_VIEWED_STORAGE_KEY) || "[]",
+    );
+
+    expect(stored).toHaveLength(2);
+    expect(stored[0].id).toBe("1");
+    expect(stored[0].name).toBe("Updated Venue 1");
+  });
+
+  it("keeps only the five most recently viewed venues", () => {
+    for (let i = 1; i <= 6; i++) {
+      render(<RecentlyViewedTracker venue={createVenue(String(i))} />);
+    }
+
+    const stored = JSON.parse(
+      localStorage.getItem(RECENTLY_VIEWED_STORAGE_KEY) || "[]",
+    );
+
+    expect(stored).toHaveLength(5);
+    expect(stored.map((venue: RecentlyViewedVenue) => venue.id)).toEqual([
+      "6",
+      "5",
+      "4",
+      "3",
+      "2",
+    ]);
+  });
+});

--- a/src/app/venues/[id]/page.tsx
+++ b/src/app/venues/[id]/page.tsx
@@ -10,6 +10,7 @@ import { isPremiumVenue } from "@/lib/zkp/membership";
 import { WeatherCloudRenderer } from "@/components/WeatherCloudRenderer";
 import { NoiseForecastChart } from "@/components/noise/NoiseForecastChart";
 import { SeatingForecastChart } from "@/components/venue/SeatingForecastChart";
+import { RecentlyViewedTracker } from "@/components/venues/RecentlyViewedTracker";
 
 import { CollaborativeNotes } from "@/components/bookings/CollaborativeNotes"; // <-- 1. Imported your new component here!
 
@@ -94,6 +95,15 @@ export default async function VenuePage({ params }: PageProps) {
 
   return (
     <div className="min-h-screen bg-zinc-50 dark:bg-zinc-950 text-zinc-900 dark:text-zinc-50 flex flex-col font-sans">
+      <RecentlyViewedTracker
+        venue={{
+          id: venue.id,
+          name: venue.name,
+          address: venue.address,
+          category: venue.category,
+          imageUrl: venue.imageUrl,
+        }}
+      />
       <TopNav hideAuth />
       <main className="flex-grow flex items-center justify-center p-4">
         <div className="max-w-2xl w-full bg-white dark:bg-zinc-900 rounded-3xl overflow-hidden shadow-2xl border border-zinc-200 dark:border-zinc-800 animate-in fade-in slide-in-from-bottom-4 duration-500">

--- a/src/components/chat/ChatMessages.tsx
+++ b/src/components/chat/ChatMessages.tsx
@@ -35,7 +35,14 @@ import { useKMeansClustering } from "@/hooks/useKMeansClustering";
 import { useSavedVenues } from "@/hooks/useSavedVenues";
 import { RecommendedBadge } from "@/components/RecommendedBadge";
 import { ClusterBadge } from "@/components/ClusterBadge";
-import { RefObject, useState, useEffect, useRef, useCallback, useMemo } from "react";
+import {
+  RefObject,
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+} from "react";
 import { motion, AnimatePresence, LayoutGroup } from "framer-motion";
 import { useSpeechRecognition } from "@/hooks/useSpeechRecognition";
 import { useSpeechSynthesis } from "@/hooks/useSpeechSynthesis";
@@ -47,6 +54,7 @@ import { EmptyState } from "@/components/ui/EmptyState";
 import { ComparisonDrawer } from "@/components/ComparisonDrawer";
 import { ChatMessageSkeleton } from "@/components/ui/skeleton";
 import { ReadAloudButton } from "./ReadAloudButton";
+import { RecentlyViewedVenues } from "@/components/venues/RecentlyViewedVenues";
 import {
   VenueGrid,
   LayoutBoundary,
@@ -401,7 +409,9 @@ export function VenueChatCard({
             </button>
             <button
               onClick={() => onToggleFavorite(venue)}
-              aria-label={isFavorited ? "Remove from favorites" : "Save to favorites"}
+              aria-label={
+                isFavorited ? "Remove from favorites" : "Save to favorites"
+              }
               className={`p-1.5 rounded-lg border active:scale-[0.95] ${
                 enableTransition ? "transition-all duration-300" : ""
               } ${
@@ -654,7 +664,11 @@ export function VenueChatCard({
                       );
                       onToggleFavorite(venue);
                     }}
-                    aria-label={isFavorited ? "Remove from favorites" : "Save to favorites"}
+                    aria-label={
+                      isFavorited
+                        ? "Remove from favorites"
+                        : "Save to favorites"
+                    }
                     className={`flex-1 flex items-center justify-center gap-1 px-2 py-2 text-[10px] uppercase font-black tracking-tighter rounded-lg ${
                       enableTransition ? "transition-all duration-300" : ""
                     } ${
@@ -788,7 +802,10 @@ export function VenueListings({
     if (clusterRanked.length === 0) return rerankedResults;
 
     const clusterMap = new Map(
-      clusterRanked.map((v) => [v.id, { clusterScore: v.clusterScore, cluster: v.cluster }]),
+      clusterRanked.map((v) => [
+        v.id,
+        { clusterScore: v.clusterScore, cluster: v.cluster },
+      ]),
     );
 
     return rerankedResults.map((venue) => {
@@ -899,54 +916,55 @@ export function VenueListings({
     }
   };
   const handleTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
-  if (!onRefresh || isRefreshing) return;
+    if (!onRefresh || isRefreshing) return;
 
-  const scrollContainer = containerRef.current?.closest(
-    ".overflow-y-auto",
-  ) as HTMLElement | null;
+    const scrollContainer = containerRef.current?.closest(
+      ".overflow-y-auto",
+    ) as HTMLElement | null;
 
-  if (scrollContainer?.scrollTop === 0) {
-    touchStartY.current = e.touches[0].clientY;
-  }
-};
+    if (scrollContainer?.scrollTop === 0) {
+      touchStartY.current = e.touches[0].clientY;
+    }
+  };
 
-const handleTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
-  if (touchStartY.current === null || isRefreshing) return;
+  const handleTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
+    if (touchStartY.current === null || isRefreshing) return;
 
-  const distance = e.touches[0].clientY - touchStartY.current;
+    const distance = e.touches[0].clientY - touchStartY.current;
 
-  if (distance > 0) {
-    setPullDistance(Math.min(distance * 0.5, MAX_PULL_DISTANCE));
-  }
-};
+    if (distance > 0) {
+      setPullDistance(Math.min(distance * 0.5, MAX_PULL_DISTANCE));
+    }
+  };
 
-const handleTouchEnd = async () => {
-  if (touchStartY.current === null) return;
+  const handleTouchEnd = async () => {
+    if (touchStartY.current === null) return;
 
-  const shouldRefresh = pullDistance >= PULL_THRESHOLD;
+    const shouldRefresh = pullDistance >= PULL_THRESHOLD;
 
-  touchStartY.current = null;
-  setPullDistance(0);
+    touchStartY.current = null;
+    setPullDistance(0);
 
-  if (!shouldRefresh || !onRefresh || isRefreshing) return;
+    if (!shouldRefresh || !onRefresh || isRefreshing) return;
 
-  setIsRefreshing(true);
+    setIsRefreshing(true);
 
-  try {
-    await onRefresh();
-  } finally {
-    setIsRefreshing(false);
-  }
-};
+    try {
+      await onRefresh();
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
   return (
-  <div
-    className="space-y-3 pl-2"
-    ref={containerRef}
-    onTouchStart={handleTouchStart}
-    onTouchMove={handleTouchMove}
-    onTouchEnd={handleTouchEnd}
-  >
-    {(pullDistance > 0 || isRefreshing) && (
+    <div
+      className="space-y-3 pl-2"
+      ref={containerRef}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+    >
+      <RecentlyViewedVenues />
+      {(pullDistance > 0 || isRefreshing) && (
         <div
           className="flex items-center justify-center overflow-hidden transition-all duration-200"
           style={{

--- a/src/components/venues/RecentlyViewedTracker.tsx
+++ b/src/components/venues/RecentlyViewedTracker.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect } from "react";
+
+export interface RecentlyViewedVenue {
+  id: string;
+  name: string;
+  address?: string | null;
+  category?: string | null;
+  imageUrl?: string | null;
+}
+
+export const RECENTLY_VIEWED_STORAGE_KEY = "worksphere-recently-viewed";
+const MAX_RECENTLY_VIEWED = 5;
+
+interface RecentlyViewedTrackerProps {
+  venue: RecentlyViewedVenue;
+}
+
+export function RecentlyViewedTracker({ venue }: RecentlyViewedTrackerProps) {
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(RECENTLY_VIEWED_STORAGE_KEY);
+
+      const recentlyViewed: RecentlyViewedVenue[] = stored
+        ? JSON.parse(stored)
+        : [];
+
+      const updated = [
+        venue,
+        ...recentlyViewed.filter((item) => item.id !== venue.id),
+      ].slice(0, MAX_RECENTLY_VIEWED);
+
+      localStorage.setItem(
+        RECENTLY_VIEWED_STORAGE_KEY,
+        JSON.stringify(updated),
+      );
+    } catch (error) {
+      console.error("Failed to save recently viewed venue:", error);
+    }
+  }, [venue]);
+
+  return null;
+}

--- a/src/components/venues/RecentlyViewedVenues.tsx
+++ b/src/components/venues/RecentlyViewedVenues.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { MapPin, X } from "lucide-react";
+import Link from "next/link";
+import {
+  RECENTLY_VIEWED_STORAGE_KEY,
+  type RecentlyViewedVenue,
+} from "@/components/venues/RecentlyViewedTracker";
+
+export function RecentlyViewedVenues() {
+  const [venues, setVenues] = useState<RecentlyViewedVenue[]>([]);
+
+  const loadRecentlyViewed = () => {
+    try {
+      const stored = localStorage.getItem(RECENTLY_VIEWED_STORAGE_KEY);
+
+      if (!stored) {
+        setVenues([]);
+        return;
+      }
+
+      const parsed = JSON.parse(stored);
+
+      if (Array.isArray(parsed)) {
+        setVenues(parsed.slice(0, 5));
+      } else {
+        setVenues([]);
+      }
+    } catch (error) {
+      console.error("Failed to load recently viewed venues:", error);
+      setVenues([]);
+    }
+  };
+
+  useEffect(() => {
+    loadRecentlyViewed();
+  }, []);
+
+  const handleClear = () => {
+    localStorage.removeItem(RECENTLY_VIEWED_STORAGE_KEY);
+    setVenues([]);
+  };
+
+  if (venues.length === 0) {
+    return null;
+  }
+
+  return (
+    <section aria-labelledby="recently-viewed-heading" className="space-y-2">
+      <div className="flex items-center justify-between border-b border-zinc-100 dark:border-zinc-800 pb-2">
+        <p
+          id="recently-viewed-heading"
+          className="text-[10px] uppercase font-black tracking-widest text-zinc-400"
+        >
+          Recently Viewed
+        </p>
+
+        <button
+          type="button"
+          onClick={handleClear}
+          className="text-[10px] font-bold uppercase tracking-wider text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 transition-colors"
+        >
+          Clear
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        {venues.map((venue) => (
+          <Link
+            key={venue.id}
+            href={`/venues/${venue.id}`}
+            className="group rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 p-3 transition-all hover:border-zinc-300 dark:hover:border-zinc-700 hover:shadow-sm"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <p className="truncate text-sm font-bold text-zinc-800 dark:text-zinc-100">
+                  {venue.name}
+                </p>
+
+                {venue.address && (
+                  <p className="mt-1 flex items-start gap-1 text-xs text-zinc-500 dark:text-zinc-400">
+                    <MapPin className="mt-0.5 h-3 w-3 shrink-0" />
+                    <span className="line-clamp-2">{venue.address}</span>
+                  </p>
+                )}
+              </div>
+
+              <X
+                className="h-4 w-4 shrink-0 text-transparent group-hover:text-zinc-300 dark:group-hover:text-zinc-600"
+                aria-hidden="true"
+              />
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Description

Adds a Recently Viewed Venues section to the venue/search page.

### What changed

- Stores the last 5 viewed venues in localStorage.
- Adds a venue when its details page is opened.
- Moves an already-viewed venue to the top instead of duplicating it.
- Displays recently viewed venues with their name and address.
- Adds a Clear option to remove the recently viewed list.
- Hides the section when there are no recently viewed venues.
- Added unit tests covering localStorage behavior and the 5-venue limit.

## Related Issue

Fixes #2270

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing relevant unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


## Breaking Changes

- [ ] Yes
- [x] No