### PR TITLE
feat: add command palette navigation

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,6 +16,7 @@ import { SyncManager } from "../hooks/usePWA";
 import { ToastProvider } from "../components/ui/Toast";
 import { PWAUpdateListener } from "../components/PWAUpdateListener";
 import { KeyboardShortcutsModal } from "../components/KeyboardShortcutsModal";
+import { CommandPalette } from "../components/CommandPalette";
 
 const THEME_INIT_SCRIPT = `
 (function () {
@@ -165,6 +166,7 @@ export default async function RootLayout({
           <CurrencyProvider>
             <PWAUpdateListener />
             <KeyboardShortcutsModal />
+            <CommandPalette />
             <I18nProvider>{children}</I18nProvider>
           </CurrencyProvider>
         </ToastProvider>

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useEffect, useState, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Search,
+  Bookmark,
+  FolderHeart,
+  GitCompare,
+  CalendarCheck,
+  Users,
+  Settings,
+} from "lucide-react";
+
+interface CommandItem {
+  label: string;
+  href: string;
+  icon: React.ComponentType<{ className?: string }>;
+  keywords?: string;
+}
+
+const COMMANDS: CommandItem[] = [
+  {
+    label: "Saved",
+    href: "/saved",
+    icon: Bookmark,
+    keywords: "favorites bookmarks",
+  },
+  {
+    label: "Collections",
+    href: "/collections",
+    icon: FolderHeart,
+    keywords: "folders",
+  },
+  {
+    label: "Compare",
+    href: "/compare",
+    icon: GitCompare,
+    keywords: "comparison venues",
+  },
+  {
+    label: "Reserve",
+    href: "/reserve",
+    icon: CalendarCheck,
+    keywords: "book booking",
+  },
+  {
+    label: "Sessions",
+    href: "/sessions",
+    icon: Users,
+    keywords: "coworking buddy",
+  },
+  {
+    label: "Settings",
+    href: "/settings",
+    icon: Settings,
+    keywords: "account preferences",
+  },
+];
+
+export function CommandPalette() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+  const router = useRouter();
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return COMMANDS;
+    return COMMANDS.filter(
+      (c) =>
+        c.label.toLowerCase().includes(q) ||
+        c.keywords?.toLowerCase().includes(q),
+    );
+  }, [query]);
+
+  useEffect(() => {
+    const handleGlobalKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setIsOpen((prev) => !prev);
+      }
+    };
+
+    window.addEventListener("keydown", handleGlobalKeyDown);
+    return () => window.removeEventListener("keydown", handleGlobalKeyDown);
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setQuery("");
+      setActiveIndex(0);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [query]);
+
+  const handleSelect = (href: string) => {
+    setIsOpen(false);
+    router.push(href);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      setIsOpen(false);
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIndex((prev) => (prev + 1) % Math.max(filtered.length, 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex(
+        (prev) => (prev - 1 + filtered.length) % Math.max(filtered.length, 1),
+      );
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const item = filtered[activeIndex];
+      if (item) handleSelect(item.href);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-start justify-center pt-24 bg-black/50 backdrop-blur-sm">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Command palette"
+        className="w-full max-w-lg mx-4 bg-white dark:bg-zinc-900 rounded-2xl shadow-2xl border border-zinc-200 dark:border-zinc-800 overflow-hidden animate-in fade-in zoom-in duration-150"
+        onKeyDown={handleKeyDown}
+      >
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-zinc-100 dark:border-zinc-800">
+          <Search className="w-4 h-4 text-zinc-400 shrink-0" />
+          <input
+            autoFocus
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Jump to a page…"
+            className="w-full bg-transparent outline-none text-sm text-zinc-900 dark:text-zinc-100 placeholder:text-zinc-400"
+          />
+          <kbd className="text-[10px] px-1.5 py-0.5 rounded border border-zinc-200 dark:border-zinc-700 text-zinc-400 shrink-0">
+            Esc
+          </kbd>
+        </div>
+
+        <ul className="max-h-80 overflow-y-auto py-2">
+          {filtered.length === 0 && (
+            <li className="px-4 py-6 text-sm text-center text-zinc-400">
+              No matching pages
+            </li>
+          )}
+          {filtered.map((item, index) => {
+            const Icon = item.icon;
+            const active = index === activeIndex;
+            return (
+              <li key={item.href}>
+                <button
+                  type="button"
+                  onClick={() => handleSelect(item.href)}
+                  onMouseEnter={() => setActiveIndex(index)}
+                  className={`w-full flex items-center gap-3 px-4 py-2.5 text-sm text-left transition-colors ${
+                    active
+                      ? "bg-zinc-100 dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100"
+                      : "text-zinc-600 dark:text-zinc-400"
+                  }`}
+                >
+                  <Icon className="w-4 h-4 shrink-0" />
+                  {item.label}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Related Issue

Closes #2287

## Description

Implemented a global Command Palette for quick navigation across the application.

Users can open the command palette using:

- `Ctrl + K` on Windows/Linux
- `Cmd + K` on macOS

The palette provides searchable navigation to commonly used sections of the application.

## Screenshots
<img width="817" height="806" alt="Screenshot 2026-08-20 120418" src="https://github.com/user-attachments/assets/4ff23b90-f64c-4ab4-869a-57c88401a298" />

## Changes Made

- Added `src/components/CommandPalette.tsx`
- Registered the global Cmd/Ctrl+K keyboard shortcut in `src/app/layout.tsx`
- Added searchable navigation actions
- Added keyboard navigation support
- Added Escape-to-close behavior
- Reused existing application routes
- No database or schema changes

## Testing

- [ ] Command palette opens with Ctrl+K
- [ ] Command palette opens with Cmd+K
- [ ] Search/filter works correctly
- [ ] Keyboard navigation works
- [ ] Enter navigates to the selected action
- [ ] Escape closes the palette
- [ ] Existing navigation continues to work
- [ ] Application builds successfully

Closes #2287